### PR TITLE
CX-10: lower struct field reads through IR (Phase 11 sub-packet 4)

### DIFF
--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -1087,13 +1087,18 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 let instance_ty = info.inferred.clone()
                     .or_else(|| info.declared.as_ref().map(|t| semantic_type_from_decl(t.clone(), &[])))
                     .unwrap_or(SemanticType::Unknown);
-                let field_ty = if let SemanticType::Struct(struct_name) = &instance_ty {
-                    self.structs.get(struct_name)
+                let resolved_struct_name = if let SemanticType::Struct(sn) = &instance_ty {
+                    sn.clone()
+                } else {
+                    String::new()
+                };
+                let field_ty = if resolved_struct_name.is_empty() {
+                    SemanticType::Unknown
+                } else {
+                    self.structs.get(&resolved_struct_name)
                         .and_then(|fields| fields.iter().find(|(fname, _)| fname == field))
                         .map(|(_, ftype)| semantic_type_from_decl(ftype.clone(), &self.current_type_params))
                         .unwrap_or(SemanticType::Unknown)
-                } else {
-                    SemanticType::Unknown
                 };
                 Ok(SemanticExpr {
                     ty: field_ty,
@@ -1101,6 +1106,7 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                         binding: Some(info.binding),
                         container: container.clone(),
                         field: field.clone(),
+                        struct_name: resolved_struct_name,
                     },
                 })
             }

--- a/src/frontend/semantic_types.rs
+++ b/src/frontend/semantic_types.rs
@@ -70,6 +70,10 @@ pub enum SemanticExprKind {
         binding: Option<BindingId>,
         container: String,
         field: String,
+        /// Name of the struct type that owns this field.
+        /// Populated by the semantic analyser when the container has a known
+        /// `Struct(name)` type; empty string when the type is Unknown.
+        struct_name: String,
     },
     HandleNew {
         value: Box<SemanticExpr>,

--- a/src/ir/instr.rs
+++ b/src/ir/instr.rs
@@ -65,6 +65,18 @@ pub enum IrInst {
         size: usize,
         align: usize,
     },
+    /// Advance a pointer by a compile-time byte offset.
+    ///
+    /// `dst = ptr_offset base + offset`
+    ///
+    /// Used to address struct fields at non-zero offsets.  When `offset`
+    /// is 0 the instruction is still valid but the caller should prefer
+    /// reusing `base` directly to avoid a no-op instruction.
+    PtrOffset {
+        dst: ValueId,
+        base: ValueId,
+        offset: usize,
+    },
     Load {
         dst: ValueId,
         ty: IrType,

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -301,6 +301,11 @@ fn lower_program_inner(program: &SemanticProgram, trace: bool) -> Result<IrModul
                 }
                 module.functions.push(lower_semantic_function(function, &signature_table, &struct_table, trace)?);
             }
+            // Struct definitions are pre-processed into the struct_table before
+            // code lowering begins (see build_struct_table).  They carry no
+            // executable semantics and produce no IR, so skip them here rather
+            // than routing them into the synthetic-main statement sequence.
+            SemanticStmt::StructDef { .. } => {}
             other => top_level_stmts.push(other),
         }
     }
@@ -1380,7 +1385,9 @@ fn lower_expr(
                 ty: return_ty,
             })
         },
-        SemanticExprKind::DotAccess { .. } => { unsupported!("DotAccess") },
+        SemanticExprKind::DotAccess { binding, container, field, struct_name } => {
+            lower_dot_access(binding, container, field, struct_name, &expr.ty, ctx, active)
+        }
         SemanticExprKind::HandleNew { .. } => { unsupported!("HandleNew") },
         SemanticExprKind::HandleVal { .. } => { unsupported!("HandleVal") },
         SemanticExprKind::HandleDrop { .. } => { unsupported!("HandleDrop") },
@@ -1592,6 +1599,127 @@ fn lower_binary(
             construct: "Binary::Or".to_string(),
         }),
     }
+}
+
+// Struct field read lowering strategy
+//
+// A DotAccess expression `container.field` is lowered in three steps:
+//
+//   1. Resolve the container binding to its SSA value (a Ptr produced by a
+//      prior Alloca when the struct was created).
+//
+//   2. Look up the struct layout from the pre-built struct_table.  The struct
+//      type name is carried directly in `struct_name` (populated by the
+//      semantic analyser); no run-time type lookup is needed.
+//
+//   3. Compute the field's byte offset from the layout.  If the offset is
+//      greater than zero, emit IrInst::PtrOffset to advance the base pointer
+//      to the field's address.  If the offset is zero the base pointer itself
+//      already addresses the first field.
+//
+//   4. Emit IrInst::Load with the field's IR type to read the value.
+//
+// This produces at most two instructions per field read (PtrOffset + Load)
+// and reuses the existing memory instruction set without requiring a
+// dedicated GEP instruction.
+fn lower_dot_access(
+    binding: &Option<BindingId>,
+    container: &str,
+    field: &str,
+    struct_name: &str,
+    field_sem_ty: &SemanticType,
+    ctx: &mut LoweringCtx,
+    active: &mut ActiveBlock,
+) -> Result<LoweredValue, LoweringError> {
+    // 1. Resolve the container binding to get the struct pointer.
+    let binding_id = binding.ok_or_else(|| LoweringError::InternalInvariantViolation {
+        detail: format!(
+            "DotAccess on '{container}.{field}' has no binding; \
+             the semantic analyser must supply one for all lowerable field reads"
+        ),
+    })?;
+
+    let base = active.bindings.get(&binding_id).cloned().ok_or_else(|| {
+        LoweringError::InternalInvariantViolation {
+            detail: format!(
+                "binding for '{container}' (id {}) not found in scope for DotAccess '{container}.{field}'",
+                binding_id.0
+            ),
+        }
+    })?;
+
+    if base.ty != IrType::Ptr {
+        return Err(LoweringError::InternalInvariantViolation {
+            detail: format!(
+                "DotAccess on '{container}': expected Ptr-typed binding, got {:?}",
+                base.ty
+            ),
+        });
+    }
+
+    // 2. Look up the struct layout.
+    if struct_name.is_empty() {
+        return Err(LoweringError::UnresolvedSemanticArtifact {
+            artifact: format!(
+                "struct type for '{container}' is unknown; \
+                 DotAccess '{container}.{field}' cannot be lowered"
+            ),
+        });
+    }
+    let info = ctx.struct_table.get(struct_name).cloned().ok_or_else(|| {
+        LoweringError::UnresolvedSemanticArtifact {
+            artifact: format!("struct '{struct_name}' in DotAccess '{container}.{field}'"),
+        }
+    })?;
+
+    // 3. Find the field index, offset, and IR type.
+    let field_idx = info
+        .fields
+        .iter()
+        .position(|(name, _)| name == field)
+        .ok_or_else(|| LoweringError::UnresolvedSemanticArtifact {
+            artifact: format!("field '{field}' on struct '{struct_name}'"),
+        })?;
+
+    let field_ir_ty = info.fields[field_idx].1.clone();
+    let field_offset = info.layout.field_offsets[field_idx];
+
+    // Verify that the semantic field type agrees with what the struct table says.
+    let expected_ir_ty = lower_type(field_sem_ty)?;
+    if expected_ir_ty != field_ir_ty {
+        return Err(LoweringError::InternalInvariantViolation {
+            detail: format!(
+                "DotAccess '{container}.{field}': IR type mismatch — \
+                 semantic layer says {expected_ir_ty:?}, struct layout says {field_ir_ty:?}"
+            ),
+        });
+    }
+
+    // 4. Advance the pointer to the field's address (skip if offset is 0).
+    let field_ptr = if field_offset > 0 {
+        let fp = ctx.fresh_value();
+        active.emit(IrInst::PtrOffset {
+            dst: fp,
+            base: base.value,
+            offset: field_offset,
+        })?;
+        fp
+    } else {
+        base.value
+    };
+
+    // 5. Load the field value.
+    let dst = ctx.fresh_value();
+    active.emit(IrInst::Load {
+        dst,
+        ty: field_ir_ty.clone(),
+        ptr: field_ptr,
+    })?;
+
+    Ok(LoweredValue {
+        value: dst,
+        ty: field_ir_ty,
+    })
 }
 
 fn lower_type(ty: &SemanticType) -> Result<IrType, LoweringError> {
@@ -3647,5 +3775,240 @@ mod tests {
                 artifact: "compound assign binding BindingId(98)".to_string()
             }
         );
+    }
+
+    // ── struct field read tests ───────────────────────────────────────────────
+
+    fn point_struct_def() -> SemanticStmt {
+        SemanticStmt::StructDef {
+            name: "Point".to_string(),
+            type_params: vec![],
+            fields: vec![
+                ("x".to_string(), SemanticType::I64),
+                ("y".to_string(), SemanticType::I64),
+            ],
+            pos: 0,
+        }
+    }
+
+    fn dot_access_expr(
+        binding: BindingId,
+        container: &str,
+        field: &str,
+        struct_name: &str,
+        field_ty: SemanticType,
+    ) -> SemanticExpr {
+        SemanticExpr {
+            ty: field_ty,
+            kind: SemanticExprKind::DotAccess {
+                binding: Some(binding),
+                container: container.to_string(),
+                field: field.to_string(),
+                struct_name: struct_name.to_string(),
+            },
+        }
+    }
+
+    // Reading the first field (`x` at offset 0) should emit a single Load —
+    // no PtrOffset is needed because the base pointer already addresses the field.
+    #[test]
+    fn lowers_dot_access_first_field_emits_load_only() {
+        // fn read_x(p: Point) -> i64 { p.x }
+        let program = SemanticProgram {
+            stmts: vec![
+                point_struct_def(),
+                semantic_function(
+                    "read_x",
+                    vec![typed_param(
+                        BindingId(0),
+                        "p",
+                        SemanticType::Struct("Point".to_string()),
+                    )],
+                    Some(SemanticType::I64),
+                    vec![],
+                    Some(dot_access_expr(
+                        BindingId(0),
+                        "p",
+                        "x",
+                        "Point",
+                        SemanticType::I64,
+                    )),
+                ),
+            ],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let func = module.functions.iter().find(|f| f.name == "read_x").unwrap();
+        let insts: Vec<&IrInst> = func.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+
+        // Must have a Load for i64
+        let has_load = insts.iter().any(|i| matches!(i, IrInst::Load { ty: IrType::I64, .. }));
+        assert!(has_load, "expected Load i64 for first-field DotAccess");
+
+        // Must NOT have a PtrOffset — first field is at offset 0
+        let has_ptr_offset = insts.iter().any(|i| matches!(i, IrInst::PtrOffset { .. }));
+        assert!(!has_ptr_offset, "unexpected PtrOffset for first field (offset 0)");
+    }
+
+    // Reading the second field (`y` at offset 8) must emit PtrOffset(8) then Load.
+    // Point { x: i64, y: i64 } — y is at byte offset 8 after alignment padding.
+    #[test]
+    fn lowers_dot_access_second_field_emits_ptr_offset_then_load() {
+        // fn read_y(p: Point) -> i64 { p.y }
+        let program = SemanticProgram {
+            stmts: vec![
+                point_struct_def(),
+                semantic_function(
+                    "read_y",
+                    vec![typed_param(
+                        BindingId(0),
+                        "p",
+                        SemanticType::Struct("Point".to_string()),
+                    )],
+                    Some(SemanticType::I64),
+                    vec![],
+                    Some(dot_access_expr(
+                        BindingId(0),
+                        "p",
+                        "y",
+                        "Point",
+                        SemanticType::I64,
+                    )),
+                ),
+            ],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let func = module.functions.iter().find(|f| f.name == "read_y").unwrap();
+        let insts: Vec<&IrInst> = func.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+
+        // Must have PtrOffset with offset 8
+        let has_ptr_offset = insts
+            .iter()
+            .any(|i| matches!(i, IrInst::PtrOffset { offset: 8, .. }));
+        assert!(
+            has_ptr_offset,
+            "expected PtrOffset(8) for second field of Point"
+        );
+
+        // Must have a Load for i64
+        let has_load = insts.iter().any(|i| matches!(i, IrInst::Load { ty: IrType::I64, .. }));
+        assert!(has_load, "expected Load i64 after PtrOffset for second field");
+    }
+
+    // Reading a f64 field verifies correct IR type propagation.
+    #[test]
+    fn lowers_dot_access_f64_field_produces_f64_load() {
+        // struct Vec2 { dx: f64, dy: f64 }
+        // fn get_dx(v: Vec2) -> f64 { v.dx }
+        let program = SemanticProgram {
+            stmts: vec![
+                SemanticStmt::StructDef {
+                    name: "Vec2".to_string(),
+                    type_params: vec![],
+                    fields: vec![
+                        ("dx".to_string(), SemanticType::F64),
+                        ("dy".to_string(), SemanticType::F64),
+                    ],
+                    pos: 0,
+                },
+                semantic_function(
+                    "get_dx",
+                    vec![typed_param(
+                        BindingId(0),
+                        "v",
+                        SemanticType::Struct("Vec2".to_string()),
+                    )],
+                    Some(SemanticType::F64),
+                    vec![],
+                    Some(dot_access_expr(
+                        BindingId(0),
+                        "v",
+                        "dx",
+                        "Vec2",
+                        SemanticType::F64,
+                    )),
+                ),
+            ],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let func = module.functions.iter().find(|f| f.name == "get_dx").unwrap();
+        let has_f64_load = func
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .any(|i| matches!(i, IrInst::Load { ty: IrType::F64, .. }));
+        assert!(has_f64_load, "expected Load f64 for f64 DotAccess");
+    }
+
+    // Reject DotAccess when the binding is missing (None) — lowering cannot
+    // resolve the base pointer without a BindingId.
+    #[test]
+    fn rejects_dot_access_with_no_binding() {
+        let program = SemanticProgram {
+            stmts: vec![
+                point_struct_def(),
+                SemanticStmt::ExprStmt {
+                    expr: SemanticExpr {
+                        ty: SemanticType::I64,
+                        kind: SemanticExprKind::DotAccess {
+                            binding: None,
+                            container: "p".to_string(),
+                            field: "x".to_string(),
+                            struct_name: "Point".to_string(),
+                        },
+                    },
+                    pos: 0,
+                },
+            ],
+            enums: vec![],
+        };
+        assert!(lower_program(&program).is_err());
+    }
+
+    // Reject DotAccess when struct_name is empty (unknown container type).
+    #[test]
+    fn rejects_dot_access_with_unknown_struct_name() {
+        let program = SemanticProgram {
+            stmts: vec![SemanticStmt::ExprStmt {
+                expr: SemanticExpr {
+                    ty: SemanticType::I64,
+                    kind: SemanticExprKind::DotAccess {
+                        binding: Some(BindingId(0)),
+                        container: "x".to_string(),
+                        field: "val".to_string(),
+                        struct_name: String::new(),
+                    },
+                },
+                pos: 0,
+            }],
+            enums: vec![],
+        };
+        assert!(lower_program(&program).is_err());
+    }
+
+    // Reject DotAccess when the named struct does not exist in the program.
+    #[test]
+    fn rejects_dot_access_with_missing_struct_def() {
+        let program = SemanticProgram {
+            stmts: vec![SemanticStmt::ExprStmt {
+                expr: SemanticExpr {
+                    ty: SemanticType::I64,
+                    kind: SemanticExprKind::DotAccess {
+                        binding: Some(BindingId(0)),
+                        container: "p".to_string(),
+                        field: "x".to_string(),
+                        struct_name: "Ghost".to_string(),
+                    },
+                },
+                pos: 0,
+            }],
+            enums: vec![],
+        };
+        assert!(lower_program(&program).is_err());
     }
 }

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -111,6 +111,14 @@ pub fn print_inst(inst: &IrInst) -> String {
         IrInst::Alloca { dst, size, align } => {
             format!("{} = alloca size {} align {}", print_value_id(*dst), size, align)
         }
+        IrInst::PtrOffset { dst, base, offset } => {
+            format!(
+                "{} = ptr_offset {} + {}",
+                print_value_id(*dst),
+                print_value_id(*base),
+                offset
+            )
+        }
         IrInst::Load { dst, ty, ptr } => {
             format!("{} = load {} {}", print_value_id(*dst), print_type(ty), print_value_id(*ptr))
         }

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -441,6 +441,19 @@ fn validate_inst(
             }
             define_value(function, block, *dst, IrType::Ptr, "Alloca destination", defined_values, errors);
         }
+        IrInst::PtrOffset { dst, base, .. } => {
+            require_value(function, block, *base, "PtrOffset base", defined_values, errors);
+            if let Some(base_ty) = defined_values.get(base) {
+                if *base_ty != IrType::Ptr {
+                    errors.push(IrValidationError::InvalidTypeUsage {
+                        function: function.name.clone(),
+                        block,
+                        detail: format!("PtrOffset base must be Ptr, got {:?}", base_ty),
+                    });
+                }
+            }
+            define_value(function, block, *dst, IrType::Ptr, "PtrOffset destination", defined_values, errors);
+        }
         IrInst::Load { dst, ty, ptr } => {
             require_value(function, block, *ptr, "Load ptr", defined_values, errors);
             if let Some(ptr_ty) = defined_values.get(ptr) {


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-10/lower-struct-field-reads-through-ir-phase-11-sub-packet-4

## Summary

- Add `IrInst::PtrOffset` to advance a pointer by a compile-time byte offset (needed for non-zero-offset struct fields)
- Add `struct_name: String` to `SemanticExprKind::DotAccess` so the lowering pass can find the struct layout
- Implement `lower_dot_access()`: resolve binding → lookup struct layout → emit `PtrOffset` (if offset > 0) + `Load`
- Fix top-level loop to skip `StructDef` (already pre-processed into `struct_table`)

## Files changed

- `src/ir/instr.rs` — `IrInst::PtrOffset { dst, base, offset }`
- `src/ir/printer.rs` — prints as `vN = ptr_offset vM + K`
- `src/ir/validate.rs` — validates base is `Ptr`, defines dst as `Ptr`
- `src/frontend/semantic_types.rs` — adds `struct_name: String` to `SemanticExprKind::DotAccess`
- `src/frontend/semantic.rs` — populates `struct_name` from `SemanticType::Struct(sn)` during analysis
- `src/ir/lower.rs` — `lower_dot_access()` helper, dispatch in `lower_expr`, top-level StructDef skip, 6 new tests

## Lowering strategy

A field read `container.field` emits at most two instructions:

```
; field at offset > 0:
vN = ptr_offset vBase + 8
vM = load i64 vN

; field at offset 0 (no PtrOffset needed):
vM = load i64 vBase
```

## Tests run

```
cargo build --features jit   ✓
cargo test --features jit    ✓  134 passed, 0 failed
```

New tests added (all green):
- `lowers_dot_access_first_field_emits_load_only`
- `lowers_dot_access_second_field_emits_ptr_offset_then_load`
- `lowers_dot_access_f64_field_produces_f64_load`
- `rejects_dot_access_with_no_binding`
- `rejects_dot_access_with_unknown_struct_name`
- `rejects_dot_access_with_missing_struct_def`

## Dependency note

This PR depends on `stokowski/cx-9` (Phase 11 sub-packet 3, struct literals) for end-to-end Cx program tests, but is self-contained at the IR lowering level. PtrOffset is also added here to avoid blocking on cx-9 merge order; if cx-9 merges first the `PtrOffset` addition will conflict trivially (identical code).

## Linear ticket

CX-10 — Lower struct field reads through IR (Phase 11 sub-packet 4)