### PR TITLE
Audit: Cx 0.1 state on 2026-05-05

### DIFF
--- a/docs/audits/audit_2026_05_05.md
+++ b/docs/audits/audit_2026_05_05.md
@@ -1,0 +1,647 @@
+# Cx 0.1 Audit — May 5, 2026
+
+**Audited by:** backend dev lead agent (Cx_0V)
+**Branch audited:** main
+**Commit at audit:** `fedf93fbad05a3587618089a438423a4a6521377` (short: `fedf93f`, "Merge pull request #76 from COMMENTERTHE9/submain", 2026-05-05 20:39:57 −0400)
+**Roadmap version cited:** `cx_backend_roadmap_v3_1.md` v4.0 (2026-05-03)
+**Build status:** clean — `cargo build --features jit` finished in 1m 44s, 0 errors, 21 warnings (all pre-existing dead-code/unused-import warnings)
+**Test status:** 163 passed, 0 failed, 0 ignored — `cargo test --features jit` finished in 2.26s
+
+---
+
+## Section 1 — Headline
+
+Cx 0.1 has cleared every backend phase up through Phase 11 (Surface Area Reduction) and has skeletons in place for Phases 12 (Differential Harness), 13 (Cranelift Lowering), and the JIT Runtime Host Boundary. The IR layer is complete enough to lower the entire supported 0.1 language subset into validated IR — including struct construction, struct field reads/writes, fixed-size array literals, array element reads/writes, and direct/void function calls — and 163 tests pass cleanly. The single biggest pending question is **whether Cranelift codegen will land in time**: every IrInst arm in `src/backend/cranelift/mod.rs` is currently a structured `UnsupportedInstruction` stub, the host boundary unconditionally returns `Phase 14 pending`, and no end-to-end execution path exists from a `.cx` source file to a callable function pointer. Realistic estimate to 0.1: **roughly 6–10 weeks of focused backend work** to land Phase 14 (first executable slice), Phase 9 (intrinsics boundary, blocked on `print` becoming a frontend function), the remaining Phase 8 Round 2 ABI items (str/strref, TBool calling convention, IrType::Void), and Phase 15 (full JIT for the supported subset). The trajectory looks **on-track for an October–December 2026 release window** if Cranelift execution starts compiling actual instructions within the next two weeks; if not, the schedule slips.
+
+---
+
+## Section 2 — Phase status table
+
+Every roadmap phase, plus sub-packets where the roadmap or commit history breaks them out. Status values: **Done**, **In Progress**, **Not Started**, **Blocked**, **Out of Scope for 0.1**.
+
+| Phase | Name | Status | Evidence | Landed (commit/date) | Notes |
+|------|------|--------|----------|----------------------|-------|
+| 0 | Foundation Setup | Done | `src/main.rs` invokes `prepare_ir` then dispatches via `Backend` trait; `frontend::semantic::analyze_resolved_program` returns `Result<SemanticProgram, Vec<SemanticError>>` | pre-March 2026 | Roadmap "Done ✅" |
+| 0.5 | Backend trait takes `&IrModule` | Done | `Backend::execute(&self, module: &IrModule)` in `src/backend/mod.rs`; `main.rs:227–276` passes lowered IR | `f305bb8` (2026-03-25) | Roadmap "Done — 2026-03-25" |
+| 1 | Real IR Data Model | Done | `IrType` (9 variants), `IrInst` (12 variants), `IrTerminator` (3 variants), `IrModule`/`IrFunction`/`IrBlock`/`IrParam`/`BlockParam`/`ValueId`/`BlockId` in `src/ir/types.rs` and `src/ir/instr.rs` | pre-March 2026 | Block params for SSA merges, no phi nodes |
+| 2 | Straight-Line Lowering | Done | `lower.rs` arms for `Decl`, `Assign`, `TypedAssign`, `ExprStmt`, `Value`, `VarRef`, `Binary`, `Cast` | pre-March 2026 | Synthetic main path live |
+| 3 | IR Validation | Done | `src/ir/validate.rs` — duplicate block id, undefined value, missing target, duplicate def, type checks for every IrInst variant including memory ops; 15 tests in `validate::tests` | pre-March 2026, Memory ops added `6252994` | All 12 IrInst arms covered |
+| 4 | Function Lowering | Done | `lower_semantic_function` (`lower.rs:354`); typed params, return types, entry block params, function-local SSA maps; tests `lowers_simple_function_with_one_parameter_and_return_value`, `function_local_ssa_maps_do_not_leak_between_functions`, etc. | pre-March 2026 | Real `main` vs synthetic main collision rejected |
+| 5 | if / else Lowering | Done | `lower_if_else` and `lower_if_chain` (`lower.rs:817, 847`); `merge_fallthroughs` (`lower.rs:922`); chained else-if; join block params; dead-branch return handling | pre-March 2026 | "2559 insertions across lower.rs, mod.rs, validate.rs" per roadmap |
+| 6 | Function Call Lowering | Done | `lower.rs:1468–1528` (value-position calls), `lower_void_call` (`lower.rs:2322`); `signature_table` built in `build_signature_table` (`lower.rs:83`); validator cross-function check at `validate.rs:336–370` | `326d9bf` (2026-05-03 frontend), prior backend `Phase 6 Stage 2b` (2026-03-22) | Void calls lowered as of `4a5436a` (CX-13) |
+| 7 | IR Pretty Printer & Diagnostics | Done | `src/ir/printer.rs` covers all 12 `IrInst` and 3 `IrTerminator`; `--backend=validate` mode in `main.rs:254–275`; `--debug-trace` in `main.rs:47`; auto IR dump on validation failure in test helper | `1bd6cae` (2026-03-25) | Roadmap "Done — 2026-03-25" |
+| 8 Round 1 | ABI & Layout — scalars/structs/arrays/enums/calling convention | Done | `IrType::size_bytes()`/`align_bytes()`; `compute_struct_layout`, `compute_array_layout`; 18 layout-confidence tests in `ir::types::tests`; `docs/backend/cx_abi_v0.1.md` covers scalar table, calling convention, struct, array, enum layouts | `00c38d0`, `5d91c6e`, `c95eea6`, `6252994` (2026-03-27 → 2026-04-26) | TBool added; Ptr added |
+| 8 Round 2 | ABI — str/strref, Handle<T>, TBool calling convention, Unknown propagation, IrType::Void | In Progress | All five items still open per roadmap line 236–242 | — | str layout blocked on arena ownership decision |
+| 9 | Runtime Intrinsics Boundary | Blocked | No `intrinsics` module exists in `src/backend/`. Roadmap line 252–273. | — | Blocked on frontend promoting `print` to a real function |
+| 10 | Loop Lowering | Done | `lower_while` (`lower.rs:1018`), `lower_loop` (`lower.rs:1131`), `lower_for` (`lower.rs:1235`); `Break`/`Continue` arms (`lower.rs:752, 772`); 7+ loop tests in `ir::lower::tests` | `0fa06a6`, `bcd49f2`, `3aa28f1`, `2aa72fa` (2026-03-22 → 2026-04-15) | Loop-var read-only invariant **not** enforced in validator (gap) |
+| 11 sub-packet 1 | Compound assign on bindings | Done | `lower.rs:606–727`; tests `lowers_compound_assign_add`, `lowers_compound_assign_sub`, `rejects_compound_assign_dot_access` | `9015aff` | DotAccess and Index targets handled in later sub-packets |
+| 11 sub-packet 2 | Unary expressions | Done | `lower.rs:1560–1606`; tests `lowers_unary_negate_int`, `lowers_unary_negate_float`, `lowers_unary_not_bool`, `rejects_unsupported_unary_op` | `6cc4807`, doc commit `2d665a4` | `-x` lowers as `0 − x`; `!x` as `x == 0` |
+| 11 sub-packet 1a | Memory ops (Alloca/Load/Store, IrType::Ptr) | Done | `IrInst::Alloca`/`Load`/`Store` in `instr.rs:63–101`; printer + validator coverage; `IrType::Ptr` (size 8, align 8) | `6252994` | First memory model in IR |
+| 11 sub-packet 2a | Struct registry threaded into LoweringCtx | Done | `build_struct_table` (`lower.rs:129`); `LoweringCtx.struct_table` (`lower.rs:165`); `lower_type` maps `Struct` and `Array` → `IrType::Ptr` (`lower.rs:2297–2298`) | `c95eea6` | Layout via `compute_struct_layout` |
+| 11 sub-packet 3 | Struct literals (`StructInstance`) | Done | `lower.rs:1637–1691`; `IrInst::PtrOffset` for non-zero field offsets; tests in `ir::lower::tests` (struct literal coverage) | `66bd94e` (CX-9) | Zero-size structs rejected with structured error |
+| 11 sub-packet 4 | Struct field reads (`SemanticExprKind::DotAccess`) | Done | `lower_dot_access` (`lower.rs:2051`); `lower.rs:1529–1530`; helper `resolve_field_ptr` (`lower.rs:1860`) | `a5de1f0` (CX-10) | Loads via `IrInst::Load` after `IrInst::PtrOffset` |
+| 11 sub-packet 5 | Struct field writes (`SemanticLValue::DotAccess`) | Done | `lower.rs:517–528` (Assign), `lower.rs:645–685` (CompoundAssign); shared helper `resolve_field_ptr` | `0257652` (CX-14) | `Store` after `PtrOffset`; field type checked via `ensure_type_match` |
+| 11 — void call lowering | Done | `lower_void_call` (`lower.rs:2322`); detected in `ExprStmt` path (`lower.rs:562–569`) | `4a5436a` (CX-13) | Void return from non-call positions still error |
+| 11 sub-packet 6 | Array type + array literals (`ArrayLit`) | Done | `lower_array_lit` (`lower.rs:2094`); `SemanticType::Array(_,_) → IrType::Ptr`; `IrInst::Alloca` + `PtrOffset` per element | `46e79f9` (CX-16), `8968957` (CX-18) | Array-of-structs covered by tests |
+| 11 sub-packet 7 | Array element reads (`Index`) | Done | `lower_index` (`lower.rs:2184`); helper `resolve_array_element_ptr` (`lower.rs:1976`); `IrInst::PtrAdd` (runtime offset) | `17f49ef` (CX-17) | Bounds checking deferred |
+| 11 sub-packet 8 | Range structured error | Done | `lower.rs:1535–1539` returns `UnsupportedSemanticConstruct` with explanatory message: "range expression used as a value — ranges are only supported in for-loop bounds" | `0e78b7d` (CX-19) | for-loops use explicit start/end, not Range |
+| 11 sub-packet 9 | Array element writes (`SemanticLValue::Index`) | Done | `lower.rs:529–538` (Assign), `lower.rs:686–725` (CompoundAssign); helper `resolve_array_element_ptr` | `85f2350` (CX-20) | Same `PtrAdd` + `Store` shape |
+| 11 final | MethodCall structured error | Done | `lower.rs:1613–1617` returns `UnsupportedSemanticConstruct` naming the instance and method | `18ab47c` (CX-21) | Closes Phase 11 surface |
+| 11 — when blocks | Done (rejected) | `SemanticStmt::When` (`lower.rs:792`) and `SemanticExprKind::When` (`lower.rs:1692`) both `unsupported!` | pre-Phase 11 | Per roadmap explicitly unsupported in 0.1 |
+| 12 sub-packet 1 | Differential harness shell + interpreter baseline | In Progress | `src/diff_harness.rs` (390 lines); `TestExpectation`, `TestFixture`, `InterpOutcome`, `collect_matrix_tests`, `run_interpreter`, `interpreter_baseline_all` test passes against 117 fixtures | `63ffdee` (CX-23) | JIT path not yet wired — still needs subprocess + stdout diff vs interpreter |
+| 12 — full parity harness | Not Started | No JIT-side runner in `diff_harness.rs`; no per-fixture pass/fail report against backend | — | Blocks 0.1 hard blocker "All supported frontend matrix tests pass through the Cranelift JIT path" |
+| 13 — Cranelift Lowering Skeleton | In Progress | `src/backend/cranelift/mod.rs` (254 lines): `ir_type_to_cranelift` complete for all 9 IrType variants; `lower_module`/`lower_function`/`lower_block`/`lower_instruction`/`lower_terminator` traverse safely; every IrInst returns `UnsupportedInstruction` with full context; structured `CraneliftLoweringError` enum | `ef1971e` (CX-22) | Skeleton walks any valid IR without panicking — meets "Done when" criterion 1 of 3 (the other two require actual codegen) |
+| 13 — JIT runtime host boundary | In Progress | `src/backend/cranelift/host_boundary.rs` (336 lines): `JitExitCode`, `JitOutcome`, `JitExecutionError`, `HostBoundary::execute`; comprehensive doc comments; 11 host-boundary tests | `f6499db` (CX-24) | `execute` is a stub returning `UnsupportedConstruct { construct: "Phase 14 pending" }` |
+| 14 — First Executable Cranelift Slice | Not Started | No instruction emission. `HostBoundary::execute` stub. No `cranelift_jit::JITModule` instantiation anywhere in the backend. | — | Critical path item 1 to "hello world" |
+| 15 — Cranelift JIT — 0.1 Target | Not Started | Depends on Phase 14 + remaining Phase 9 + Phase 12 full harness | — | The shipping line for 0.1 |
+| 16 — Cranelift AOT | Out of Scope for 0.1 | `src/backend/cranelift/aot.rs` is a 7-line stub: `Err("Cranelift AOT backend not implemented yet")` | — | Roadmap post-0.1 |
+| 17 — LLVM AOT | Out of Scope for 0.1 | `src/backend/llvm/aot.rs` is a 6-line stub | — | Roadmap post-0.1 |
+| 18 — FFI and C Boundary | Out of Scope for 0.1 | No FFI code present | — | Design pass needed |
+
+**Discrepancies between roadmap text and code state:**
+
+- Roadmap line 194 ("Compound assign, unary, memory ops, struct registry, and struct literal lowering have landed. Remaining open: range expressions, DotAccess (field reads/writes), array indexing, method calls, and void-return calls.") is stale — every item it lists as remaining has shipped (CX-10, CX-13, CX-14, CX-16, CX-17, CX-19, CX-20, CX-21). The Progress Board at lines 605–607 reflects similar staleness.
+- Roadmap line 312–319 ("Still open" under Phase 11) is stale — same shipped items listed as open.
+- Roadmap line 184 marks Phase 0.5 done 2026-03-25, but the actual `f305bb8` commit landed on or shortly after that date — record-keeping is consistent here.
+
+---
+
+## Section 3 — IR data model coverage
+
+### 3.1 `IrType` variants
+
+`IrType` has **9 variants** in `src/ir/types.rs`. Every variant has size/align entries, printer coverage, and a Cranelift mapping.
+
+| Variant | Lowered from SemanticType? | Validated? | Printed? | Cranelift mapping? |
+|---------|---------------------------|-----------|----------|---------------------|
+| `I8` | Yes — `SemanticType::I8` (`lower.rs:2281`) | Yes — `ConstInt` allows it (`validate.rs:199`); `Binary` allows it (`validate.rs:263`) | Yes — `"i8"` (`printer.rs:186`) | `types::I8` (`backend/cranelift/mod.rs:75`) |
+| `I16` | Yes — `SemanticType::I16` | Yes (same arms) | Yes — `"i16"` | `types::I16` |
+| `I32` | Yes — `SemanticType::I32` | Yes | Yes — `"i32"` | `types::I32` |
+| `I64` | Yes — `SemanticType::I64` | Yes; required for `PtrAdd` offset (`validate.rs:470`) | Yes — `"i64"` | `types::I64` |
+| `I128` | Yes — `SemanticType::I128` | Yes | Yes — `"i128"` | `types::I128` (Cranelift emulates as 2× i64) |
+| `F64` | Yes — `SemanticType::F64` | Yes — `Binary` only (no `ConstInt`) | Yes — `"f64"` | `types::F64` |
+| `Bool` | Yes — `SemanticType::Bool` | Yes — `ConstInt` allows it; `Compare` produces it | Yes — `"bool"` | `types::I8` (0/1 convention) |
+| `TBool` | **No** — `SemanticType::TBool` does not exist in the frontend yet (roadmap Phase 8 Round 2 open item) | Yes — implicitly via `Load`/`Store`/`SsaBind` | Yes — `"tbool"` | `types::I8` (0/1/2 convention) |
+| `Ptr` | Yes — `SemanticType::Struct(_) → IrType::Ptr` and `SemanticType::Array(_,_) → IrType::Ptr` (`lower.rs:2297–2298`) | Yes — `Alloca`/`PtrOffset`/`PtrAdd`/`Load`/`Store` enforce ptr-typed operands | Yes — `"ptr"` | `types::I64` |
+
+**Notable:** `IrType::Void` does **not** exist. Void function returns are handled by `Option<IrType>` on `IrFunction.return_ty`. Void calls are handled by `Option<ValueId>` on `IrInst::Call.dst` and `IrInst::Call.return_ty`. Roadmap Phase 8 Round 2 still tracks `IrType::Void` as pending.
+
+### 3.2 `IrInst` variants
+
+`IrInst` has **12 variants** in `src/ir/instr.rs`. Every variant has emitter coverage in `lower.rs`, validator coverage in `validate.rs`, and printer coverage in `printer.rs`. None are yet emitted to Cranelift — every `lower_instruction` arm in `src/backend/cranelift/mod.rs` returns `CraneliftLoweringError::UnsupportedInstruction`.
+
+| Variant | Emitted by lower.rs? | Validated? | Printed? | Cranelift mapping? |
+|---------|---------------------|-----------|----------|---------------------|
+| `ConstInt` | Yes — `lower_value` (`lower.rs:1699`), `lower_unary` zero-literal (`lower.rs:1572`), `lower_for` increment (`lower.rs:1235`) | Yes — type must be I8/I16/I32/I64/I128/Bool (`validate.rs:196–216`) | Yes (`printer.rs:58`) | Not yet mapped (`backend/cranelift/mod.rs:120`) |
+| `ConstFloat` | Yes — `lower_value`, `lower_unary` for f64 negation | Yes — defines dst as F64 (`validate.rs:217`) | Yes (`printer.rs:61`) | Not yet mapped (`backend/cranelift/mod.rs:126`) |
+| `SsaBind` | Yes — typed assigns, plain assigns, compound assigns | Yes — type-checked source/dst (`validate.rs:228`) | Yes (`printer.rs:64`) | Not yet mapped |
+| `Binary` | Yes — `lower_binary` (`lower.rs:1758`) for arithmetic; `lower_unary` for negation; compound assigns; `lower_for` increment | Yes — restricts result type to arith-capable; ensures lhs/rhs match (`validate.rs:258–296`) | Yes (`printer.rs:72`) | Not yet mapped |
+| `Compare` | Yes — `lower_binary` for `==`/`<`/etc.; `lower_unary` for `!`; loop header conditions | Yes — operands must match each other; produces Bool (`validate.rs:298`) | Yes (`printer.rs:82`) | Not yet mapped |
+| `Call` | Yes — value-position call (`lower.rs:1468`); void-call `lower_void_call` (`lower.rs:2322`) | Yes — callee resolved via `function_sigs` map; arity + arg type checked (`validate.rs:326`) | Yes (`printer.rs:91`) | Not yet mapped (`backend/cranelift/mod.rs:150`) |
+| `Cast` | Yes — `SemanticExprKind::Cast` arm (`lower.rs:1420`); also `lower_for` integer downcast | Yes — source type check (`validate.rs:392`) | Yes (`printer.rs:102`) | Not yet mapped |
+| `Alloca` | Yes — `StructInstance` (`lower.rs:1651`); `lower_array_lit` (`lower.rs:2094`) | Yes — size > 0 and align is power of 2 (`validate.rs:427`) | Yes (`printer.rs:111`) | Not yet mapped (`backend/cranelift/mod.rs:164`) |
+| `PtrOffset` | Yes — struct field addressing in `lower_dot_access`, `resolve_field_ptr`, `StructInstance` | Yes — base must be Ptr (`validate.rs:444`) | Yes (`printer.rs:114`) | Not yet mapped (`backend/cranelift/mod.rs:170`) |
+| `PtrAdd` | Yes — array element addressing in `lower_index`, `resolve_array_element_ptr` | Yes — base must be Ptr, offset must be I64 (`validate.rs:457`) | Yes (`printer.rs:122`) | Not yet mapped (`backend/cranelift/mod.rs:176`) |
+| `Load` | Yes — `lower_dot_access`, `lower_index`, compound assign read-step | Yes — ptr must be Ptr (`validate.rs:480`) | Yes (`printer.rs:130`) | Not yet mapped |
+| `Store` | Yes — `StructInstance`, `lower_array_lit`, dot-access write, index write, compound assign write-back | Yes — ptr must be Ptr (`validate.rs:493`) | Yes (`printer.rs:133`) | Not yet mapped |
+
+### 3.3 `IrTerminator` variants
+
+`IrTerminator` has **3 variants**. All emitted by lower.rs, all validated, all printed. None yet mapped to Cranelift instructions.
+
+| Variant | Emitted by lower.rs? | Validated? | Printed? | Cranelift mapping? |
+|---------|---------------------|-----------|----------|---------------------|
+| `Jump` | Yes — block linking, loop backedges, merge-block construction | Yes — target exists; arg count and types match block params (`validate.rs:439–453`) | Yes (`printer.rs:141`) | Not yet mapped (`backend/cranelift/mod.rs:199`) |
+| `Branch` | Yes — if/else lowering, loop header tests | Yes — cond must be Bool; both targets exist; both arg lists checked (`validate.rs:455–520`) | Yes (`printer.rs:149`) | Not yet mapped |
+| `Return` | Yes — explicit `Return` stmt; trailing ret_expr; void function fallthrough | Yes — return value defined when present (`validate.rs:522`) | Yes (`printer.rs:177`) | Not yet mapped |
+
+---
+
+## Section 4 — Semantic-to-IR coverage matrix
+
+Status legend:
+- ✅ **Lowers** — emits real IR
+- ⚠️ **Structured error** — `LoweringError::UnsupportedSemanticConstruct` or `UnsupportedSemanticType` with named context
+- ❌ **Panics** — none found in the IR layer
+- ❓ **Unhandled** — match arm absent (none — all enums are exhaustive in `match`)
+
+### 4.1 `SemanticExprKind` variants (19 total)
+
+| Variant | Status | Evidence | Notes |
+|---------|--------|----------|-------|
+| `Value` | ✅ Lowers | `lower.rs:1403` → `lower_value` (`lower.rs:1699`) | Int / Float / Bool literals; Unknown rejected at value level |
+| `VarRef` | ✅ Lowers | `lower.rs:1404–1416` | Reads from `active.bindings`; ensures type match |
+| `DotAccess` | ✅ Lowers | `lower.rs:1529–1530` → `lower_dot_access` (`lower.rs:2051`) | CX-10; uses `resolve_field_ptr` + `Load` |
+| `HandleNew` | ⚠️ Structured error | `lower.rs:1532` `unsupported!("HandleNew")` | Phase 9 work — runtime intrinsics |
+| `HandleVal` | ⚠️ Structured error | `lower.rs:1533` `unsupported!("HandleVal")` | Phase 9 |
+| `HandleDrop` | ⚠️ Structured error | `lower.rs:1534` `unsupported!("HandleDrop")` | Phase 9 |
+| `Call` | ✅ Lowers | `lower.rs:1468–1528` | CX-7; signature-table-driven; void calls rejected here, handled in `ExprStmt` path |
+| `Range` | ⚠️ Structured error | `lower.rs:1535–1539` | CX-19; explanatory message ("ranges are only supported in for-loop bounds") |
+| `Unary` | ✅ Lowers | `lower.rs:1560–1606` | Op::Minus → `0 − x`; Op::Not → `x == 0`; other ops rejected |
+| `Binary` | ✅ Lowers | `lower.rs:1417–1419` → `lower_binary` (`lower.rs:1758`) | Arithmetic → `IrInst::Binary`; comparisons → `IrInst::Compare` |
+| `Cast` | ✅ Lowers | `lower.rs:1420–1436` | Emits `IrInst::Cast` |
+| `ArrayLit` | ✅ Lowers | `lower.rs:1607–1609` → `lower_array_lit` (`lower.rs:2094`) | CX-16; Alloca + per-element PtrOffset + Store |
+| `Index` | ✅ Lowers | `lower.rs:1610–1612` → `lower_index` (`lower.rs:2184`) | CX-17; uses `PtrAdd` for runtime offset |
+| `MethodCall` | ⚠️ Structured error | `lower.rs:1613–1617` | CX-21; names instance and method in error |
+| `StructInstance` | ✅ Lowers | `lower.rs:1637–1691` | CX-9; canonical field-order traversal; rejects zero-size structs |
+| `When` | ⚠️ Structured error | `lower.rs:1692` `unsupported!("WhenExpr")` | Roadmap explicitly unsupported in 0.1 |
+| `ResultOk` | ⚠️ Structured error | `lower.rs:1693` `unsupported!("ResultOk")` | `Result<T>` not in 0.1 surface |
+| `ResultErr` | ⚠️ Structured error | `lower.rs:1694` `unsupported!("ResultErr")` | `Result<T>` not in 0.1 surface |
+| `Try` | ⚠️ Structured error | `lower.rs:1695` `unsupported!("Try")` | `Result<T>` not in 0.1 surface |
+
+### 4.2 `SemanticType` variants (20 total)
+
+| Variant | Status | Evidence | Notes |
+|---------|--------|----------|-------|
+| `I8` | ✅ Lowers | `lower.rs:2281` → `IrType::I8` | |
+| `I16` | ✅ Lowers | `lower.rs:2282` → `IrType::I16` | |
+| `I32` | ✅ Lowers | `lower.rs:2283` → `IrType::I32` | |
+| `I64` | ✅ Lowers | `lower.rs:2284` → `IrType::I64` | |
+| `I128` | ✅ Lowers | `lower.rs:2285` → `IrType::I128` | |
+| `F64` | ✅ Lowers | `lower.rs:2286` → `IrType::F64` | |
+| `Bool` | ✅ Lowers | `lower.rs:2287` → `IrType::Bool` | |
+| `Numeric` | ⚠️ Structured error | `lower.rs:2288` `unsupported_type!("Numeric")` | Should be resolved to a concrete type before lowering |
+| `Unknown` | ⚠️ Structured error | `lower.rs:2289` `unsupported_type!("Unknown")` | Phase 8 Round 2 / Phase 9 |
+| `Handle(_)` | ⚠️ Structured error | `lower.rs:2290` `unsupported_type!("Handle")` | Phase 8 Round 2 |
+| `StrRef` | ⚠️ Structured error | `lower.rs:2291` `unsupported_type!("StrRef")` | Phase 8 Round 2 — blocked on arena ownership decision |
+| `Container` | ⚠️ Structured error | `lower.rs:2292` `unsupported_type!("Container")` | Frontend-only construct |
+| `Str` | ⚠️ Structured error | `lower.rs:2293` `unsupported_type!("Str")` | Phase 8 Round 2 |
+| `Char` | ⚠️ Structured error | `lower.rs:2294` `unsupported_type!("Char")` | Not in 0.1 surface |
+| `Enum(_)` | ⚠️ Structured error | `lower.rs:2295` `unsupported_type!("Enum")` | Tag-only enum layout locked in ABI doc but type lowering still pending |
+| `TypeParam(_)` | ⚠️ Structured error | `lower.rs:2296` `unsupported_type!("TypeParam")` | Generics not in 0.1 surface |
+| `Struct(_)` | ✅ Lowers | `lower.rs:2297` → `IrType::Ptr` | Sub-packet 2; concrete layout via `ctx.struct_table` |
+| `Array(_,_)` | ✅ Lowers | `lower.rs:2298` → `IrType::Ptr` | CX-16; concrete layout via `compute_array_layout` |
+| `Result(_)` | ⚠️ Structured error | `lower.rs:2299` `unsupported_type!("Result")` | Not in 0.1 surface |
+| `Void` | ⚠️ Structured error | `lower.rs:2300` `unsupported_type!("Void")` | `IrType::Void` not yet defined |
+
+### 4.3 `SemanticLValue` variants (3 total)
+
+| Variant | Status | Evidence | Notes |
+|---------|--------|----------|-------|
+| `Binding` | ✅ Lowers | `Assign` arm `lower.rs:503–516`; `CompoundAssign` arm `lower.rs:608–644` | SSA rebind on every write |
+| `DotAccess` | ✅ Lowers | `Assign` arm `lower.rs:517–528`; `CompoundAssign` arm `lower.rs:645–685` | CX-14; uses `resolve_field_ptr` + `Store` |
+| `Index` | ✅ Lowers | `Assign` arm `lower.rs:529–538`; `CompoundAssign` arm `lower.rs:686–725` | CX-20; uses `resolve_array_element_ptr` + `Store` |
+
+### 4.4 `SemanticStmt` variants (21 total)
+
+| Variant | Status | Evidence | Notes |
+|---------|--------|----------|-------|
+| `Noop` | ✅ Lowers | `lower.rs:493` `Ok(Some(current))` | No-op pass-through |
+| `EnumDef` | ⚠️ Structured error | `lower.rs:731` `unsupported!("EnumDef")` | Tag-only layout locked in ABI doc but stmt lowering still pending |
+| `Decl` | ✅ Lowers | `lower.rs:494–499` | Type validated; no IR emitted |
+| `Assign` | ✅ Lowers | `lower.rs:500–540` | Three sub-arms (Binding/DotAccess/Index) |
+| `TypedAssign` | ✅ Lowers | `lower.rs:541–557` | SsaBind + binding-map insert |
+| `CompoundAssign` | ✅ Lowers | `lower.rs:606–727` | Three sub-arms; supports +,−,×,÷,% |
+| `ExprStmt` | ✅ Lowers | `lower.rs:558–573` | Detects void calls, otherwise discards expression value |
+| `Return` | ✅ Lowers | `lower.rs:574–605` | Type-checked against function spec; rejected at top level |
+| `FuncDef` | ⚠️ Structured error inside `lower_stmt` (`lower.rs:728–730` "nested FuncDef"); ✅ Lowers when at module level via `lower_program_inner` (`lower.rs:298–302`) | Nested function defs not allowed — top-level only |
+| `Block` | ⚠️ Structured error | `lower.rs:732` `unsupported!("Block")` | Frontend-side construct |
+| `While` | ✅ Lowers | `lower.rs:734–739` → `lower_while` (`lower.rs:1018`) | Header/body/exit CFG |
+| `For` | ✅ Lowers | `lower.rs:740–745` → `lower_for` (`lower.rs:1235`) | Inline range; increment block |
+| `Loop` | ✅ Lowers | `lower.rs:746–751` → `lower_loop` (`lower.rs:1131`) | Header/body CFG with break exit |
+| `Break` | ✅ Lowers | `lower.rs:752–771` | Jumps to current loop's exit block |
+| `Continue` | ✅ Lowers | `lower.rs:772–791` | Jumps to current loop's header (or for-loop increment block) |
+| `IfElse` | ✅ Lowers | `lower.rs:793–810` → `lower_if_else` (`lower.rs:817`) | Block params at merge points |
+| `WhileIn` | ⚠️ Structured error | `lower.rs:733` `unsupported!("WhileIn")` | Iteration over arrays — Phase 11+/12+ |
+| `When` | ⚠️ Structured error | `lower.rs:792` `unsupported!("When")` | Roadmap explicitly unsupported in 0.1 |
+| `StructDef` | ✅ Lowers (no-op) | `lower.rs:811` `Ok(Some(current))` | Pre-processed by `build_struct_table` |
+| `ImplBlock` | ⚠️ Structured error | `lower.rs:812` `unsupported!("ImplBlock")` | Methods not in 0.1 surface |
+| `ConstDecl` | ⚠️ Structured error | `lower.rs:813` `unsupported!("ConstDecl")` | Module-level constants — not in 0.1 surface |
+
+---
+
+## Section 5 — Cranelift and JIT readiness
+
+### 5.1 Crate dependencies present
+
+From `Cargo.toml`, all gated by `feature = "jit"`:
+
+| Crate | Version | Notes |
+|-------|---------|-------|
+| `cranelift-codegen` | 0.115 | optional; enabled by `jit` feature |
+| `cranelift-frontend` | 0.115 | optional; enabled by `jit` feature |
+| `cranelift-module` | 0.115 | optional; enabled by `jit` feature |
+| `cranelift-jit` | 0.115 | optional; enabled by `jit` feature |
+| `cranelift-native` | 0.115 | optional; enabled by `jit` feature |
+
+`target-lexicon` is **not** listed directly. It is brought in transitively by `cranelift-codegen`/`cranelift-jit`. No explicit pin; will track Cranelift's vendored version.
+
+### 5.2 Files in `src/backend/`
+
+| File | Role | Lines | Status |
+|------|------|-------|--------|
+| `src/backend/mod.rs` | `Backend` trait, `BackendKind` enum, `parse_backend_flag`, `lower_to_ir` | 37 | Complete |
+| `src/backend/cranelift/mod.rs` | `CraneliftBackend`, `ir_type_to_cranelift`, `lower_module/function/block/instruction/terminator` traversal, structured `CraneliftLoweringError` | 254 | Skeleton — every IrInst/IrTerminator returns `UnsupportedInstruction`/`UnsupportedTerminator` |
+| `src/backend/cranelift/jit.rs` | `run_jit` thin wrapper delegating to `HostBoundary::execute` | 12 | Stub (delegates to host_boundary which is also stubbed) |
+| `src/backend/cranelift/aot.rs` | `emit_object` returning `"Cranelift AOT backend not implemented yet"` | 7 | Stub — out of scope for 0.1 |
+| `src/backend/cranelift/host_boundary.rs` | `JitExitCode`, `JitOutcome`, `JitExecutionError`, `HostBoundary`; comprehensive doc comments; 11 unit tests of the type machinery | 336 | Scaffold — `HostBoundary::execute` returns `UnsupportedConstruct { construct: "Phase 14 pending" }` unconditionally |
+| `src/backend/llvm/mod.rs` | `LlvmBackend` struct, `Backend` impl returning "not implemented" | 12 | Stub — out of scope for 0.1 |
+| `src/backend/llvm/aot.rs` | `emit_object` stub | 6 | Stub — out of scope for 0.1 |
+
+**Total backend code:** 664 lines, of which 336 (51%) are documentation comments and tests for the host boundary scaffold.
+
+### 5.3 IrType → Cranelift Type mapping
+
+Implemented in `src/backend/cranelift/mod.rs:69–85` (`ir_type_to_cranelift`). Every `IrType` variant has a mapping:
+
+| IrType | Cranelift type | Blocked by? |
+|--------|----------------|-------------|
+| `I8` | `types::I8` | — |
+| `I16` | `types::I16` | — |
+| `I32` | `types::I32` | — |
+| `I64` | `types::I64` | — |
+| `I128` | `types::I128` | Cranelift emulates as 2× i64 — runtime helper functions for arithmetic ops may be needed; not yet stubbed |
+| `F64` | `types::F64` | — |
+| `Bool` | `types::I8` | 0/1 convention |
+| `TBool` | `types::I8` | 0/1/2 convention; depends on frontend `SemanticType::TBool` and TBool calling-convention decision |
+| `Ptr` | `types::I64` | 64-bit only — fine for Windows x64 / Linux x64 0.1 targets |
+
+### 5.4 IrInst → Cranelift instruction mapping
+
+**No IrInst variant has a real Cranelift mapping yet.** Every arm in `lower_instruction` (`backend/cranelift/mod.rs:118–195`) returns `CraneliftLoweringError::UnsupportedInstruction { inst, context }` with the operand details captured in the context string. This is intentional Phase 13 skeleton behavior.
+
+| IrInst variant | Status | Blocking |
+|----------------|--------|----------|
+| `ConstInt` | Stub (returns `UnsupportedInstruction`) | Phase 14 — first executable slice |
+| `ConstFloat` | Stub | Phase 14 |
+| `SsaBind` | Stub | Phase 14 (or eliminate as no-op into a value-id alias map) |
+| `Binary` | Stub | Phase 14 |
+| `Compare` | Stub | Phase 14 |
+| `Call` | Stub | Phase 14 (multi-function programs) — needs symbol table |
+| `Cast` | Stub | Phase 14 — int widening/narrowing helpers |
+| `Alloca` | Stub | Phase 14 — Cranelift `StackSlot`s |
+| `PtrOffset` | Stub | Phase 14 — `iadd_imm` |
+| `PtrAdd` | Stub | Phase 14 — `iadd` |
+| `Load` | Stub | Phase 14 — Cranelift `load` |
+| `Store` | Stub | Phase 14 — Cranelift `store` |
+
+### 5.5 End-to-end execution path
+
+**There is no path from a `.cx` source file to a callable function pointer.** The pipeline up to IR is complete:
+
+```
+.cx source
+  → tokenize (frontend/lexer.rs)
+  → parse (frontend/parser.rs, chumsky)
+  → resolve imports (frontend/resolver.rs)
+  → semantic analysis (frontend/semantic.rs → SemanticProgram)
+  → lower_program (ir/lower.rs → IrModule)
+  → validate_module (ir/validate.rs)
+```
+
+This pipeline runs cleanly for the supported 0.1 subset and is exercised by 100+ tests. The remaining edges to cross before "function pointer the host can call" exist:
+
+1. **`HostBoundary::execute`** must instantiate a Cranelift `JITModule`, declare each `IrFunction`, and define each function via `cranelift_frontend::FunctionBuilder` — currently returns `UnsupportedConstruct`.
+2. **`lower_instruction`** must replace stub error returns with real `InstBuilder` calls — every variant.
+3. **`lower_terminator`** must call `block_call` / `brif` / `return_` — currently stubs.
+4. **`HostBoundary::execute`** must `module.finalize_definitions()` and `module.get_finalized_function(main_id)` to obtain a function pointer, then `transmute` to a callable signature.
+5. **Synthetic main** is currently lowered as `fn main() -> ()` (no return value); the host boundary doc says exit code is the I32 return of main — needs a decision on whether to add an exit-code path through the IR or change synthetic main's signature.
+
+**Estimated dependency order to "hello world":** Phase 14 first slice → minimal Phase 9 print intrinsic → `--backend=cranelift` runs `examples/hello.cx`. Section 9 of this audit spells out the steps.
+
+### 5.6 JIT runtime host boundary
+
+**Present but stubbed.** Per CX-24, the scaffold is in `src/backend/cranelift/host_boundary.rs` (336 lines).
+
+What it owns:
+- **Process ownership:** documented as in-process (no fork). `HostBoundary` is a per-execution struct dropped after `execute` returns; doc comment says Cranelift will free JIT memory on drop.
+- **Exit-code extraction:** `JitExitCode` type with `SUCCESS = 0`, `JIT_RUNTIME_FAILURE = 126`, `UNSUPPORTED_CONSTRUCT = 127`, plus arbitrary `failure(i32)` constructor. Designed to map Cx `main`'s I32 return to the exit code.
+- **Stdout/stderr capture:** doc comment says capture is **not** in-process — JIT-compiled code writes to host stdout via C runtime; the differential harness is supposed to capture by running the compiler binary as a subprocess.
+- **Runtime failure surfacing:** four `JitExecutionError` variants — `UnsupportedConstruct`, `CodegenFailure`, `MainNotFound`, `RuntimePanic`. Documented contract: no Rust panics escape, all failures become structured errors.
+- **Differential harness integration:** doc-only — the harness in `diff_harness.rs` runs the interpreter as a subprocess; the JIT subprocess equivalent is not yet wired.
+
+What it does **not** yet own:
+- Any real Cranelift `JITModule` instantiation.
+- Any function-pointer extraction.
+- Any real `main` invocation.
+- `execute` always returns `Err(UnsupportedConstruct { construct: "JIT codegen not yet implemented — Phase 14 (First Executable Cranelift Slice) pending" })`.
+
+The 11 unit tests cover `JitExitCode`, `JitOutcome`, `JitExecutionError::Display`, and the stub-`execute` contract — they confirm the type plumbing and the no-panic guarantee, not real execution.
+
+### 5.7 Differential harness (Phase 12)
+
+**Shell present; baseline gate working; JIT comparison not yet wired.** Per CX-23, `src/diff_harness.rs` (390 lines):
+
+- **Fixture format:** `<name>.cx` source plus optional companion files `<name>.cx.expected_output` (stdout match) and `<name>.cx.expected_fail` (zero-byte marker for expected non-zero exit). Three `TestExpectation` variants: `PassWithOutput(String)`, `PassAny`, `Fail`.
+- **Collection:** `collect_matrix_tests()` enumerates `src/tests/verification_matrix/`. As of audit, 117 `.cx` files with 30 `.expected_output` companions and 26 `.expected_fail` markers (61 are `PassAny`).
+- **Interpreter baseline:** `run_interpreter()` spawns `target/debug/Cx_0V[.exe]` per fixture, captures stdout/stderr/exit. `interpreter_baseline_all` is a `#[test]` that runs every fixture and panics on any divergence from expectation. It is currently passing (counted in the 163 green tests).
+- **JIT path:** **not yet present.** No symmetric `run_jit_subprocess()` function or test exists in `diff_harness.rs`.
+
+What's missing for full Phase 12:
+- A `run_jit()` symmetric to `run_interpreter()` that invokes `Cx_0V --backend=cranelift <fixture>`.
+- A `differential_all` test that runs every fixture through both backends and reports stdout/exit-code divergences with IR dump.
+- Per-feature parity checklist tracking which fixtures are expected to pass through JIT vs which are expected to surface a structured "unsupported" error.
+
+---
+
+## Section 6 — Test surface
+
+### 6.1 Total counts
+
+- `cargo test --features jit` → **163 passed, 0 failed, 0 ignored** (2.26 s)
+- 0 panics on test-side; the diff_harness `interpreter_baseline_all` test internally validates 117 matrix fixtures.
+
+### 6.2 Tests by area
+
+Counts derived from `cargo test --features jit` test-name prefixes:
+
+| Area | Test count | Files | Notes |
+|------|-----------|-------|-------|
+| Parser / Lexer | 0 | (none in this measurement) | Frontend tests not enumerated by the IR/backend audit; presumed to live alongside frontend code |
+| Semantic analysis | 7 | `src/frontend/semantic.rs` | `accumulates_semantic_errors`, `expressions_carry_resolved_types`, `inserts_explicit_casts_for_typed_numeric_assignment`, `populates_enum_registry_for_declared_enums`, `resolves_function_call_targets`, `resolves_variable_references_to_declarations`, `returns_semantic_program_on_success` |
+| IR builder | 2 | `src/ir/builder.rs` | `builder_allocates_unique_value_ids_and_block_ids`, `builder_can_construct_function_with_one_block` |
+| IR instr | 2 | `src/ir/instr.rs` | `inst_variants_hold_expected_typed_fields`, `terminator_variants_hold_expected_target_value_data` |
+| IR types (layout) | 24 | `src/ir/types.rs` | 9 scalar size/align, 7 struct-layout, 5 array-layout, 1 enum-tag, plus 2 IR-shape sanity tests |
+| IR lowering | 84 | `src/ir/lower.rs` | The bulk of the test suite — every Phase 4–11 sub-packet shipped with tests |
+| IR printer | 5 | `src/ir/printer.rs` | `prints_block_params`, `prints_branch_with_args`, `prints_call_instruction`, `prints_function_with_params`, `prints_simple_function` |
+| IR validation | 15 | `src/ir/validate.rs` | Duplicate block/value/param, undefined value, missing target, type usage checks |
+| Cranelift host boundary | 11 | `src/backend/cranelift/host_boundary.rs` | All 11 cover JitExitCode, JitOutcome, JitExecutionError, HostBoundary stub contract |
+| Cranelift skeleton (other) | 0 | `src/backend/cranelift/mod.rs` | `lower_module`/`lower_function`/`lower_block` etc. have no tests yet — all return `UnsupportedInstruction`/`UnsupportedTerminator` and there is no positive-path test |
+| Differential harness | 4 | `src/diff_harness.rs` | `collects_matrix_tests_non_empty`, `fixture_expectations_cover_pass_and_fail`, `pass_with_output_expectations_are_non_empty`, `interpreter_baseline_all` (the last one internally exercises all 117 matrix fixtures) |
+| Runtime handle | 9 | `src/runtime/handle.rs` | Generation-tagged handle registry tests |
+| **Total** | **163** | | |
+
+### 6.3 Coverage gaps
+
+- **Cranelift skeleton has 0 positive-path tests.** Every IrInst arm in `lower_instruction` returns the same shape of `UnsupportedInstruction`. There is no test asserting "given a 1-instruction module with `ConstInt`, the skeleton produces the expected `UnsupportedInstruction { inst: 'ConstInt' }` error" — the structured-error contract per IrInst variant is unverified.
+- **No multi-function call validator test** for arg-type mismatch involving `Ptr`, `TBool`, or `F64` — current `validate.rs` tests only exercise `I64` arg/return shapes (`validates_normal_function_with_params_and_return_value` at `validate.rs:1041`).
+- **Loop-variable read-only invariant** is not enforced in the validator (roadmap Phase 10 known gap, line 293). The runtime catches it; the IR validator should reject assignments to a for-loop binding inside the body. No test reproduces this scenario.
+- **`StructDef` lowering** has no dedicated test in `ir::lower::tests` — the no-op behavior is exercised indirectly through `StructInstance` tests (CX-9, CX-18).
+- **Differential harness** has no JIT-path test (consistent with Phase 12 sub-packet 1 only delivering the interpreter baseline). When CX-23 lands a JIT-side runner, this gap closes.
+- **`IrType::TBool`** has size/align tests but no `lower_type` test that exercises a `SemanticType::TBool` → `IrType::TBool` mapping (because that frontend variant doesn't exist yet).
+- **`PtrAdd` + I64 offset**: validator requires offset to be I64 (`validate.rs:470`). Tests confirm validation but the lowering test count for runtime-offset array reads/writes is small relative to the StructInstance/DotAccess coverage; CX-17 added one `lowers_index` and CX-20 added one `lowers_array_index_write` per the commit log — verifying detail would require finer-grained reading.
+
+---
+
+## Section 7 — Gap analysis to 0.1
+
+Ordered by dependency. Sizes: S = one Stokowski packet (hours), M = 1–3 packets (days), L = multiple packets (week+), XL = research / design needed before scoping.
+
+1. **First executable Cranelift slice (Phase 14)**
+   - **What:** Wire `HostBoundary::execute` to actually instantiate a `cranelift_jit::JITModule`, declare every `IrFunction`, define each function by translating IR through `FunctionBuilder`, finalize, and call `main`. Replace every `lower_instruction` stub for the arithmetic subset (`ConstInt`, `ConstFloat`, `SsaBind`, `Binary`, `Compare`, `Cast`) and `Return` terminator. Multi-function programs (`Call`) follow.
+   - **Size:** L
+   - **Blocked by:** nothing (skeleton is in place, IR is correct)
+   - **Blocks:** Phase 15, full Phase 12 harness, "hello world" demo
+   - **Roadmap reference:** Phase 14
+2. **Print intrinsic (Phase 9, minimal)**
+   - **What:** Define a runtime entry point for `print`. Decide whether `print` is lowered as `IrInst::Call` to a special name (e.g. `__cx_print_i64`, `__cx_print_str`) or as a new `IrInst::Intrinsic` variant. Wire the JIT path to declare those entry points as imported symbols (Cranelift `Module::declare_function` with `Linkage::Import`) and bind them at JIT-finalize time via `JITBuilder::symbol`.
+   - **Size:** M
+   - **Blocked by:** Frontend promoting `print` to a function with a known signature (per roadmap line 258–259)
+   - **Blocks:** any matrix fixture that uses `print` (which is most of them — at least 30 `.expected_output` files imply prints)
+   - **Roadmap reference:** Phase 9
+3. **`IrType::Void` and void-return calling convention finalization**
+   - **What:** Currently void calls work in IR via `Option<IrType>` on call/function — but the calling convention doc says return uses RAX or "—" for void. Decide whether to add an explicit `IrType::Void` (cleaner) or keep the option-based encoding. Document in ABI doc.
+   - **Size:** S–M
+   - **Blocked by:** nothing
+   - **Blocks:** clean Cranelift signature construction in Phase 14
+   - **Roadmap reference:** Phase 8 Round 2 / Phase 11 trailing
+4. **Phase 8 Round 2 — str / strref layout**
+   - **What:** Decide arena ownership for JIT mode (interpreter arena via intrinsic? separate JIT arena? heap-allocated str?). Lock str representation as `(ptr, u32 len)` per existing frontend convention. Add lowering for `SemanticType::Str` and `SemanticType::StrRef`. Add ABI doc rows.
+   - **Size:** M (XL if "strings as heap-allocated" needs runtime allocator integration)
+   - **Blocked by:** Arena ownership decision
+   - **Blocks:** any program that uses string variables (which currently lower to `unsupported_type!("Str")`)
+   - **Roadmap reference:** Phase 8 Round 2 (line 237–238)
+5. **TBool calling convention + `SemanticType::TBool`**
+   - **What:** Frontend needs a `SemanticType::TBool`. Backend already has `IrType::TBool` and layout. Calling convention for TBool params needs an explicit decision (treat as u8? tag-and-payload?). ABI doc update.
+   - **Size:** M
+   - **Blocked by:** Frontend addition of `SemanticType::TBool`
+   - **Blocks:** when-block lowering (which depends on TBool three-way semantics) — but when-blocks are explicitly post-0.1 per roadmap
+   - **Roadmap reference:** Phase 8 Round 2 (line 240–241)
+6. **`Handle<T>` runtime representation**
+   - **What:** Decide the wire representation of generation-tagged handles (`(slot u32, gen u32)` packed into u64? two i32s?). Lower `SemanticType::Handle(_)`. Define `__cx_handle_alloc` / `__cx_handle_get` / `__cx_handle_drop` runtime entry points.
+   - **Size:** L
+   - **Blocked by:** Phase 9 intrinsics decision (handles are runtime objects)
+   - **Blocks:** any program using `Handle.new`, `h.val`, `h.drop()` (currently lowers to `HandleNew/HandleVal/HandleDrop` structured errors)
+   - **Roadmap reference:** Phase 8 Round 2 (line 239), Phase 9
+7. **Loop-variable read-only validator gap**
+   - **What:** Add validator check that rejects assignments to a loop-variable binding inside its loop body. Add test reproducing the violation.
+   - **Size:** S
+   - **Blocked by:** nothing
+   - **Blocks:** "Backend must not panic on any valid IR" hard blocker — currently the gap is upstream (semantic layer should catch this) but backend should defensively reject
+   - **Roadmap reference:** Phase 10 known gap (line 293)
+8. **Phase 12 — JIT-side runner in differential harness**
+   - **What:** Add `run_jit_subprocess()` symmetric to `run_interpreter()`. Add `differential_all` test that runs every fixture through both backends and reports divergences.
+   - **Size:** S–M (mostly mechanical once JIT subprocess is callable)
+   - **Blocked by:** Phase 14 (need a working JIT path to subprocess against)
+   - **Blocks:** "All supported frontend matrix tests pass through the Cranelift JIT path" hard blocker
+   - **Roadmap reference:** Phase 12 (full harness)
+9. **Determinism check**
+   - **What:** Add a test that runs a deterministic Cx program twice through the JIT and asserts byte-identical output. Add a stable IR-printer round-trip test.
+   - **Size:** S
+   - **Blocked by:** Phase 14
+   - **Blocks:** "Minimal determinism guaranteed" hard blocker
+   - **Roadmap reference:** "Determinism — Minimal" (line 498)
+10. **i128 runtime helpers (if needed)**
+    - **What:** Cranelift emulates i128 as 2× i64 for arithmetic; whether the emulation is automatic for all arithmetic ops or whether some require runtime helper functions (libgcc-style `__multi3`) needs verification. If required, stub helpers in the runtime.
+    - **Size:** XL → S after research
+    - **Blocked by:** Phase 14 attempt at i128 arithmetic
+    - **Blocks:** any program using `t128`
+    - **Roadmap reference:** ABI doc note on i128 emulation
+11. **End-to-end smoke tests directory (`tests/jit_smoke/` or equivalent)**
+    - **What:** A landing zone for integration tests that compile a small `.cx` program, call `--backend=cranelift`, and assert exit code + stdout. Currently no such directory exists.
+    - **Size:** S
+    - **Blocked by:** Phase 14
+    - **Blocks:** "One non-trivial multi-function program runs correctly end to end through JIT" hard blocker
+    - **Roadmap reference:** Phase 14 acceptance
+
+---
+
+## Section 8 — Risk register
+
+| Risk | Likelihood (L/M/H) | Impact (L/M/H) | Mitigation |
+|------|--------------------|-----------------|------------|
+| Cranelift's `i128` arithmetic requires runtime helper functions on x86_64 not yet stubbed | M | M | Verify with a one-line test compiling `let x: t128 = 1 + 2` through Phase 14 once it lands; stub `__multi3` / `__udivti3` etc. if Cranelift's vendored emulation fails to link |
+| Struct passing by-value through Cranelift signatures requires `iconcat`/`isplit` or stack-spill — current ABI says structs are pointers but call boundaries haven't been exercised | M | H | Decide before Phase 14 lands struct args/returns whether to spill to stack at call site or pass by Cranelift-native i128. Lock convention in ABI doc Round 2 |
+| `print` is not a function in the frontend; Phase 9 cannot close until it is. If frontend changes `print` semantics (newline param, name change) post-Phase-9-design, the intrinsic table churns | M | M | Design Phase 9 with versioned intrinsic names (`__cx_print_i64_v1`) so frontend behavior changes can ship side-by-side without breaking JIT |
+| Differential harness baselines come from interpreter; interpreter is not pinned to a release version. If interpreter behavior drifts during a Phase 14 push, baselines move under us | L | M | Snapshot expected_output files into a versioned directory per release candidate; freeze when starting Phase 14 |
+| Synthetic main's signature is currently `() -> ()` but JIT host boundary docs assume `() -> i32` for exit codes. Mismatch will surface as the first thing Phase 14 needs to solve | H | M | Lock decision before Phase 14: either (a) change synthetic main to return I32, or (b) keep void main and use a sentinel exit code (always 0 for clean execution, 126/127 for JIT failures). Currently the host_boundary doc says (a) but lower.rs synthesizes (b). |
+| JIT memory not freed between executions in long-running test runs (the `interpreter_baseline_all` test runs 117 subprocesses; if a future JIT-side test runs them in-process, leaks compound) | L | L | Drop `HostBoundary` per execution as the doc already says — verify with valgrind or `cargo test --release` memory growth |
+| The IR validator allows `IrType::TBool` to flow into `Compare` and `Binary` operands implicitly (via `define_value`), but `Binary`'s arith-capable check excludes it — TBool arithmetic would pass `Load` validation but fail `Binary`. Error message clarity | L | L | Add explicit `Binary` rejection of `TBool` with a named error; covered by Phase 8 Round 2 |
+| Loop-variable read-only invariant is enforced by the runtime but not by the IR validator. A backend-only path that skips the runtime would silently accept bad IR | L | M | Land the validator check (gap #7 in Section 7) before Phase 14 starts emitting code that would observe the violation |
+| `cargo test --features jit` compile time: full clean rebuild took 1m 44s in this audit. As IR/backend grows, will rise. Already affecting iteration speed | M | L | Move heavy backend tests to integration tests directory (`tests/`) so they don't recompile on every `lib.rs`/`mod.rs` change. Use `cargo test --features jit --no-run` then targeted runs |
+| 21 build warnings (mostly dead-code on `#![allow(dead_code)]` modules in backend/llvm and unused items in `lower.rs`) accumulating — silently hides real warnings when they appear | L | L | Audit warnings in a separate ticket; remove `#![allow(dead_code)]` from active modules and inline `#[allow(dead_code)]` per item |
+| Frontend `analyze_program` was renamed/removed (test-time errors during one earlier audit attempt) — frontend test surface is unstable. Backend audit doesn't depend on it but backend changes that touch `src/main.rs` could collide | L | L | Coordinate touch of `src/main.rs` with frontend dev per doctrine line 226 |
+
+---
+
+## Section 9 — Critical path to executable hello world
+
+The shortest sequence from current state to a Cx program printing "hello world" via JIT and exiting 0.
+
+1. **Step 1: Lock synthetic-main return type**
+   - **Why this is next:** The host boundary docs assume `main` returns I32 for exit-code extraction; the current `lower_top_level_main` produces a void function. Phase 14 cannot proceed until this is consistent.
+   - **Estimated size:** S (one packet — change `lower_top_level_main` to take an optional explicit-exit-code path, or document that void-main is mapped to exit code 0 inside `HostBoundary`)
+   - **Acceptance test:** A unit test in `host_boundary.rs` that constructs a void-main IR module and asserts `JitOutcome::exit_code == 0` (currently this would test the documented behavior; once Step 4 lands, would test real execution)
+2. **Step 2: First executable Cranelift slice — arithmetic-only**
+   - **Why this is next:** Lifts the JIT path from "always errors" to "executes a no-op" and proves the wiring. The roadmap explicitly calls this out as Phase 14's first deliverable: constants, arithmetic, returns, synthetic main.
+   - **Estimated size:** L (multi-packet — `lower_instruction` arms for `ConstInt`/`ConstFloat`/`SsaBind`/`Binary`/`Compare`/`Cast`; `lower_terminator` for `Jump`/`Branch`/`Return`; `HostBoundary::execute` instantiates `JITModule`, builds each function, finalizes, calls main)
+   - **Acceptance test:** New test `tests/jit_smoke/arith_returns.rs` that runs `examples/hello.cx` (replaced with an arithmetic-only program, e.g. `42`) and asserts exit code 42
+3. **Step 3: Add `IrInst::Call` codegen**
+   - **Why this is next:** Multi-function programs require it; without it, the matrix's function-using tests can't be verified.
+   - **Estimated size:** M
+   - **Acceptance test:** A `.cx` program with two functions where main calls a helper returning a constant; assert exit code matches helper's return
+4. **Step 4: Define the print intrinsic and bind in JIT**
+   - **Why this is next:** "Hello world" requires `print`. This is also the first runtime-boundary work and unblocks Phase 9's close.
+   - **Estimated size:** M
+   - **Acceptance test:** A `.cx` program containing `print(42)` runs through JIT and produces stdout `42` (subprocess-captured by the differential harness)
+5. **Step 5: Wire the `--backend=cranelift` path in `main.rs` to invoke the JIT instead of just dumping IR**
+   - **Why this is next:** Currently `main.rs` line 235 prints the IR module then calls `b.execute(&ir)` which the Cranelift backend implements but routes to `HostBoundary::execute` which is the stub. Once Step 2/3/4 land, this line already works — but the IR-print before execute is debug spam that breaks differential harness stdout matching. Decide whether to gate the print behind `--debug-trace` only.
+   - **Estimated size:** S
+   - **Acceptance test:** `cargo run --features jit -- --backend=cranelift examples/hello.cx` exits 0 with `hello world` on stdout
+
+After Step 5, the project has its first runnable Cx program through JIT. Steps 6+ extend coverage to the full supported subset (control flow, loops, structs, arrays) until Phase 15 closes.
+
+---
+
+## Section 10 — Recommendations
+
+1. **Update `cx_backend_roadmap_v3_1.md` to reflect the 8 Phase 11 sub-packets shipped after the v4.0 reconcile.** Specifically: Phase 11 active section (lines 192–197) and "Still open" list (lines 312–319) both treat range, DotAccess, array indexing, method calls, and void calls as open — they all shipped (CX-9 through CX-21). Move them into "Landed". Add a closing line on Phase 11 status: "Closed 2026-05-05 — all surface-area items either lower or produce structured errors."
+   - **Why:** A stale roadmap is worse than no roadmap; it makes new contributors and the planning agent re-derive state.
+   - **How (concrete first step):** Add a v4.1 entry in the changelog section (line 633) noting Phase 11 closure; rewrite the Active section to call Phases 12, 13, 14 the active surface; move shipped items to the Done section.
+2. **Decide synthetic-main return type before any Phase 14 work starts.** The current mismatch between `lower_top_level_main` (void) and `host_boundary::JitOutcome::from_main_return(i32)` will become a real bug the moment Cranelift codegen lands. A 30-minute design lock now saves a full packet of churn later.
+   - **Why:** First Cranelift packet will need to build a Cranelift `Signature` for main; the choice of return type is structurally load-bearing.
+   - **How:** Open a design-lock packet titled "Synthetic main exit-code contract." Pick option (a) "synthetic main returns I32, defaults to ConstInt 0 if no explicit exit code" or (b) "synthetic main is void; HostBoundary maps to exit code 0 on success." Update both the host_boundary doc and `lower_top_level_main` in the same commit.
+3. **Add positive-path tests to the Cranelift skeleton before adding real codegen.** Right now every `lower_instruction` arm returns the same shape of `UnsupportedInstruction { inst, context }`. There's no test asserting "given module M with one ConstInt, lowering produces error E with `inst='ConstInt'` and context including the dst/ty/value." When real codegen lands and replaces the error returns, those tests will flip from `expect_err` to `expect_ok` — a clean discipline.
+   - **Why:** Catches regressions where a future packet replaces the error for one arm but not another, leaving inconsistent error-vs-success behavior across the IR surface.
+   - **How:** Add one test per IrInst variant in `src/backend/cranelift/mod.rs` `#[cfg(test)] mod tests` that constructs a minimal IrModule containing only that instruction and asserts the exact `CraneliftLoweringError::UnsupportedInstruction` shape. Twelve tests, ~150 LOC total.
+4. **Create `tests/jit_smoke/` as a named landing zone for integration tests that compile + execute a `.cx` through the JIT path.** Even an empty directory with a README pointing at the first-executable-slice acceptance test makes the intent visible.
+   - **Why:** When Phase 14 lands its first slice, the first acceptance test needs a home that isn't `src/diff_harness.rs`. Pre-creating the directory removes a friction point and makes the milestone show up in the file tree.
+   - **How:** `mkdir tests/jit_smoke`; add a README naming the milestone; commit. Five-minute change.
+5. **Lock the str/strref arena ownership decision before Phase 14 second-pass.** Strings will be needed for any meaningful "hello world"-class test beyond the integer-only first slice. The decision (interpreter arena via intrinsic vs. JIT-private arena vs. heap) shapes Phase 9's intrinsic table and Phase 14's runtime startup code.
+   - **Why:** Without this lock, the print-intrinsic packet (Section 7 item 2) has to make the decision implicitly, leaving it un-documented and easy to break.
+   - **How:** Convene a 30-minute design pass with the frontend dev. Document the decision in `cx_abi_v0.1.md` (currently has "OPEN" placeholder) and in the Phase 8 Round 2 section of the roadmap. No code changes yet — just the locked decision.
+
+---
+
+## Section 11 — Appendix: raw data
+
+### 11.1 `git log --oneline -50` of main
+
+```
+fedf93f Merge pull request #76 from COMMENTERTHE9/submain
+9f073ec Merge pull request #74 from COMMENTERTHE9/stokowski/cx-24
+8d6b229 Merge branch 'submain' into stokowski/cx-24
+0076af9 Merge pull request #73 from COMMENTERTHE9/stokowski/cx-23
+7d276b8 Merge pull request #72 from COMMENTERTHE9/stokowski/cx-22
+a0637b2 Merge pull request #71 from COMMENTERTHE9/stokowski/cx-21
+92781f6 Merge pull request #75 from COMMENTERTHE9/daily-log-2026-05-05
+7129e58 daily log 2026-05-05
+f6499db CX-24: JIT runtime host boundary — process ownership, exit-code extraction, and output capture scaffold
+63ffdee CX-23: differential harness shell — interpreter baseline capture and fixture format (Phase 12 sub-packet 1)
+ef1971e CX-22: Add Cranelift lowering skeleton — IrType mapping, module traversal, and structured not-implemented errors (Phase 13)
+18ab47c CX-21: emit named structured error for MethodCall in IR lowering
+dfe0619 Merge pull request #70 from COMMENTERTHE9/stokowski/cx-20
+389fcfc Merge branch 'submain' into stokowski/cx-20
+1baffb5 Merge pull request #68 from COMMENTERTHE9/stokowski/cx-19
+9f0af4a Merge pull request #67 from COMMENTERTHE9/stokowski/cx-18
+85f2350 CX-20: lower array element writes through IR (Phase 11 sub-packet 9)
+25317fd Merge pull request #69 from COMMENTERTHE9/daily-log-2026-05-04
+4070ab9 daily log 2026-05-04
+1baaeb0 Merge pull request #66 from COMMENTERTHE9/stokowski/cx-17
+dbe9ac6 Merge branch 'submain' into stokowski/cx-17
+cfea668 Merge pull request #65 from COMMENTERTHE9/stokowski/cx-16
+032944c Merge pull request #64 from COMMENTERTHE9/stokowski/cx-15
+7ba098c Merge pull request #55 from COMMENTERTHE9/daily-log-2026-05-03
+3db2418 Merge pull request #54 from COMMENTERTHE9/daily-log-2026-05-02
+0e78b7d CX-19: named structured error for SemanticExprKind::Range in IR lowering
+46e79f9 CX-16: lower array type and array literal through IR
+8968957 CX-18: add array-of-structs lowering tests (close CX-16 test gap)
+a1865b9 Merge pull request #63 from COMMENTERTHE9/stokowski/cx-14
+17f49ef CX-17: lower array element access through IR (Phase 11 sub-packet 7)
+0ecc29f CX-15: add Stokowski connector verification note to CONTRIBUTING.md
+1889e34 Merge pull request #62 from COMMENTERTHE9/stokowski/cx-13
+0257652 CX-14: lower struct field writes through IR
+4a5436a CX-13: lower void function calls through IR
+15438da Merge pull request #61 from COMMENTERTHE9/stokowski/cx-12
+9f6bd60 Merge pull request #60 from COMMENTERTHE9/stokowski/cx-11-reconcile-backend-roadmap
+cab039b CX-12: fix stale base check to compare against submain, not main
+448bb67 Merge pull request #59 from COMMENTERTHE9/stokowski/cx-10
+c872dff Merge branch 'submain' into stokowski/cx-10
+89d06cc CX-11: reconcile backend roadmap with actually-shipped work
+0626a12 Merge pull request #58 from COMMENTERTHE9/stokowski/cx-9
+a5de1f0 CX-10: lower struct field reads through IR (Phase 11 sub-packet 4)
+66bd94e CX-9: lower struct literals through IR (Phase 11 sub-packet 3)
+15810ba Merge pull request #57 from COMMENTERTHE9/submain
+17b57d4 Merge branch 'main' into submain
+51fdd8c Merge pull request #56 from COMMENTERTHE9/stokowski/cx-7-lower-direct-function-calls
+326d9bf CX-7: Lower direct function calls through IR (Phase 6)
+160c9de daily log 2026-05-03
+f0b3ee5 Merge pull request #53 from COMMENTERTHE9/stokowski/cx-6-document-unary-lowering
+d884cfe daily log 2026-05-02
+```
+
+### 11.2 `cargo test --features jit` summary
+
+```
+test result: ok. 163 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.26s
+```
+
+Test counts by area (re-listed for self-containment):
+
+```
+     84 test ir::lower
+     24 test ir::types
+     15 test ir::validate
+     11 test backend::cranelift
+      9 test runtime::handle
+      7 test frontend::semantic
+      5 test ir::printer
+      4 test diff_harness::tests
+      2 test ir::instr
+      2 test ir::builder
+```
+
+### 11.3 Full file tree of `src/`
+
+```
+src/backend/cranelift/aot.rs                7 lines
+src/backend/cranelift/host_boundary.rs    336 lines
+src/backend/cranelift/jit.rs               12 lines
+src/backend/cranelift/mod.rs              254 lines
+src/backend/llvm/aot.rs                     6 lines
+src/backend/llvm/mod.rs                    12 lines
+src/backend/mod.rs                         37 lines
+src/diff_harness.rs                       390 lines
+src/frontend/ast.rs                       (frontend; not deep-dived)
+src/frontend/diagnostics.rs               (frontend)
+src/frontend/lexer.rs                     (frontend)
+src/frontend/mod.rs                       (frontend)
+src/frontend/parser.rs                    (frontend)
+src/frontend/resolver.rs                  (frontend)
+src/frontend/semantic.rs                  (frontend)
+src/frontend/semantic_types.rs            (frontend)
+src/frontend/types.rs                     (frontend)
+src/ir/builder.rs                         163 lines
+src/ir/instr.rs                           165 lines
+src/ir/lower.rs                          5278 lines
+src/ir/mod.rs                              13 lines
+src/ir/printer.rs                         347 lines (system-reminder snapshot — actual may differ; line range covers print_inst, print_terminator, print_type, plus 5 tests)
+src/ir/types.rs                           353 lines
+src/ir/validate.rs                       1109 lines (system-reminder snapshot — actual covers all 12 IrInst arms + 15 tests)
+src/main.rs                               379 lines
+src/runtime/arena.rs                       96 lines
+src/runtime/handle.rs                     183 lines
+src/runtime/mod.rs                          3 lines
+src/runtime/runtime.rs                   1893 lines
+```
+
+Total `src/`: **207 files, 16,673 lines** per `git ls-files` and `find -name '*.rs'`.
+
+### 11.4 TODO / FIXME / XXX comments in `src/ir/` and `src/backend/`
+
+```
+src/backend/cranelift/aot.rs:5:    // TODO: Implement Cranelift AOT object emission from lowered IR.
+src/backend/llvm/aot.rs:4:    // TODO: Implement LLVM AOT object emission from lowered IR.
+```
+
+Two TODOs total. Both are AOT stubs explicitly marked as out-of-scope for 0.1 by the roadmap (Phase 16/17). No FIXME or XXX comments anywhere in `src/ir/` or `src/backend/`.
+
+### 11.5 Audit branch and commit
+
+- Branch: `audit/2026-05-05` (created off `main` at `fedf93f`)
+- Commit message (next commit, after this doc): `docs(audit): full 0.1 audit on 2026-05-05`
+- PR title: `Audit: Cx 0.1 state on 2026-05-05`
+
+---
+
+*End of audit.*


### PR DESCRIPTION
## Summary

Full read-only audit of the Cx 0.1 backend state at commit `fedf93f` (origin/main, 2026-05-05). One-write packet — only adds `docs/audits/audit_2026_05_05.md`.

## What's in the audit

- Phase status table — every phase with evidence (file path, commit hash, sub-packet)
- IR data model coverage tables (all 9 IrType / 12 IrInst / 3 IrTerminator variants)
- Exhaustive semantic-to-IR coverage matrix (19 SemanticExprKind, 20 SemanticType, 3 SemanticLValue, 21 SemanticStmt)
- Cranelift / JIT readiness section with a clean inventory of what's stubbed vs landed
- Test surface breakdown (163 tests, by area)
- Gap analysis ordered by dependency, sized S/M/L/XL
- Risk register (12 entries, all specific to this codebase)
- Critical path to executable hello world (5 steps)
- 5 concrete recommendations
- Raw data appendix (50-commit history, file tree, TODO scan)

## Headline finding

Phase 11 is closed. Phase 13 skeleton walks any valid IR safely without panicking. Phase 14 is the next critical-path step — every Cranelift instruction emitter is currently a structured `UnsupportedInstruction` stub. No end-to-end execution path exists yet from `.cx` source to a callable function pointer. Estimated 6–10 weeks of focused backend work to October–December 2026 release window if Phase 14 starts within two weeks.

## Test plan

- [x] Audit doc renders cleanly as markdown
- [x] Every section header from the spec is present
- [x] All tables have specified columns
- [x] No empty sections — every "Not present" item explicit
- [x] Frontmatter filled with real commit hash
- [x] Branch `audit/2026-05-05` off `main` at `fedf93f`
- [x] Build still clean (`cargo build --features jit`)
- [x] Tests still green (163/163)

Closes the May 5 audit task.