### PR TITLE
Update site code examples to frozen Cx syntax

### DIFF
--- a/src/content/docs/basic-syntax.mdx
+++ b/src/content/docs/basic-syntax.mdx
@@ -19,18 +19,22 @@ No module header is required. A Cx file is a flat list of function definitions a
 - Top-level `print` calls also execute directly
 
 ```cx
-fnc main() {
+fnc: main() {
     print(42)
 }
 ```
 
 ## Comments
 
-Line comments only for now. Block comments are not implemented.
+Line comments and block comments are supported:
 
 ```cx
-// this is a comment
+// this is a line comment
 x: t64 = 10  // inline comment
+
+/# this is a block comment #/
+/# it can span
+   multiple lines #/
 ```
 
 ## Variables
@@ -117,17 +121,17 @@ Do not use yet - the parser does not recognize it.
 
 ## Functions
 
-Functions use `fnc`. Parameters are typed. Return type is declared with `->`.
+Functions use `fnc:`. Parameters are typed. Return type is declared after `fnc:` before the name.
 
 - Implicit return = last expression in body
 - Explicit return uses `return`
 
 ```cx
-fnc add(a: t64, b: t64) -> t64 {
+fnc: t64 add(a: t64, b: t64) {
     a + b
 }
 
-fnc greet(name: str) {
+fnc: greet(name: str) {
     print("hello {name}")
 }
 ```
@@ -137,25 +141,23 @@ fnc greet(name: str) {
 Cx supports three distinct parameter kinds:
 
 ```cx
-fnc inner(x.copy) { ... }        // copy - bleeds final value back to outer
-fnc inner(x.copy.free) { ... }   // copy.free - isolated, nothing bleeds back
-fnc inner(t: copy_into(x, y)) { ... }  // copy_into - bundles multiple vars into container t
+fnc: inner(x.copy) { ... }        // copy - bleeds final value back to outer
+fnc: inner(x.copy.free) { ... }   // copy.free - isolated, nothing bleeds back
+fnc: inner(t: copy_into(x, y)) { ... }  // copy_into - bundles multiple vars into container t
 ```
 
 These are not overloads. They are separate semantics.
 
 ## Printing
 
-`print` and `print!` are built-ins:
+`print` and `printn` are built-in functions:
 
 ```cx
 print(42)             // prints with newline
 print("hello")        // string
-print!("no newline")  // inline, no newline appended
+printn("no newline")  // no newline appended
 print("{x} + {y}")    // template interpolation
 ```
-
-`print` is not a normal function call - you cannot assign its return value or pass it as an argument.
 
 ## Handles
 

--- a/src/content/docs/data-types.mdx
+++ b/src/content/docs/data-types.mdx
@@ -39,6 +39,17 @@ count: t64 = 42
 big: t128 = 999999999999
 ```
 
+### Floating point
+
+`f64` is a 64-bit floating-point type:
+
+```cx
+score: f64 = 3.14
+velocity: f64 = 9.8
+```
+
+Float literals default to `f64`.
+
 ### Boolean
 
 Boolean values use `bool`:
@@ -125,6 +136,7 @@ Safe to teach first:
 - `t32`
 - `t64`
 - `t128`
+- `f64`
 - `bool`
 - `str`
 

--- a/src/content/docs/functions.mdx
+++ b/src/content/docs/functions.mdx
@@ -15,10 +15,10 @@ They are meant to stay direct: typed where it matters, short where possible, exp
 
 ### Basic function definition
 
-A function with parameters and a return type looks like this:
+A function with parameters and a return type looks like this (return type goes after `fnc:`):
 
 ```cx
-fnc add(a: t64, b: t64) -> t64 {
+fnc: t64 add(a: t64, b: t64) {
     a + b
 }
 ```
@@ -27,10 +27,10 @@ The final bare expression is the return value.
 
 ### Function without a return type
 
-If a function performs work and does not return a value, the return type can be omitted:
+If a function performs work and does not return a value, omit the type after `fnc:`:
 
 ```cx
-fnc greet(name: str) {
+fnc: greet(name: str) {
     print(name)
 }
 ```
@@ -40,7 +40,7 @@ fnc greet(name: str) {
 Cx supports explicit `return`:
 
 ```cx
-fnc pick(a: t64, b: t64) -> t64 {
+fnc: t64 pick(a: t64, b: t64) {
     return a;
 }
 ```
@@ -50,7 +50,7 @@ fnc pick(a: t64, b: t64) -> t64 {
 The last expression in the function body is the implicit return value:
 
 ```cx
-fnc double(x: t64) -> t64 {
+fnc: t64 double(x: t64) {
     x + x
 }
 ```
@@ -62,7 +62,7 @@ Top-level forward calls work today:
 ```cx
 outer()
 
-fnc outer() {
+fnc: outer() {
     print(99)
 }
 ```
@@ -93,7 +93,7 @@ Cx currently exposes three special parameter forms:
 #### `.copy`
 
 ```cx
-fnc inner(x.copy) -> t64 {
+fnc: t64 inner(x.copy) {
     x = x + 5;
     x
 }
@@ -106,7 +106,7 @@ The safest description today is: it acts like a copied value that can write a fi
 #### `.copy.free`
 
 ```cx
-fnc inner(x.copy.free) -> t64 {
+fnc: t64 inner(x.copy.free) {
     x = x + 5;
     x
 }
@@ -117,7 +117,7 @@ This is the isolated form. It does not write changes back to the caller in the c
 #### `copy_into(...)`
 
 ```cx
-fnc inner(t: copy_into(x, y, z)) -> t64 {
+fnc: t64 inner(t: copy_into(x, y, z)) {
     t.x + t.y + t.z
 }
 

--- a/src/content/docs/introduction.mdx
+++ b/src/content/docs/introduction.mdx
@@ -46,7 +46,7 @@ The goal is **"Python for adults"** - expressive and learnable, not hostile.
 - Comparison operators
 - Boolean logic
 - String literals with escape sequences
-- `print` and `print!`
+- `print` and `printn`
 - Variables with type annotations
 - Scoped arenas with bump allocator
 - Free checker with double-free prevention

--- a/src/content/docs/variables-and-assignment.mdx
+++ b/src/content/docs/variables-and-assignment.mdx
@@ -47,6 +47,18 @@ hp = 100
 
 Use this when the type is known but the value is not ready yet.
 
+### Constant declarations
+
+Use `const` for values that never change. Constants must be initialized at declaration:
+
+```cx
+const MAX_HP: t32 = 100
+const GRAVITY: f64 = 9.8
+pub const TILE_SIZE: t32 = 32
+```
+
+`pub const` makes the constant publicly visible (module system is not yet implemented, but the syntax is accepted).
+
 ### Reassignment
 
 Existing variables can be reassigned:
@@ -97,6 +109,7 @@ Safe to teach today:
 - `let x;`
 - `name: Type = value`
 - typed declaration before later assignment
+- `const` declarations
 - reassignment with `=`
 
 Present but still rough:

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const featuresLater = [
   { name: "Standard library", desc: "Later - minimal core first." },
 ];
 
-const hello = `fnc main() {
+const hello = `fnc: main() {
     print("hello world")
 }`;
 ---


### PR DESCRIPTION
## Summary

- **Function syntax**: `fnc name() -> Type {}` → `fnc: Type name() {}` across all pages
- **Void functions**: `fnc name()` → `fnc: name()`
- **Block comments**: Documented `/# ... #/` syntax (previously said "not implemented")
- **print!/printn**: Replaced `print!()` with `printn()` for no-newline printing
- **f64 type**: Added floating-point `f64` to data-types reference as a safe-to-teach type
- **const declarations**: Added `const` and `pub const` syntax to variables reference
- **Homepage**: Updated hero code snippet to use `fnc: main()`

## Files changed (6)

- `src/pages/index.astro` — homepage hero code example
- `src/content/docs/functions.mdx` — all function signatures and descriptions
- `src/content/docs/basic-syntax.mdx` — function syntax, comments, print, parameter modes
- `src/content/docs/introduction.mdx` — `print!` → `printn` in feature list
- `src/content/docs/data-types.mdx` — added `f64` section and summary entry
- `src/content/docs/variables-and-assignment.mdx` — added `const` declarations section

## Verification

Searched entire `src/` for old patterns — all clear:
- `-> Type {` in function signatures: **0 matches**
- `]t` in array type declarations: **0 matches**
- `arr[` for array index access: **0 matches**
- `print!` for inline print: **0 matches**
- `fnc name(` (old style without colon): **0 matches**

## Test plan

- [ ] Verify site builds without errors
- [ ] Check homepage hero snippet renders correctly
- [ ] Review functions, basic-syntax, data-types, and variables pages
- [ ] Confirm no old syntax patterns remain in rendered output

https://claude.ai/code/session_01LP5AgMq4Mp71KQaQU9Ujv3