### PR TITLE
CX-12: fix stale base check to compare against submain, not main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,14 +121,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check how far behind main
+      - name: Check how far behind submain
         run: |
-          git fetch origin main
-          BEHIND=$(git rev-list --count HEAD..origin/main)
-          echo "Branch is $BEHIND commits behind main"
+          git fetch origin submain
+          BEHIND=$(git rev-list --count HEAD..origin/submain)
+          echo "Branch is $BEHIND commits behind submain"
           if [ "$BEHIND" -gt 20 ]; then
-            echo "STALE BASE: This branch is $BEHIND commits behind main."
-            echo "Rebase onto main before merging."
+            echo "STALE BASE: This branch is $BEHIND commits behind submain."
+            echo "Rebase onto submain before merging."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,17 +5,17 @@
 ### Rule 1 — One backend branch per task
 Backend branches are short-lived. Create a branch for one task, merge or abandon it, then delete it. Never keep a long-lived backend branch open while the frontend is evolving.
 
-### Rule 2 — Always start from fresh main
+### Rule 2 — Always start from fresh submain
 Every backend session starts with:
 ```bash
-git checkout main
+git checkout submain
 git pull
 git checkout -b backend/<task-name>
 ```
 Never resume an old backend branch from a previous session.
 
 ### Rule 3 — Stale base gate
-Any PR more than 20 commits behind main is blocked from merging until rebased. CI will label it `stale-base` automatically.
+Any PR more than 20 commits behind submain is blocked from merging until rebased. CI will label it `stale-base` automatically.
 
 ### Rule 4 — Backend recovery is file-scoped
 If backend work must be recovered from an old branch, carry over only the backend files needed. Never revive a stale branch as the working base. Never cherry-pick broad frontend commits into a backend branch.


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-12/fix-stale-base-check-to-compare-against-submain-not-main

## Summary

- Fixed the `stale-base` CI job in `.github/workflows/ci.yml` to fetch and compare against `origin/submain` instead of `origin/main`
- Updated `CONTRIBUTING.md` Rule 2 and Rule 3 to reference `submain` as the integration base branch

## Files Changed

- `.github/workflows/ci.yml` — stale-base job step name, fetch target, rev-list comparison, and error messages updated from `main` → `submain`
- `CONTRIBUTING.md` — Rule 2 (`Always start from fresh submain`) and Rule 3 (stale gate description) updated to reference `submain`

## Validation

```
cargo build --features jit   →  Finished dev profile (warnings only, no errors)
cargo test --features jit    →  134 passed; 0 failed
```

## Linear Ticket

CX-12