### PR TITLE
CX-26: Cranelift emit Alloca + Load + Store (Phase 14 sub-packet 2)

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -1,8 +1,6 @@
 //! JIT Runtime Host Boundary
 //!
 //! This module defines the execution boundary between the Cx JIT backend and the host process.
-//! It is a scaffold: the types and contract are defined here; Cranelift compilation is wired in
-//! Phase 14 (First Executable Cranelift Slice).
 //!
 //! # Process Ownership
 //!
@@ -44,9 +42,6 @@
 //! The differential harness captures JIT output by running the Cx compiler binary as a
 //! subprocess with `--backend=cranelift <source_file>`, exactly as it does for the interpreter
 //! baseline. This approach requires no in-process hooking and is consistent across both paths.
-//!
-//! In-process capture (e.g. redirecting stdout via `dup2` before calling into JIT code) is a
-//! post-scaffold enhancement. It is not required for the differential harness to work.
 //!
 //! # Runtime Failure Surfacing
 //!
@@ -105,7 +100,7 @@ impl std::fmt::Display for JitExitCode {
 ///
 /// ## Stdout and Stderr
 ///
-/// In the current scaffold `stdout` and `stderr` are always empty strings.
+/// In the current subprocess-capture model `stdout` and `stderr` are always empty strings.
 /// JIT-compiled code writes directly to the host process streams; the differential harness
 /// captures them by running the Cx binary as a subprocess. In-process capture is post-scaffold.
 #[derive(Debug, Clone)]
@@ -187,7 +182,7 @@ impl std::fmt::Display for JitExecutionError {
 /// ## Ownership and Lifecycle
 ///
 /// - Created once per JIT execution, before `execute` is called.
-/// - Will hold a Cranelift `JITModule` in Phase 14 (First Executable Cranelift Slice).
+/// - Holds a Cranelift `JITModule` for the duration of execution (when the `jit` feature is on).
 /// - Dropped after `execute` returns; Cranelift frees JIT memory on drop.
 /// - Does **not** call `std::process::exit`; callers decide what to do with [`JitOutcome`].
 ///
@@ -202,6 +197,16 @@ impl std::fmt::Display for JitExecutionError {
 /// JIT-compiled code writes to the host process stdout/stderr via C runtime intrinsics.
 /// The differential harness captures this output by running the compiler as a subprocess.
 /// In-process pipe redirection is a post-scaffold enhancement.
+///
+/// ## Phase 14 Sub-Packet 1 Scope
+///
+/// The JIT implementation (enabled with the `jit` feature) supports:
+/// - `ConstInt` (types: I8, I16, I32, I64 — not I128)
+/// - `Binary` (Add, Sub, Mul, Div, Rem — signed integer operations)
+/// - `Return` (with or without a value)
+///
+/// All other IR instructions and terminators return [`JitExecutionError::UnsupportedConstruct`].
+/// Multi-block functions with `Jump`/`Branch` terminators are not yet supported.
 pub struct HostBoundary;
 
 impl HostBoundary {
@@ -215,10 +220,96 @@ impl HostBoundary {
     /// Returns [`JitOutcome`] when `main` returns (including non-zero exit codes).
     /// Returns [`JitExecutionError`] only for JIT-level failures: codegen errors,
     /// missing symbols, or runtime panics inside JIT-compiled code.
-    ///
-    /// In the current scaffold this always returns
-    /// `Err(JitExecutionError::UnsupportedConstruct)` indicating Phase 14 is pending.
-    /// Phase 14 will replace this stub with real Cranelift JIT compilation.
+    #[cfg(feature = "jit")]
+    pub fn execute(&self, ir: &crate::ir::IrModule) -> Result<JitOutcome, JitExecutionError> {
+        use cranelift_codegen::settings::{self, Configurable};
+        use cranelift_jit::{JITBuilder, JITModule};
+        use cranelift_module::{Linkage, Module};
+
+        // Build the native ISA.
+        let mut flag_builder = settings::builder();
+        flag_builder
+            .set("use_colocated_libcalls", "false")
+            .map_err(|e| JitExecutionError::CodegenFailure {
+                detail: e.to_string(),
+            })?;
+        flag_builder
+            .set("is_pic", "false")
+            .map_err(|e| JitExecutionError::CodegenFailure {
+                detail: e.to_string(),
+            })?;
+        let flags = settings::Flags::new(flag_builder);
+        let isa = cranelift_native::builder()
+            .map_err(|s| JitExecutionError::CodegenFailure {
+                detail: s.to_string(),
+            })?
+            .finish(flags)
+            .map_err(|e| JitExecutionError::CodegenFailure {
+                detail: e.to_string(),
+            })?;
+
+        let jit_builder =
+            JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+        let mut module = JITModule::new(jit_builder);
+
+        let mut main_id = None;
+
+        for (func_idx, ir_func) in ir.functions.iter().enumerate() {
+            let sig = build_cl_signature(&module, ir_func)?;
+            let func_id = module
+                .declare_function(&ir_func.name, Linkage::Export, &sig)
+                .map_err(|e| JitExecutionError::CodegenFailure {
+                    detail: e.to_string(),
+                })?;
+
+            // Build the Cranelift IR for this function.
+            let mut cl_func = cranelift_codegen::ir::Function::with_name_signature(
+                cranelift_codegen::ir::UserFuncName::user(0, func_idx as u32),
+                sig,
+            );
+            {
+                let mut fbc = cranelift_frontend::FunctionBuilderContext::new();
+                let mut builder =
+                    cranelift_frontend::FunctionBuilder::new(&mut cl_func, &mut fbc);
+                compile_ir_function(&mut builder, ir_func)?;
+                builder.finalize();
+            }
+
+            // Define the function in the JIT module.
+            let mut ctx = module.make_context();
+            ctx.func = cl_func;
+            module
+                .define_function(func_id, &mut ctx)
+                .map_err(|e| JitExecutionError::CodegenFailure {
+                    detail: e.to_string(),
+                })?;
+            module.clear_context(&mut ctx);
+
+            if ir_func.name == "main" {
+                main_id = Some(func_id);
+            }
+        }
+
+        module
+            .finalize_definitions()
+            .map_err(|e| JitExecutionError::CodegenFailure {
+                detail: e.to_string(),
+            })?;
+
+        let main_id = main_id.ok_or(JitExecutionError::MainNotFound)?;
+        let main_ptr = module.get_finalized_function(main_id);
+
+        // SAFETY: `module` is still alive here, keeping the JIT code mapped.
+        // The function signature () -> i32 matches the IR declaration of `main`.
+        let main_fn: unsafe extern "C" fn() -> i32 =
+            unsafe { std::mem::transmute(main_ptr) };
+        let ret = unsafe { main_fn() };
+
+        Ok(JitOutcome::from_main_return(ret))
+    }
+
+    /// Stub used when the `jit` feature is not enabled.
+    #[cfg(not(feature = "jit"))]
     pub fn execute(&self, _ir: &crate::ir::IrModule) -> Result<JitOutcome, JitExecutionError> {
         Err(JitExecutionError::UnsupportedConstruct {
             construct: "JIT codegen not yet implemented — Phase 14 (First Executable Cranelift Slice) pending".to_string(),
@@ -232,10 +323,167 @@ impl Default for HostBoundary {
     }
 }
 
+// ── JIT helpers (only compiled when the `jit` feature is active) ─────────────
+
+/// Build a Cranelift [`Signature`] from an [`IrFunction`]'s parameter and return-type list.
+#[cfg(feature = "jit")]
+fn build_cl_signature<M: cranelift_module::Module>(
+    module: &M,
+    ir_func: &crate::ir::types::IrFunction,
+) -> Result<cranelift_codegen::ir::Signature, JitExecutionError> {
+    use cranelift_codegen::ir::AbiParam;
+    use super::ir_type_to_cranelift;
+
+    let call_conv = module.target_config().default_call_conv;
+    let mut sig = cranelift_codegen::ir::Signature::new(call_conv);
+
+    for param in &ir_func.params {
+        let cl_ty = ir_type_to_cranelift(&param.ty).map_err(|e| {
+            JitExecutionError::UnsupportedConstruct {
+                construct: e.to_string(),
+            }
+        })?;
+        sig.params.push(AbiParam::new(cl_ty));
+    }
+
+    if let Some(ret_ty) = &ir_func.return_ty {
+        let cl_ty = ir_type_to_cranelift(ret_ty).map_err(|e| {
+            JitExecutionError::UnsupportedConstruct {
+                construct: e.to_string(),
+            }
+        })?;
+        sig.returns.push(AbiParam::new(cl_ty));
+    }
+
+    Ok(sig)
+}
+
+/// Emit Cranelift IR instructions for a single [`IrFunction`] into `builder`.
+///
+/// Supported instructions (Phase 14 sub-packet 1):
+/// - [`IrInst::ConstInt`] — integer constants for I8/I16/I32/I64 (not I128)
+/// - [`IrInst::Binary`] — signed integer arithmetic: Add, Sub, Mul, Div, Rem
+/// - [`IrTerminator::Return`] — return with or without a value
+///
+/// All other instructions and terminators yield [`JitExecutionError::UnsupportedConstruct`].
+#[cfg(feature = "jit")]
+fn compile_ir_function(
+    builder: &mut cranelift_frontend::FunctionBuilder,
+    ir_func: &crate::ir::types::IrFunction,
+) -> Result<(), JitExecutionError> {
+    use cranelift_codegen::ir::InstBuilder;
+    use crate::ir::instr::{BinaryOp, IrInst, IrTerminator};
+    use crate::ir::types::{BlockId, IrType, ValueId};
+    use super::ir_type_to_cranelift;
+    use std::collections::HashMap;
+
+    // Phase 1: create all Cranelift blocks and set up their block parameters.
+    // We do this before switching into any block so that append_block_param is
+    // always called on a block that has not yet had instructions emitted.
+    let mut block_map: HashMap<BlockId, cranelift_codegen::ir::Block> = HashMap::new();
+    let mut val_map: HashMap<ValueId, cranelift_codegen::ir::Value> = HashMap::new();
+
+    for ir_block in &ir_func.blocks {
+        let cl_block = builder.create_block();
+        block_map.insert(ir_block.id, cl_block);
+
+        for bp in &ir_block.params {
+            let cl_ty = ir_type_to_cranelift(&bp.ty).map_err(|e| {
+                JitExecutionError::UnsupportedConstruct {
+                    construct: e.to_string(),
+                }
+            })?;
+            let val = builder.append_block_param(cl_block, cl_ty);
+            val_map.insert(bp.value, val);
+        }
+    }
+
+    // Phase 2: emit each block's body.
+    for ir_block in &ir_func.blocks {
+        let cl_block = block_map[&ir_block.id];
+        builder.switch_to_block(cl_block);
+        // Safe to seal immediately: only Return terminators are supported in this
+        // sub-packet, so no block has a back-edge predecessor.
+        builder.seal_block(cl_block);
+
+        for inst in &ir_block.insts {
+            match inst {
+                IrInst::ConstInt { dst, ty, value } => {
+                    // I128 cannot be represented as a single iconst (Cranelift
+                    // emulates it as two i64s). Deferred to a future sub-packet.
+                    if *ty == IrType::I128 {
+                        return Err(JitExecutionError::UnsupportedConstruct {
+                            construct: "ConstInt I128 (not supported in Phase 14 sub-packet 1)"
+                                .to_string(),
+                        });
+                    }
+                    let cl_ty = ir_type_to_cranelift(ty).map_err(|e| {
+                        JitExecutionError::UnsupportedConstruct {
+                            construct: e.to_string(),
+                        }
+                    })?;
+                    // The value fits in i64 for all supported integer types (I8/I16/I32/I64).
+                    let cl_val = builder.ins().iconst(cl_ty, *value as i64);
+                    val_map.insert(*dst, cl_val);
+                }
+
+                IrInst::Binary { dst, op, ty: _, lhs, rhs } => {
+                    let lhs_val = *val_map.get(lhs).ok_or_else(|| {
+                        JitExecutionError::CodegenFailure {
+                            detail: format!("undefined value {:?} used as binary lhs", lhs),
+                        }
+                    })?;
+                    let rhs_val = *val_map.get(rhs).ok_or_else(|| {
+                        JitExecutionError::CodegenFailure {
+                            detail: format!("undefined value {:?} used as binary rhs", rhs),
+                        }
+                    })?;
+                    let result = match op {
+                        BinaryOp::Add => builder.ins().iadd(lhs_val, rhs_val),
+                        BinaryOp::Sub => builder.ins().isub(lhs_val, rhs_val),
+                        BinaryOp::Mul => builder.ins().imul(lhs_val, rhs_val),
+                        BinaryOp::Div => builder.ins().sdiv(lhs_val, rhs_val),
+                        BinaryOp::Rem => builder.ins().srem(lhs_val, rhs_val),
+                    };
+                    val_map.insert(*dst, result);
+                }
+
+                other => {
+                    return Err(JitExecutionError::UnsupportedConstruct {
+                        construct: format!("{:?}", other),
+                    });
+                }
+            }
+        }
+
+        match &ir_block.term {
+            IrTerminator::Return { value: Some(vid) } => {
+                let ret_val = *val_map.get(vid).ok_or_else(|| {
+                    JitExecutionError::CodegenFailure {
+                        detail: format!("undefined return value {:?}", vid),
+                    }
+                })?;
+                builder.ins().return_(&[ret_val]);
+            }
+            IrTerminator::Return { value: None } => {
+                builder.ins().return_(&[]);
+            }
+            other => {
+                return Err(JitExecutionError::UnsupportedConstruct {
+                    construct: format!("{:?}", other),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::types::IrModule;
 
     #[test]
     fn jit_exit_code_success_is_zero() {
@@ -313,8 +561,12 @@ mod tests {
         assert!(s.contains("stack overflow"), "got: {}", s);
     }
 
+    // The stub test only makes sense without the JIT feature, where execute()
+    // still returns the Phase 14-pending placeholder error.
+    #[cfg(not(feature = "jit"))]
     #[test]
     fn host_boundary_stub_returns_structured_error() {
+        use crate::ir::types::IrModule;
         let boundary = HostBoundary::new();
         let ir = IrModule {
             debug_name: "test_module".to_string(),
@@ -332,5 +584,268 @@ mod tests {
             }
             other => panic!("expected UnsupportedConstruct, got {:?}", other),
         }
+    }
+}
+
+// ── JIT integration tests (require the `jit` feature) ────────────────────────
+
+#[cfg(all(test, feature = "jit"))]
+mod jit_tests {
+    use super::*;
+    use crate::ir::instr::{BinaryOp, IrInst, IrTerminator};
+    use crate::ir::types::{BlockId, IrBlock, IrFunction, IrModule, IrType, ValueId};
+
+    /// Build a minimal `main() -> i32` module that returns a single constant.
+    fn const_return_module(value: i128) -> IrModule {
+        IrModule {
+            debug_name: "test_const".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![IrInst::ConstInt {
+                        dst: ValueId(0),
+                        ty: IrType::I32,
+                        value,
+                    }],
+                    term: IrTerminator::Return {
+                        value: Some(ValueId(0)),
+                    },
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn jit_const_return_zero() {
+        let module = const_return_module(0);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 0);
+    }
+
+    #[test]
+    fn jit_const_return_42() {
+        let module = const_return_module(42);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42);
+    }
+
+    #[test]
+    fn jit_const_return_1() {
+        let module = const_return_module(1);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 1);
+    }
+
+    #[test]
+    fn jit_arithmetic_add() {
+        // main(): i32 { v0 = 10; v1 = 32; v2 = v0 + v1; return v2 }  → 42
+        let module = IrModule {
+            debug_name: "test_add".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 10 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 32 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Add,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42); // 10 + 32
+    }
+
+    #[test]
+    fn jit_arithmetic_sub() {
+        // main(): i32 { v0 = 50; v1 = 8; v2 = v0 - v1; return v2 }  → 42
+        let module = IrModule {
+            debug_name: "test_sub".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 50 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 8 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Sub,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42); // 50 - 8
+    }
+
+    #[test]
+    fn jit_arithmetic_mul() {
+        // main(): i32 { v0 = 6; v1 = 7; v2 = v0 * v1; return v2 }  → 42
+        let module = IrModule {
+            debug_name: "test_mul".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 6 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 7 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Mul,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42); // 6 * 7
+    }
+
+    #[test]
+    fn jit_arithmetic_div() {
+        // main(): i32 { v0 = 84; v1 = 2; v2 = v0 / v1; return v2 }  → 42
+        let module = IrModule {
+            debug_name: "test_div".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 84 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 2 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Div,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42); // 84 / 2
+    }
+
+    #[test]
+    fn jit_arithmetic_rem() {
+        // main(): i32 { v0 = 142; v1 = 100; v2 = v0 % v1; return v2 }  → 42
+        let module = IrModule {
+            debug_name: "test_rem".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 142 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 100 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Rem,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42); // 142 % 100
+    }
+
+    #[test]
+    fn jit_no_main_returns_main_not_found() {
+        let module = IrModule {
+            debug_name: "no_main".to_string(),
+            functions: vec![],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(
+            matches!(result, Err(JitExecutionError::MainNotFound)),
+            "expected MainNotFound, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn jit_unsupported_inst_returns_error() {
+        // SsaBind is not supported in sub-packet 1.
+        let module = IrModule {
+            debug_name: "test_unsupported".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 0 },
+                        IrInst::SsaBind {
+                            dst: ValueId(1),
+                            ty: IrType::I32,
+                            src: ValueId(0),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(1)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(
+            matches!(result, Err(JitExecutionError::UnsupportedConstruct { .. })),
+            "expected UnsupportedConstruct, got {:?}",
+            result
+        );
     }
 }

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -198,11 +198,14 @@ impl std::fmt::Display for JitExecutionError {
 /// The differential harness captures this output by running the compiler as a subprocess.
 /// In-process pipe redirection is a post-scaffold enhancement.
 ///
-/// ## Phase 14 Sub-Packet 1 Scope
+/// ## Supported Instructions (Phase 14 sub-packets 1 and 2)
 ///
 /// The JIT implementation (enabled with the `jit` feature) supports:
 /// - `ConstInt` (types: I8, I16, I32, I64 — not I128)
 /// - `Binary` (Add, Sub, Mul, Div, Rem — signed integer operations)
+/// - `Alloca` — stack slot allocation; `dst` receives an I64 pointer to the slot
+/// - `Load` — typed memory load from an Alloca-produced pointer
+/// - `Store` — typed memory store through an Alloca-produced pointer
 /// - `Return` (with or without a value)
 ///
 /// All other IR instructions and terminators return [`JitExecutionError::UnsupportedConstruct`].
@@ -360,9 +363,12 @@ fn build_cl_signature<M: cranelift_module::Module>(
 
 /// Emit Cranelift IR instructions for a single [`IrFunction`] into `builder`.
 ///
-/// Supported instructions (Phase 14 sub-packet 1):
+/// Supported instructions (Phase 14 sub-packets 1 and 2):
 /// - [`IrInst::ConstInt`] — integer constants for I8/I16/I32/I64 (not I128)
 /// - [`IrInst::Binary`] — signed integer arithmetic: Add, Sub, Mul, Div, Rem
+/// - [`IrInst::Alloca`] — stack slot allocation; `dst` receives an I64 pointer
+/// - [`IrInst::Load`] — typed memory load from a pointer
+/// - [`IrInst::Store`] — typed memory store through a pointer
 /// - [`IrTerminator::Return`] — return with or without a value
 ///
 /// All other instructions and terminators yield [`JitExecutionError::UnsupportedConstruct`].
@@ -446,6 +452,56 @@ fn compile_ir_function(
                         BinaryOp::Rem => builder.ins().srem(lhs_val, rhs_val),
                     };
                     val_map.insert(*dst, result);
+                }
+
+                IrInst::Alloca { dst, size, align } => {
+                    use cranelift_codegen::ir::stackslot::{StackSlotData, StackSlotKind};
+                    use cranelift_codegen::ir::types;
+
+                    // align must be a power of two (IR invariant); align_shift = log2(align).
+                    // align == 0 is treated as naturally aligned (shift = 0).
+                    let align_shift = if *align == 0 { 0u8 } else { align.trailing_zeros() as u8 };
+                    let slot = builder.create_sized_stack_slot(StackSlotData::new(
+                        StackSlotKind::ExplicitSlot,
+                        *size as u32,
+                        align_shift,
+                    ));
+                    // Materialize the slot address as a native pointer (I64 on all supported targets).
+                    let ptr_val = builder.ins().stack_addr(types::I64, slot, 0);
+                    val_map.insert(*dst, ptr_val);
+                }
+
+                IrInst::Load { dst, ty, ptr } => {
+                    use cranelift_codegen::ir::MemFlags;
+
+                    let ptr_val = *val_map.get(ptr).ok_or_else(|| {
+                        JitExecutionError::CodegenFailure {
+                            detail: format!("undefined value {:?} used as load ptr", ptr),
+                        }
+                    })?;
+                    let cl_ty = ir_type_to_cranelift(ty).map_err(|e| {
+                        JitExecutionError::UnsupportedConstruct {
+                            construct: e.to_string(),
+                        }
+                    })?;
+                    let result = builder.ins().load(cl_ty, MemFlags::new(), ptr_val, 0);
+                    val_map.insert(*dst, result);
+                }
+
+                IrInst::Store { ptr, value } => {
+                    use cranelift_codegen::ir::MemFlags;
+
+                    let ptr_val = *val_map.get(ptr).ok_or_else(|| {
+                        JitExecutionError::CodegenFailure {
+                            detail: format!("undefined value {:?} used as store ptr", ptr),
+                        }
+                    })?;
+                    let stored_val = *val_map.get(value).ok_or_else(|| {
+                        JitExecutionError::CodegenFailure {
+                            detail: format!("undefined value {:?} used as store value", value),
+                        }
+                    })?;
+                    builder.ins().store(MemFlags::new(), stored_val, ptr_val, 0);
                 }
 
                 other => {
@@ -847,5 +903,163 @@ mod jit_tests {
             "expected UnsupportedConstruct, got {:?}",
             result
         );
+    }
+
+    // ── Sub-packet 2: Alloca + Load + Store ──────────────────────────────────
+
+    #[test]
+    fn jit_alloca_store_load_i32() {
+        // main(): i32 {
+        //   slot = alloca(4, 4)   // 4-byte I32 slot, 4-byte aligned
+        //   store(slot, 42i32)
+        //   v = load(i32, slot)
+        //   return v              // → 42
+        // }
+        let module = IrModule {
+            debug_name: "test_alloca_store_load_i32".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::Alloca { dst: ValueId(0), size: 4, align: 4 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 42 },
+                        IrInst::Store { ptr: ValueId(0), value: ValueId(1) },
+                        IrInst::Load { dst: ValueId(2), ty: IrType::I32, ptr: ValueId(0) },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42);
+    }
+
+    #[test]
+    fn jit_alloca_store_load_i8() {
+        // Verify that an i8 slot round-trips correctly.
+        // main(): i32 {
+        //   slot = alloca(1, 1)
+        //   store(slot, 99i8)
+        //   v8  = load(i8, slot)
+        //   v32 = sext v8 to i32      (done via ConstInt + Binary to avoid Cast)
+        //   return v32                → 99
+        // }
+        // Simplification: store an i32 into a 4-byte slot and load it back as i32,
+        // but use size=1/align=1 to exercise minimum-alignment alloca path.
+        // We work around the lack of Cast by widening to i32 via arithmetic:
+        // load i8, then add 0 (i32) would need Cast. Instead keep the result as i8
+        // and cast via return_ty. Cranelift accepts returning an i8 from a function
+        // declared with an i8 return type and the host receives it sign-extended.
+        // Use i32 slot but align=1 to test the align_shift=0 path.
+        let module = IrModule {
+            debug_name: "test_alloca_i8_align".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        // align=1 exercises the align_shift=0 code path.
+                        IrInst::Alloca { dst: ValueId(0), size: 4, align: 1 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 7 },
+                        IrInst::Store { ptr: ValueId(0), value: ValueId(1) },
+                        IrInst::Load { dst: ValueId(2), ty: IrType::I32, ptr: ValueId(0) },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 7);
+    }
+
+    #[test]
+    fn jit_alloca_overwrite_returns_last_value() {
+        // Write 10, overwrite with 42, load — must see 42 not 10.
+        // main(): i32 {
+        //   slot = alloca(4, 4)
+        //   store(slot, 10i32)
+        //   store(slot, 42i32)
+        //   v = load(i32, slot)
+        //   return v              // → 42
+        // }
+        let module = IrModule {
+            debug_name: "test_alloca_overwrite".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::Alloca { dst: ValueId(0), size: 4, align: 4 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 10 },
+                        IrInst::Store { ptr: ValueId(0), value: ValueId(1) },
+                        IrInst::ConstInt { dst: ValueId(2), ty: IrType::I32, value: 42 },
+                        IrInst::Store { ptr: ValueId(0), value: ValueId(2) },
+                        IrInst::Load { dst: ValueId(3), ty: IrType::I32, ptr: ValueId(0) },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42);
+    }
+
+    #[test]
+    fn jit_alloca_two_independent_slots() {
+        // Two slots hold independent values; verify both survive.
+        // main(): i32 {
+        //   s0 = alloca(4, 4); store(s0, 10)
+        //   s1 = alloca(4, 4); store(s1, 32)
+        //   a  = load(i32, s0)
+        //   b  = load(i32, s1)
+        //   r  = a + b          // → 42
+        //   return r
+        // }
+        let module = IrModule {
+            debug_name: "test_alloca_two_slots".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::Alloca { dst: ValueId(0), size: 4, align: 4 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 10 },
+                        IrInst::Store { ptr: ValueId(0), value: ValueId(1) },
+                        IrInst::Alloca { dst: ValueId(2), size: 4, align: 4 },
+                        IrInst::ConstInt { dst: ValueId(3), ty: IrType::I32, value: 32 },
+                        IrInst::Store { ptr: ValueId(2), value: ValueId(3) },
+                        IrInst::Load { dst: ValueId(4), ty: IrType::I32, ptr: ValueId(0) },
+                        IrInst::Load { dst: ValueId(5), ty: IrType::I32, ptr: ValueId(2) },
+                        IrInst::Binary {
+                            dst: ValueId(6),
+                            op: BinaryOp::Add,
+                            ty: IrType::I32,
+                            lhs: ValueId(4),
+                            rhs: ValueId(5),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(6)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42); // 10 + 32
     }
 }


### PR DESCRIPTION
Closes CX-26

## Summary

Extends the Cranelift JIT backend with stack-memory instructions, building on the Phase 14 sub-packet 1 foundation (ConstInt, Binary, Return).

Three new instruction handlers in `compile_ir_function` (`host_boundary.rs`):

- **`IrInst::Alloca { dst, size, align }`** → `create_sized_stack_slot(ExplicitSlot, size, align_shift)` + `stack_addr(I64, slot, 0)` — `dst` receives an I64 pointer to the stack slot; `align_shift = align.trailing_zeros()` (align=0 maps to shift=0)
- **`IrInst::Load { dst, ty, ptr }`** → `load(cl_ty, MemFlags::new(), ptr_val, 0)` — typed load through an Alloca-produced pointer
- **`IrInst::Store { ptr, value }`** → `store(MemFlags::new(), stored_val, ptr_val, 0)` — typed store through a pointer; type inferred from the stored value's Cranelift type

Doc comments on `HostBoundary` and `compile_ir_function` updated to reflect the expanded sub-packet 2 scope.

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — three new instruction arms in `compile_ir_function`, updated doc comments, four new JIT integration tests

## Tests Run

```
cargo build --features jit
cargo test --features jit
```

## Validation Result

```
test result: ok. 173 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Four new tests added in `jit_tests` module (`#[cfg(all(test, feature = "jit"))]`):
- `jit_alloca_store_load_i32` — basic i32 roundtrip via stack slot → 42
- `jit_alloca_store_load_i8` — exercises align=1 path (align_shift=0 edge case) → 7
- `jit_alloca_overwrite_returns_last_value` — store 10, overwrite with 42, load → 42
- `jit_alloca_two_independent_slots` — two slots at 10 and 32, add → 42

## Branch Note

This branch is based on `stokowski/cx-25` (Phase 14 sub-packet 1) which is not yet merged to submain. The diff relative to submain includes both sub-packet 1 and sub-packet 2 changes. Once CX-25 merges, CX-26's diff will reduce to only the Alloca/Load/Store additions.

## Known Limitations

- Single-block functions only; `Jump`/`Branch` terminators still yield `UnsupportedConstruct`
- `IrInst::PtrOffset` and `IrInst::PtrAdd` not yet handled (struct field addressing and array indexing — future sub-packets)
- `IrInst::Cast` not yet handled — no sext/zext/trunc emission

## Linear Ticket

https://linear.app/cx-lang/issue/CX-26/cranelift-emit-alloca-load-store-phase-14-sub-packet-2