### PR TITLE
CX-20: lower array element writes through IR

### DIFF
--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -431,6 +431,26 @@ impl Analyzer {
                             struct_name,
                         }
                     }
+                    Expr::Index(target_expr, index_expr, _) => {
+                        let sem_target = self.analyze_expr(target_expr)?;
+                        let elem_ty = match &sem_target.ty {
+                            SemanticType::Array(_, elem_ty) => *elem_ty.clone(),
+                            SemanticType::Unknown => SemanticType::Unknown,
+                            _ => return Err(sem_err!(*pos_eq, "index assignment target must be an array")),
+                        };
+                        if elem_ty != SemanticType::Unknown {
+                            if !types_compatible(&elem_ty, &semantic_expr.ty) {
+                                return Err(type_mismatch_error(&elem_ty, &semantic_expr.ty, *pos_eq));
+                            }
+                            semantic_expr = insert_cast_if_needed(semantic_expr, &elem_ty);
+                        }
+                        let sem_index = self.analyze_expr(index_expr)?;
+                        SemanticLValue::Index {
+                            target: Box::new(sem_target),
+                            index: Box::new(sem_index),
+                            elem_ty,
+                        }
+                    }
                     _ => {
                         return Err(sem_err!(*pos_eq, "bad assignment target"));
                     }

--- a/src/frontend/semantic_types.rs
+++ b/src/frontend/semantic_types.rs
@@ -181,6 +181,16 @@ pub enum SemanticLValue {
         /// `Struct(name)` type; empty string when the type is Unknown.
         struct_name: String,
     },
+    /// Array element write: `arr:[i] = value`.
+    ///
+    /// `target` is the analysed array expression (typically a VarRef);
+    /// `index` is the analysed index expression; `elem_ty` is the element
+    /// type derived from the array's declared type.
+    Index {
+        target: Box<SemanticExpr>,
+        index: Box<SemanticExpr>,
+        elem_ty: SemanticType,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -526,6 +526,16 @@ fn lower_stmt(
                     })?;
                     Ok(Some(current))
                 }
+                SemanticLValue::Index { target, index, .. } => {
+                    let (elem_ptr, elem_ir_ty) =
+                        resolve_array_element_ptr(&*target, &*index, ctx, &mut current)?;
+                    ensure_type_match("array element assign", elem_ir_ty, lowered.ty)?;
+                    current.emit(IrInst::Store {
+                        ptr: elem_ptr,
+                        value: lowered.value,
+                    })?;
+                    Ok(Some(current))
+                }
             }
         }
         SemanticStmt::TypedAssign {
@@ -669,6 +679,46 @@ fn lower_stmt(
             // Write back to the field.
             current.emit(IrInst::Store {
                 ptr: field_ptr,
+                value: result_dst,
+            })?;
+            Ok(Some(current))
+        }
+        SemanticLValue::Index { target, index, .. } => {
+            let (elem_ptr, elem_ir_ty) =
+                resolve_array_element_ptr(&*target, &*index, ctx, &mut current)?;
+            // Read the current element value.
+            let current_dst = ctx.fresh_value();
+            current.emit(IrInst::Load {
+                dst: current_dst,
+                ty: elem_ir_ty.clone(),
+                ptr: elem_ptr,
+            })?;
+            // Lower the operand.
+            let rhs = lower_expr(operand, ctx, &mut current)?;
+            // Compute the binary result.
+            let bin_op = match op {
+                Op::Plus => BinaryOp::Add,
+                Op::Minus => BinaryOp::Sub,
+                Op::Mul => BinaryOp::Mul,
+                Op::Div => BinaryOp::Div,
+                Op::Mod => BinaryOp::Rem,
+                _ => {
+                    return Err(LoweringError::UnsupportedSemanticConstruct {
+                        construct: format!("compound assign operator {:?}", op),
+                    });
+                }
+            };
+            let result_dst = ctx.fresh_value();
+            current.emit(IrInst::Binary {
+                dst: result_dst,
+                op: bin_op,
+                ty: elem_ir_ty.clone(),
+                lhs: current_dst,
+                rhs: rhs.value,
+            })?;
+            // Write back to the element.
+            current.emit(IrInst::Store {
+                ptr: elem_ptr,
                 value: result_dst,
             })?;
             Ok(Some(current))
@@ -1855,6 +1905,108 @@ fn resolve_field_ptr(
     };
 
     Ok((field_ptr, field_ir_ty))
+}
+
+// Array element write lowering strategy
+//
+// An array element write `arr:[i] = value` where `arr: Array(N, ElemTy)` is
+// lowered to:
+//
+//   1. Lower `arr` to a base Ptr (the Alloca produced when the array was
+//      created).
+//
+//   2. Lower `i` to an integer SSA value; cast to I64 if needed.
+//
+//   3. Emit ConstInt(stride) then Binary(Mul, I64, i_i64, stride) to compute
+//      the byte offset at runtime.
+//
+//   4. Emit PtrAdd(base, byte_offset) to advance the pointer.
+//
+//   5. Caller emits Store(elem_ptr, value) to write the element.
+//
+// `resolve_array_element_ptr` encapsulates steps 1–4 and returns the element
+// pointer ValueId together with the element's IR type.  The caller is
+// responsible for emitting the Store (for simple writes) or the Load + Binary
+// + Store sequence (for compound-assign writes).
+
+/// Resolve the address of an array element, emitting the index arithmetic.
+///
+/// Returns `(elem_ptr, elem_ir_ty)` where `elem_ptr` is the ValueId of the
+/// pointer to the element and `elem_ir_ty` is its IR type.  The caller is
+/// responsible for emitting Load/Store as appropriate.
+fn resolve_array_element_ptr(
+    target: &SemanticExpr,
+    index: &SemanticExpr,
+    ctx: &mut LoweringCtx,
+    active: &mut ActiveBlock,
+) -> Result<(ValueId, IrType), LoweringError> {
+    // 1. Derive element IR type from the array target's declared type.
+    let (count, elem_sem_ty) = match &target.ty {
+        SemanticType::Array(count, elem_ty) => (*count, elem_ty.as_ref()),
+        _ => {
+            return Err(LoweringError::InternalInvariantViolation {
+                detail: format!(
+                    "array element write: target has non-Array type: {:?}",
+                    target.ty
+                ),
+            })
+        }
+    };
+
+    let elem_ir_ty = lower_type(elem_sem_ty)?;
+    let layout = compute_array_layout(&elem_ir_ty, count);
+
+    // 2. Lower the array target to a base pointer.
+    let base = lower_expr(target, ctx, active)?;
+    if base.ty != IrType::Ptr {
+        return Err(LoweringError::InternalInvariantViolation {
+            detail: format!(
+                "array element write: target must lower to Ptr, got {:?}",
+                base.ty
+            ),
+        });
+    }
+
+    // 3. Lower the index expression; cast to I64 if it isn't already.
+    let idx = lower_expr(index, ctx, active)?;
+    let idx_i64 = if idx.ty == IrType::I64 {
+        idx.value
+    } else {
+        let cast_dst = ctx.fresh_value();
+        active.emit(IrInst::Cast {
+            dst: cast_dst,
+            from: idx.ty.clone(),
+            to: IrType::I64,
+            value: idx.value,
+        })?;
+        cast_dst
+    };
+
+    // 4. Compute byte_offset = idx_i64 * stride.
+    let stride_val = ctx.fresh_value();
+    active.emit(IrInst::ConstInt {
+        dst: stride_val,
+        ty: IrType::I64,
+        value: layout.stride as i128,
+    })?;
+    let byte_offset = ctx.fresh_value();
+    active.emit(IrInst::Binary {
+        dst: byte_offset,
+        op: BinaryOp::Mul,
+        ty: IrType::I64,
+        lhs: idx_i64,
+        rhs: stride_val,
+    })?;
+
+    // 5. elem_ptr = base + byte_offset  (runtime pointer arithmetic).
+    let elem_ptr = ctx.fresh_value();
+    active.emit(IrInst::PtrAdd {
+        dst: elem_ptr,
+        base: base.value,
+        offset: byte_offset,
+    })?;
+
+    Ok((elem_ptr, elem_ir_ty))
 }
 
 fn lower_dot_access(
@@ -4721,6 +4873,168 @@ mod tests {
                     int_expr(0, SemanticType::I64),
                     SemanticType::I64,
                 ),
+            )],
+            enums: vec![],
+        };
+        assert!(lower_program(&program).is_err());
+    }
+
+    // ── array element write lowering tests ───────────────────────────────────
+
+    // Helper: build a SemanticLValue::Index for writing to an array element.
+    fn index_lvalue(
+        arr_binding: BindingId,
+        arr_name: &str,
+        arr_ty: SemanticType,
+        index: SemanticExpr,
+        elem_ty: SemanticType,
+    ) -> SemanticLValue {
+        SemanticLValue::Index {
+            target: Box::new(binding_ref(arr_binding, arr_name, arr_ty)),
+            index: Box::new(index),
+            elem_ty,
+        }
+    }
+
+    // A simple array element write `arr:[1] = 99` must emit:
+    // ConstInt (stride), Binary (Mul for byte_offset), PtrAdd, Store.
+    // No Load should appear (this is a plain write, not read-modify-write).
+    #[test]
+    fn lowers_array_element_write_emits_ptr_add_and_store() {
+        // fn write_elem(arr: [3: i64]) { arr:[1] = 99 }
+        let arr_binding = BindingId(0);
+        let arr_ty = SemanticType::Array(3, Box::new(SemanticType::I64));
+        let program = SemanticProgram {
+            stmts: vec![semantic_function(
+                "write_elem",
+                vec![typed_param(arr_binding, "arr", arr_ty.clone())],
+                None,
+                vec![SemanticStmt::Assign {
+                    target: index_lvalue(
+                        arr_binding,
+                        "arr",
+                        arr_ty,
+                        int_expr(1, SemanticType::I64),
+                        SemanticType::I64,
+                    ),
+                    expr: int_expr(99, SemanticType::I64),
+                    pos_eq: 0,
+                }],
+                None,
+            )],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let func = module.functions.iter().find(|f| f.name == "write_elem").unwrap();
+        let insts: Vec<&IrInst> = func.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+
+        // Must have a PtrAdd (runtime pointer arithmetic for the index).
+        assert!(
+            insts.iter().any(|i| matches!(i, IrInst::PtrAdd { .. })),
+            "expected PtrAdd for array element write"
+        );
+
+        // Must have a Store for i64 (writing the element).
+        assert!(
+            insts.iter().any(|i| matches!(i, IrInst::Store { .. })),
+            "expected Store for array element write"
+        );
+
+        // Must have a Binary Mul for byte_offset computation.
+        assert!(
+            insts
+                .iter()
+                .any(|i| matches!(i, IrInst::Binary { op: BinaryOp::Mul, ty: IrType::I64, .. })),
+            "expected Binary(Mul, I64) for byte offset computation"
+        );
+
+        // Must NOT have a Load (no read-modify-write for plain assignment).
+        assert!(
+            !insts.iter().any(|i| matches!(i, IrInst::Load { .. })),
+            "unexpected Load in plain array element write"
+        );
+    }
+
+    // A compound-assign array element write `arr:[0] += 5` must emit:
+    // PtrAdd, Load (read current), Binary (Mul + Add), Store (write back).
+    #[test]
+    fn lowers_array_element_compound_assign_emits_load_binary_store() {
+        // fn compound_write(arr: [2: i64]) { arr:[0] += 5 }
+        let arr_binding = BindingId(0);
+        let arr_ty = SemanticType::Array(2, Box::new(SemanticType::I64));
+        let program = SemanticProgram {
+            stmts: vec![semantic_function(
+                "compound_write",
+                vec![typed_param(arr_binding, "arr", arr_ty.clone())],
+                None,
+                vec![SemanticStmt::CompoundAssign {
+                    target: index_lvalue(
+                        arr_binding,
+                        "arr",
+                        arr_ty,
+                        int_expr(0, SemanticType::I64),
+                        SemanticType::I64,
+                    ),
+                    op: crate::frontend::ast::Op::Plus,
+                    operand: int_expr(5, SemanticType::I64),
+                    pos: 0,
+                }],
+                None,
+            )],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let func = module.functions.iter().find(|f| f.name == "compound_write").unwrap();
+        let insts: Vec<&IrInst> = func.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+
+        // Must have a PtrAdd for element address computation.
+        assert!(
+            insts.iter().any(|i| matches!(i, IrInst::PtrAdd { .. })),
+            "expected PtrAdd for array element compound assign"
+        );
+
+        // Must have a Load to read the current element value.
+        assert!(
+            insts.iter().any(|i| matches!(i, IrInst::Load { ty: IrType::I64, .. })),
+            "expected Load i64 to read current element value"
+        );
+
+        // Must have a Binary Add for the compound operation.
+        assert!(
+            insts
+                .iter()
+                .any(|i| matches!(i, IrInst::Binary { op: BinaryOp::Add, ty: IrType::I64, .. })),
+            "expected Binary(Add, I64) for compound assign"
+        );
+
+        // Must have a Store to write back the result.
+        assert!(
+            insts.iter().any(|i| matches!(i, IrInst::Store { .. })),
+            "expected Store to write back element value"
+        );
+    }
+
+    // Array element write rejects a non-Array target type.
+    #[test]
+    fn rejects_array_element_write_on_non_array_target() {
+        // Assign to SemanticLValue::Index where target is not an array type.
+        let program = SemanticProgram {
+            stmts: vec![semantic_function(
+                "bad_write",
+                vec![],
+                None,
+                vec![SemanticStmt::Assign {
+                    target: SemanticLValue::Index {
+                        target: Box::new(int_expr(42, SemanticType::I64)),
+                        index: Box::new(int_expr(0, SemanticType::I64)),
+                        elem_ty: SemanticType::I64,
+                    },
+                    expr: int_expr(99, SemanticType::I64),
+                    pos_eq: 0,
+                }],
+                None,
             )],
             enums: vec![],
         };

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -364,6 +364,48 @@ impl RunTime {
         })
     }
 
+    /// Write a single element of an array variable in scope.
+    ///
+    /// Traverses scopes from innermost outward, finds the named variable,
+    /// and replaces the element at `index` with `value`.  Returns an error
+    /// if the variable is not found, is not an array, or the index is
+    /// out of bounds.
+    pub fn set_array_element(
+        &mut self,
+        arr_name: &str,
+        index: usize,
+        value: Value,
+        pos: usize,
+    ) -> Result<(), RuntimeError> {
+        for frame in self.scopes.iter_mut().rev() {
+            if let Some(entry) = frame.vars.get_mut(arr_name) {
+                match &mut entry.val {
+                    Some(Value::Array(elems)) => {
+                        if index < elems.len() {
+                            elems[index] = value;
+                            return Ok(());
+                        } else {
+                            return Err(RuntimeError::UndefinedVar {
+                                pos,
+                                name: format!("index {} out of bounds for '{}'", index, arr_name),
+                            });
+                        }
+                    }
+                    _ => {
+                        return Err(RuntimeError::NotAContainer {
+                            pos,
+                            name: arr_name.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+        Err(RuntimeError::UndefinedVar {
+            pos,
+            name: arr_name.to_string(),
+        })
+    }
+
     pub fn get_field(&self, container: &str, field: &str, pos: usize) -> Result<Value, RuntimeError> {
         for frame in self.scopes.iter().rev() {
             if let Some(entry) = frame.vars.get(container) {
@@ -760,6 +802,18 @@ SemanticStmt::Decl { name, ty, .. } => {
                         let truncated = apply_numeric_cast(val, ty);
                         self.set_container_field(container, field, truncated, 0)
                     }
+                    SemanticLValue::Index { target, index, elem_ty } => {
+                        let arr_name = match &target.kind {
+                            SemanticExprKind::VarRef { name, .. } => name.clone(),
+                            _ => return Err(RuntimeError::BadAssignTarget { pos: 0 }),
+                        };
+                        let idx = match self.eval_semantic_expr(index)? {
+                            Value::Num(n) => n as usize,
+                            _ => return Err(RuntimeError::BadAssignTarget { pos: 0 }),
+                        };
+                        let truncated = apply_numeric_cast(val, elem_ty);
+                        self.set_array_element(&arr_name, idx, truncated, 0)
+                    }
                 }
             }
             SemanticStmt::CompoundAssign { target, op, operand, .. } => {
@@ -777,6 +831,36 @@ SemanticStmt::Decl { name, ty, .. } => {
                         let result = self.apply_op(current, op.clone(), 0, rhs)?;
                         let truncated = apply_numeric_cast(result, ty);
                         self.set_container_field(container, field, truncated, 0)
+                    }
+                    SemanticLValue::Index { target, index, elem_ty } => {
+                        let arr_name = match &target.kind {
+                            SemanticExprKind::VarRef { name, .. } => name.clone(),
+                            _ => return Err(RuntimeError::BadAssignTarget { pos: 0 }),
+                        };
+                        let idx = match self.eval_semantic_expr(index)? {
+                            Value::Num(n) => n as usize,
+                            _ => return Err(RuntimeError::BadAssignTarget { pos: 0 }),
+                        };
+                        let current_val = {
+                            let arr = self.get_var(&arr_name, 0)?;
+                            match arr {
+                                Value::Array(elems) => elems
+                                    .get(idx)
+                                    .cloned()
+                                    .ok_or_else(|| RuntimeError::UndefinedVar {
+                                        pos: 0,
+                                        name: format!("index {} out of bounds for '{}'", idx, arr_name),
+                                    })?,
+                                _ => return Err(RuntimeError::NotAContainer {
+                                    pos: 0,
+                                    name: arr_name.clone(),
+                                }),
+                            }
+                        };
+                        let rhs = self.eval_semantic_expr(operand)?;
+                        let result = self.apply_op(current_val, op.clone(), 0, rhs)?;
+                        let truncated = apply_numeric_cast(result, elem_ty);
+                        self.set_array_element(&arr_name, idx, truncated, 0)
                     }
                 }
             }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-20/lower-array-element-writes-through-ir-phase-11-sub-packet-9

## Summary

- Add `SemanticLValue::Index` variant to represent array element write targets
- Handle `Expr::Index` as a valid assignment target in the semantic analyser, resolving the element type from the array's declared type
- Add `set_array_element` to the runtime interpreter and wire `SemanticLValue::Index` into both `Assign` and `CompoundAssign` statement handlers
- Add `resolve_array_element_ptr` helper to IR lowering (mirrors `lower_index` but omits the final Load, returns the element pointer for use by Store/Load+Binary+Store)
- Handle `SemanticLValue::Index` in `lower_stmt` for both simple assign and compound-assign lowering
- Remove `t33_arrays.cx.expected_fail` marker — the test now passes end-to-end

## Files changed

- `src/frontend/semantic_types.rs` — new `SemanticLValue::Index` variant
- `src/frontend/semantic.rs` — `Expr::Index` arm in `Stmt::Assign` target match
- `src/runtime/runtime.rs` — `set_array_element`, `SemanticLValue::Index` in `Assign`/`CompoundAssign`
- `src/ir/lower.rs` — `resolve_array_element_ptr`, `SemanticLValue::Index` in both lowering sites, 3 new unit tests
- `src/tests/verification_matrix/t33_arrays.cx.expected_fail` — deleted

## Validation

```
cargo build --features jit    → ok (0 errors, pre-existing warnings only)
cargo test --features jit     → ok (144 passed, 0 failed)
cargo run -- src/tests/verification_matrix/t33_arrays.cx → prints 10 / 30 / 50 / 99 / 1 / ? / 3
```

## Linear ticket

CX-20