### PR TITLE
New function syntax — fnc: RetType? <T>? name(params) — FROZEN

### DIFF
--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -793,31 +793,45 @@ where
                 )
                 .then_ignore(just(Token::PunctBraceClose));
 
+            // Syntax: fnc: RetType? <T>? name(params) { body }
+            // Generics parser reused in both branches
+            let generic_params = just(Token::OpLessThan)
+                .ignore_then(
+                    select! { Token::Identifier(s) => s }
+                        .separated_by(just(Token::PunctComma))
+                        .at_least(1)
+                        .collect::<Vec<_>>(),
+                )
+                .then_ignore(just(Token::OpGreaterThan))
+                .or_not()
+                .map(|tp| tp.unwrap_or_default());
+
+            // Try: ret_ty <T>? name — or fall back to: <T>? name (no ret_ty)
+            let ret_ty_generics_name = ty.clone()
+                .then(generic_params.clone())
+                .then(ident.clone())
+                .map(|((t, tp), n)| (Some(t), tp, n))
+                .or(
+                    generic_params
+                        .then(ident.clone())
+                        .map(|(tp, n)| (None, tp, n))
+                );
+
             just(Token::KeywordFnc)
                 .map_with(|_, e: &mut ParseExtra<'a, '_, I>| e.span().start)
-                .then(ident.clone())
-                .then(
-                    just(Token::OpLessThan)
-                        .ignore_then(
-                            select! { Token::Identifier(s) => s }
-                                .separated_by(just(Token::PunctComma))
-                                .at_least(1)
-                                .collect::<Vec<_>>(),
-                        )
-                        .then_ignore(just(Token::OpGreaterThan))
-                        .or_not()
-                        .map(|tp| tp.unwrap_or_default()),
-                )
+                .then_ignore(just(Token::PunctColon))
+                .then(ret_ty_generics_name)
+                .then_ignore(just(Token::PunctParenOpen))
                 .then(
                     param
                         .separated_by(just(Token::PunctComma))
-                        .collect::<Vec<_>>()
-                        .delimited_by(just(Token::PunctParenOpen), just(Token::PunctParenClose)),
+                        .allow_trailing()
+                        .collect::<Vec<_>>(),
                 )
-                .then(just(Token::PunctArrow).ignore_then(ty.clone()).or_not())
+                .then_ignore(just(Token::PunctParenClose))
                 .then(func_body)
                 .map(
-                    |(((((pos, name), type_params), params), ret_ty), (body, ret_expr))| Stmt::FuncDef {
+                    |(((pos, (ret_ty, type_params, name)), params), (body, ret_expr))| Stmt::FuncDef {
                         name,
                         type_params,
                         params,

--- a/src/tests/verification_matrix/t38_generics_array.cx
+++ b/src/tests/verification_matrix/t38_generics_array.cx
@@ -1,4 +1,4 @@
-fnc wrap<T>(a: T) -> [1]T {
+fnc: [1]T <T> wrap(a: T) {
     [a]
 }
 

--- a/src/tests/verification_matrix/t39_generics_multi.cx
+++ b/src/tests/verification_matrix/t39_generics_multi.cx
@@ -1,4 +1,4 @@
-fnc identity<T>(x: T) -> T {
+fnc: T <T> identity(x: T) {
     x
 }
 

--- a/src/tests/verification_matrix/t39_impl_basic.cx
+++ b/src/tests/verification_matrix/t39_impl_basic.cx
@@ -3,11 +3,11 @@ struct Player {
 }
 
 player_methods: impl (p: Player) {
-    fnc take_damage(amount: t32) {
+    fnc: take_damage(amount: t32) {
         p.health -= amount
     }
 
-    fnc is_alive() -> bool {
+    fnc: bool is_alive() {
         p.health > 0
     }
 }

--- a/src/tests/verification_matrix/t40_impl_return.cx
+++ b/src/tests/verification_matrix/t40_impl_return.cx
@@ -3,11 +3,11 @@ struct Counter {
 }
 
 counter_methods: impl (c: Counter) {
-    fnc increment() {
+    fnc: increment() {
         c.value = c.value + 1
     }
 
-    fnc get() -> t32 {
+    fnc: t32 get() {
         c.value
     }
 }

--- a/src/tests/verification_matrix/t41_compound_assign_dot.cx
+++ b/src/tests/verification_matrix/t41_compound_assign_dot.cx
@@ -4,11 +4,11 @@ struct Player {
 }
 
 player_methods: impl (p: Player) {
-    fnc take_damage(amount: t32) {
+    fnc: take_damage(amount: t32) {
         p.health -= amount
     }
 
-    fnc double_speed() {
+    fnc: double_speed() {
         p.speed *= 2
     }
 }


### PR DESCRIPTION
- Return type moves to after fnc: colon
- Generic type params move before function name
- Space separated — no extra punctuation separators
- No more -> arrow syntax
- Parser rewritten with try-backtrack for void vs typed ambiguity
- All test files updated
- Syntax frozen — no breaking changes after this point
- 47/47 matrix green