### PR TITLE
CX-19: named structured error for SemanticExprKind::Range in IR lowering

### DIFF
--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1451,7 +1451,11 @@ fn lower_expr(
         SemanticExprKind::HandleNew { .. } => { unsupported!("HandleNew") },
         SemanticExprKind::HandleVal { .. } => { unsupported!("HandleVal") },
         SemanticExprKind::HandleDrop { .. } => { unsupported!("HandleDrop") },
-        SemanticExprKind::Range { .. } => { unsupported!("Range") },
+        SemanticExprKind::Range { .. } => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: "range expression used as a value — ranges are only supported in for-loop bounds, not as standalone expressions".to_string(),
+            });
+        },
         // Unary expression lowering strategy
         //
         // The IR has no dedicated unary-negate or unary-not instructions.  Both
@@ -4449,5 +4453,34 @@ mod tests {
         // Must NOT have a PtrOffset — first field is at offset 0.
         let has_ptr_offset = insts.iter().any(|i| matches!(i, IrInst::PtrOffset { .. }));
         assert!(!has_ptr_offset, "unexpected PtrOffset for first field (offset 0)");
+    }
+
+    // Range expressions used as values are not supported in IR lowering.
+    // Ranges are only consumed by for-loop bounds at the semantic layer; a
+    // bare range value cannot be represented in the IR and must produce a
+    // named, descriptive error rather than a generic "Range" marker.
+    #[test]
+    fn rejects_range_expr_used_as_value() {
+        let program = SemanticProgram {
+            stmts: vec![SemanticStmt::ExprStmt {
+                expr: SemanticExpr {
+                    ty: SemanticType::I64,
+                    kind: SemanticExprKind::Range {
+                        start: Box::new(int_expr(0, SemanticType::I64)),
+                        end: Box::new(int_expr(10, SemanticType::I64)),
+                        inclusive: false,
+                    },
+                },
+                pos: 0,
+            }],
+            enums: vec![],
+        };
+
+        assert_eq!(
+            lower_program(&program).expect_err("lowering should reject range used as value"),
+            LoweringError::UnsupportedSemanticConstruct {
+                construct: "range expression used as a value — ranges are only supported in for-loop bounds, not as standalone expressions".to_string(),
+            }
+        );
     }
 }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-19/ensure-semanticexprkindrange-produces-a-named-structured-error-in-ir

## Summary

- Replaced the generic `unsupported!("Range")` macro call in `lower_expr` with an explicit `LoweringError::UnsupportedSemanticConstruct` carrying a descriptive message.
- Added a unit test `rejects_range_expr_used_as_value` that asserts the exact error string is produced when a `SemanticExprKind::Range` node is encountered during IR lowering.

## Files changed

- `src/ir/lower.rs` — lowering arm for `SemanticExprKind::Range` (line 1454) and new test at end of test module.

## Error message

```
range expression used as a value — ranges are only supported in for-loop bounds, not as standalone expressions
```

This follows the Phase 11 naming convention established in CX-13 (void call named error) and CX-14 (struct field writes).

## Validation

```
cargo build --features jit   ✓
cargo test  --features jit   ✓  139 passed, 0 failed
```

New test: `ir::lower::tests::rejects_range_expr_used_as_value` — ok

## Linear ticket

CX-19