### PR TITLE
CX-21: emit named structured error for MethodCall in IR lowering

### DIFF
--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1579,7 +1579,11 @@ fn lower_expr(
         SemanticExprKind::Index { target, index, .. } => {
             lower_index(target, index, &expr.ty, ctx, active)
         }
-        SemanticExprKind::MethodCall { .. } => { unsupported!("MethodCall") },
+        SemanticExprKind::MethodCall { instance, method, .. } => {
+            Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: format!("MethodCall '{}.{}'", instance, method),
+            })
+        }
         // Struct literal lowering strategy
         //
         // A struct literal `S { f1: e1, f2: e2, ... }` is lowered to a sequence
@@ -5043,5 +5047,39 @@ mod tests {
             enums: vec![],
         };
         assert!(lower_program(&program).is_err());
+    }
+
+    // MethodCall produces a named structured error that includes both the
+    // instance name and the method name, rather than the generic "MethodCall"
+    // placeholder produced by the unsupported! macro.
+    #[test]
+    fn method_call_produces_named_structured_error() {
+        let program = SemanticProgram {
+            stmts: vec![typed_assign(
+                BindingId(0),
+                "v",
+                SemanticType::I64,
+                SemanticExpr {
+                    ty: SemanticType::I64,
+                    kind: SemanticExprKind::MethodCall {
+                        instance: "obj".to_string(),
+                        method: "foo".to_string(),
+                        args: vec![],
+                        pos: 0,
+                    },
+                },
+            )],
+            enums: vec![],
+        };
+        let err = lower_program(&program).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                LoweringError::UnsupportedSemanticConstruct { construct }
+                if construct.contains("obj") && construct.contains("foo")
+            ),
+            "expected named error mentioning instance and method, got: {:?}",
+            err
+        );
     }
 }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-21

## Summary

- Replaced the generic `unsupported!("MethodCall")` placeholder in `lower_expr` with an explicit `LoweringError::UnsupportedSemanticConstruct` that includes both the instance name and the method name in the `construct` field (e.g. `"MethodCall 'p.take_damage'"`).
- Added a unit test (`method_call_produces_named_structured_error`) that asserts the error variant is `UnsupportedSemanticConstruct` and that the construct string contains both the instance and method identifiers.

## Files changed

- `src/ir/lower.rs` — one-arm change to `lower_expr` + one new test in `mod tests`

## Validation

```
cargo build --features jit   # Finished dev profile — warnings only, no errors
cargo test --features jit    # test result: ok. 145 passed; 0 failed
```

## Notes

MethodCall IR lowering is still unimplemented (the construct is not yet supported end-to-end); this PR improves diagnostic quality so that the error message names the specific call site rather than emitting the opaque string `"MethodCall"`. Full lowering is deferred to a later ticket.

Linear: CX-21