### PR TITLE
CX-35: Audit lowering for ad-hoc runtime hooks and document the runtime intrinsics boundary (Phase 9 sub-packet 1)

### DIFF
--- a/docs/backend/cx_backend_roadmap_v3_1.md
+++ b/docs/backend/cx_backend_roadmap_v3_1.md
@@ -253,18 +253,36 @@ Done when:
 
 Goal: define exactly what the backend lowers as pure IR versus what becomes a runtime call. Without this the backend has ad hoc hooks scattered through the lowering code instead of a clean, testable boundary.
 
-- Define backend-visible runtime entry points
-- Categorize every builtin — pure IR, runtime call, or intrinsic
-- print — classified and lowered correctly once it is promoted to a function
-  - **Cross-roadmap dependency:** print has not been promoted to a function yet in the frontend. Phase 9 cannot close until the frontend ships print as a real function with a proper call signature. If the frontend changes print behavior (e.g., newline parameter, name change), Phase 9's intrinsic definition changes too.
-- Allocation operations — arena, handle registry interactions
-- Handle registry operations — insert, get, remove, stale detection
-- String boundary operations — str copy-on-boundary, strref validity
-- Error and panic paths — how they surface through the backend
-- Define calling signatures for all runtime entry points
-- Document ownership and lifetime expectations at each boundary
-- Lower all builtins through structured intrinsics, not ad hoc hooks
-- Tests confirm each intrinsic lowers and executes correctly
+**Sub-packet 1 — Audit + structured errors** *(DONE — 2026-05-06)*
+
+- Audited all ad-hoc builtin hooks: `print`, `println`, `printn`, `read`, `input`, `assert`, `assert_eq`
+- All were previously reaching the lowering layer and failing with the generic `UnresolvedSemanticArtifact` error (a signature_table miss), which was misleading
+- Added `is_cx_builtin()` guard in `src/ir/lower.rs` — builtins now produce `UnsupportedSemanticConstruct` with an explicit "codegen pending (Phase 9)" message
+- Classified every builtin: I/O stdout, I/O stdin, debug assertion
+- Created `docs/backend/cx_runtime_intrinsics_v0.1.md` — full boundary specification including classification table, planned implementation path, draft runtime entry point registry, and non-goals
+- 7 tests added — one per builtin — verifying correct error family and that the builtin name appears in the message
+
+**Sub-packet 2 — print family lowering** *(BLOCKED — pending frontend)*
+
+- `print`, `println`, `printn` cannot be lowered until the frontend promotes them to real functions with a fixed call signature
+- Cross-roadmap dependency: frontend must ship these as real functions before Phase 9 sub-packet 2 can proceed
+- If the frontend changes print behavior (e.g., newline parameter, name change), the intrinsic definition changes too
+
+**Sub-packet 3 — assert / assert_eq lowering** *(DESIGN NEEDED)*
+
+- Abort-vs-panic semantics decision needed before implementation
+- For 0.1 the expected answer is abort — confirmed before sub-packet 3 starts
+
+**Sub-packet 4 — read / input lowering** *(BLOCKED — pending str layout)*
+
+- Blocked on str/strref layout decision from Phase 8
+
+**Remaining Phase 9 items (not yet sub-packet assigned):**
+
+- Allocation operations — arena, handle registry interactions (post-0.1)
+- Handle registry operations — insert, get, remove, stale detection (post-0.1)
+- String boundary operations — str copy-on-boundary, strref validity (blocked on Phase 8)
+- Error and panic paths — how they surface through the backend (post-0.1)
 
 Done when:
 - Every builtin has a documented classification
@@ -607,7 +625,7 @@ Nothing in the post-0.1 compiler targets should start until Phase 15 closes.
 - ABI and data layout Round 2 (Phase 8) — str/strref layout, Handle<T>, TBool calling convention, unknown propagation still open
 
 **Next — 0.1 Path**
-- Runtime intrinsics boundary (Phase 9)
+- Runtime intrinsics boundary (Phase 9) — sub-packet 1 done; sub-packets 2–4 blocked on frontend/design
 - Differential backend harness (Phase 12)
 - Cranelift lowering skeleton (Phase 13)
 - JIT runtime host boundary
@@ -627,6 +645,14 @@ Nothing in the post-0.1 compiler targets should start until Phase 15 closes.
 **Separate Roadmap**
 - GPU layer — Cx Platform and GPU Roadmap
 - Window and screen system — Cx Platform and GPU Roadmap
+
+---
+
+## Key Changes — v4.1 (2026-05-06)
+
+- Phase 9 sub-packet 1 done — audit complete, `is_cx_builtin()` guard added in `lower.rs`, 7 tests, `docs/backend/cx_runtime_intrinsics_v0.1.md` created
+- Phase 9 sub-packets 2–4 defined with explicit blocking conditions
+- Progress board updated to reflect Phase 9 partial progress
 
 ---
 

--- a/docs/backend/cx_runtime_intrinsics_v0.1.md
+++ b/docs/backend/cx_runtime_intrinsics_v0.1.md
@@ -1,0 +1,203 @@
+# Cx Runtime Intrinsics Boundary — v0.1
+Phase 9 specification  
+Status: sub-packet 1 complete (audit + structured errors), codegen pending
+
+---
+
+## Purpose
+
+This document defines the boundary between code that the Cx backend lowers as
+pure IR (arithmetic, control flow, memory ops) and code that must cross a
+runtime call boundary (I/O, assertions, allocation, error paths).
+
+Without this boundary the lowering code accumulates ad-hoc holes — callee
+names that silently miss the signature table, producing generic errors that
+reveal nothing about the missing piece or when it will be filled.
+
+Phase 9 replaces those holes with:
+
+1. An explicit classification of every builtin (this document).
+2. Structured `UnsupportedSemanticConstruct` errors that name the builtin and
+   reference Phase 9 as the tracking phase.
+3. Eventually, concrete `IrIntrinsic` opcodes or ABI-stable runtime-call
+   signatures for each builtin.
+
+---
+
+## Audit — Current Ad-hoc Hooks
+
+### How builtins are represented in the semantic layer
+
+`src/frontend/semantic.rs` recognises these names in `analyze_call()` (around
+line 1446) and assigns `FunctionId(u32::MAX)` to mark them as non-user-defined:
+
+```
+print    println    printn
+read     input
+assert   assert_eq
+```
+
+The semantic node produced is:
+
+```
+SemanticExprKind::Call {
+    callee: "<name>",
+    function: FunctionId(u32::MAX),   // sentinel — not a real function
+    args:   <analyzed args>,
+}
+```
+
+Return type is `SemanticType::Str` for `read`/`input`; `SemanticType::Void`
+for all others.
+
+### What happened during lowering before Phase 9 sub-packet 1
+
+These names are **absent from the `signature_table`** (which only holds
+user-defined functions built by `build_signature_table()`).  When a builtin
+reached lowering:
+
+- As an `ExprStmt`: the `sig_info` lookup returned `None`, the code fell
+  through to `lower_expr`, and the inner lookup failed.
+- In `lower_expr` as `SemanticExprKind::Call`: `ctx.signature_table.get(callee)`
+  returned `None`, producing:
+  ```
+  LoweringError::UnresolvedSemanticArtifact { artifact: "function '<name>'" }
+  ```
+
+This error is **misleading** — it implies a bug in the resolver, not a known
+pending feature.
+
+### Fix applied in Phase 9 sub-packet 1 (`src/ir/lower.rs`)
+
+`is_cx_builtin(name: &str) -> bool` guards both call paths.  Any builtin hit
+during lowering now returns:
+
+```
+LoweringError::UnsupportedSemanticConstruct {
+    construct: "builtin '<name>' is not yet lowerable to IR — codegen pending (Phase 9)"
+}
+```
+
+Seven tests verify this — one per builtin — ensuring the error family is
+correct and contains the builtin name.
+
+---
+
+## Builtin Classification Table
+
+| Builtin      | Category            | Return  | Planned backend mechanism        | Blocking condition |
+|--------------|---------------------|---------|----------------------------------|--------------------|
+| `print`      | I/O — stdout        | void    | runtime call to `cx_print`       | frontend must promote to function first |
+| `println`    | I/O — stdout        | void    | runtime call to `cx_println`     | same as `print` |
+| `printn`     | I/O — stdout        | void    | runtime call to `cx_printn`      | same as `print` |
+| `read`       | I/O — stdin         | str     | runtime call to `cx_read`        | str/strref layout must be locked (Phase 8 open item) |
+| `input`      | I/O — stdin         | str     | runtime call to `cx_input`       | same as `read` |
+| `assert`     | Debug / assertion   | void    | inline Branch + trap, or runtime | semantics TBD — does assert abort or panic? |
+| `assert_eq`  | Debug / assertion   | void    | inline cmp + Branch + trap       | same as `assert` |
+
+### I/O builtins — print family
+
+`print`, `println`, `printn` are stdout I/O.  They do not return a value.
+
+Cross-roadmap dependency: **the frontend has not promoted these to real
+functions yet**.  Until they have a proper call signature (parameter types,
+arity rules) Phase 9 cannot define their ABI.  Phase 9 tracks this as its
+primary blocker.
+
+Planned mechanism: a thin runtime shim (`cx_runtime.c` or equivalent)
+exported as a C-ABI symbol.  JIT-compiled code calls it via `IrInst::Call`
+with the shim's name as callee.  The shim writes to stdout using the platform
+C runtime (`puts` / `printf`).  No in-process pipe redirection.
+
+### I/O builtins — read / input
+
+`read` and `input` return a string.  They block until stdin delivers a line.
+
+Additional blocker: the `str` / `strref` layout question from Phase 8 is
+unresolved (arena ownership in JIT mode vs. interpreter mode).  The return
+type and ownership model for these calls cannot be finalised until that
+decision is made.
+
+### Debug builtins — assert / assert_eq
+
+`assert(cond)` and `assert_eq(lhs, rhs)` are diagnostic assertions.
+
+Design decision needed before these can be lowered:
+
+- Do they abort the process (like C `assert`)? If so, the backend emits a
+  conditional Branch to a trap block.
+- Do they raise a Cx panic that can be caught? If so, a runtime-call mechanism
+  is needed.
+
+For 0.1 the expected answer is "abort" (simple, no unwinding machinery).
+That decision must be confirmed before implementation.
+
+---
+
+## Planned Implementation Path (Phase 9 remaining sub-packets)
+
+**Sub-packet 2 — print family (blocked on frontend)**
+
+When the frontend promotes `print`, `println`, `printn` to real functions:
+
+1. Add shim symbols to `src/backend/cranelift/jit.rs` — declare them as
+   external C-ABI functions in the Cranelift module.
+2. Remove them from `is_cx_builtin()`.
+3. They then flow through the normal `IrInst::Call` path.
+4. Tests: a `.cx` program that calls `print` executes through the JIT and
+   produces matching stdout in the differential harness.
+
+**Sub-packet 3 — assert / assert_eq**
+
+After the abort-vs-panic decision is locked:
+
+1. If abort: lower to `IrInst::Branch` + `IrTerminator::Trap` (or equivalent).
+   Requires adding `IrTerminator::Trap` to the IR.
+2. Remove them from `is_cx_builtin()`.
+3. Tests: a program that hits a failing assert produces exit code 126 (JIT
+   runtime failure).
+
+**Sub-packet 4 — read / input (blocked on Phase 8 str layout)**
+
+Deferred until `str` and `strref` layout is locked in Phase 8.
+
+---
+
+## Runtime Entry Point Registry (draft)
+
+This section will list the stable C-ABI symbols that JIT-compiled Cx code
+may call.  It is a stub until sub-packets 2–4 land.
+
+| Symbol         | Signature (C)                     | Provided by       |
+|----------------|-----------------------------------|-------------------|
+| `cx_print`     | `void cx_print(const char* s)`    | cx_runtime shim   |
+| `cx_println`   | `void cx_println(const char* s)`  | cx_runtime shim   |
+| `cx_printn`    | `void cx_printn(int64_t n)`       | cx_runtime shim   |
+| `cx_read`      | TBD — blocked on str layout       | —                 |
+| `cx_input`     | TBD — blocked on str layout       | —                 |
+
+Ownership rules:
+- All string pointers passed to I/O shims are read-only; the shim does not
+  take ownership and does not free.
+- The caller (JIT code) is responsible for keeping the backing memory alive
+  for the duration of the call.
+
+---
+
+## Non-Goals for Phase 9
+
+- Handle<T> registry intrinsics — post-0.1
+- Arena allocation intrinsics — post-0.1
+- Error and panic propagation through the backend — post-0.1
+- TBool Unknown propagation — open design question tracked in Phase 8
+- String copy-on-boundary rules — blocked on str layout decision
+
+---
+
+## References
+
+- `src/frontend/semantic.rs` — builtin recognition in `analyze_call()` (~line 1446)
+- `src/ir/lower.rs` — `is_cx_builtin()` guard and structured error
+- `docs/backend/cx_abi_v0.1.md` — scalar layout and calling convention
+- `docs/backend/cx_backend_roadmap_v3_1.md` — Phase 9 and its blockers
+- `src/backend/cranelift/host_boundary.rs` — JIT host boundary documentation

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -66,6 +66,39 @@ impl fmt::Display for LoweringError {
 
 impl std::error::Error for LoweringError {}
 
+// ---------------------------------------------------------------------------
+// Runtime intrinsics boundary — Phase 9 audit
+// ---------------------------------------------------------------------------
+//
+// These names are Cx language builtins. They are recognized at the semantic
+// layer (semantic.rs `analyze_call`) and assigned `FunctionId(u32::MAX)` to
+// flag them as non-user-defined. They do NOT appear in the `signature_table`,
+// which only holds user-defined functions.
+//
+// Classification (see docs/backend/cx_runtime_intrinsics_v0.1.md for the
+// full boundary specification):
+//
+//   Category          | Builtins
+//   ──────────────────┼────────────────────────────────
+//   I/O (stdout)      | print, println, printn
+//   I/O (stdin)       | read, input
+//   Debug / assertion | assert, assert_eq
+//
+// None of these have codegen support yet. Lowering them through the normal
+// `signature_table` path would produce a misleading `UnresolvedSemanticArtifact`
+// error. Instead, `is_cx_builtin` gates the call paths so they produce a
+// structured `UnsupportedSemanticConstruct` with an explicit Phase 9 note.
+//
+// When Phase 9 sub-packet 2 lands, each builtin here will be replaced by a
+// concrete `IrIntrinsic` opcode or a runtime-call ABI signature — at which
+// point this function will shrink until it is empty.
+fn is_cx_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "print" | "println" | "printn" | "read" | "input" | "assert" | "assert_eq"
+    )
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct LoweredValue {
     value: ValueId,
@@ -556,6 +589,19 @@ fn lower_stmt(
             Ok(Some(current))
         }
         SemanticStmt::ExprStmt { expr, .. } => {
+            // Builtin intrinsics (print, assert, etc.) are not in the signature_table.
+            // Intercept them here so they produce a structured UnsupportedSemanticConstruct
+            // rather than falling through to a misleading UnresolvedSemanticArtifact.
+            if let SemanticExprKind::Call { callee, .. } = &expr.kind {
+                if is_cx_builtin(callee) {
+                    return Err(LoweringError::UnsupportedSemanticConstruct {
+                        construct: format!(
+                            "builtin '{}' is not yet lowerable to IR — codegen pending (Phase 9)",
+                            callee
+                        ),
+                    });
+                }
+            }
             // Void function calls cannot go through lower_expr because that function
             // must return a LoweredValue, and void calls produce no value.
             // Detect and lower void calls here before falling through to lower_expr.
@@ -1435,6 +1481,17 @@ fn lower_expr(
             })
         }
         SemanticExprKind::Call { callee, function: _, args } => {
+            // Builtin intrinsics (print, assert, etc.) are not in the signature_table.
+            // Intercept them before the lookup so the error is structured and actionable
+            // rather than the generic UnresolvedSemanticArtifact produced by a table miss.
+            if is_cx_builtin(callee) {
+                return Err(LoweringError::UnsupportedSemanticConstruct {
+                    construct: format!(
+                        "builtin '{}' is not yet lowerable to IR — codegen pending (Phase 9)",
+                        callee
+                    ),
+                });
+            }
             let (param_types, return_ty) = {
                 let sig = ctx.signature_table.get(callee).ok_or_else(|| {
                     LoweringError::UnresolvedSemanticArtifact {
@@ -5081,5 +5138,80 @@ mod tests {
             "expected named error mentioning instance and method, got: {:?}",
             err
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 9 — Runtime intrinsics boundary audit (CX-35)
+    //
+    // Each builtin must produce UnsupportedSemanticConstruct (not the
+    // generic UnresolvedSemanticArtifact that a signature_table miss gives).
+    // -----------------------------------------------------------------------
+
+    // Helper: build a top-level ExprStmt that calls a builtin with the given
+    // args. `FunctionId(u32::MAX)` is the semantic-layer sentinel for builtins.
+    fn builtin_stmt(name: &str, args: Vec<SemanticCallArg>) -> SemanticStmt {
+        SemanticStmt::ExprStmt {
+            expr: SemanticExpr {
+                ty: SemanticType::Void,
+                kind: SemanticExprKind::Call {
+                    callee: name.to_string(),
+                    function: FunctionId(u32::MAX),
+                    args,
+                },
+            },
+            pos: 0,
+        }
+    }
+
+    fn assert_builtin_structured_error(name: &str) {
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(name, vec![])],
+            enums: vec![],
+        };
+        let err = lower_program(&program).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                LoweringError::UnsupportedSemanticConstruct { construct }
+                if construct.contains(name)
+            ),
+            "builtin '{}' should produce UnsupportedSemanticConstruct mentioning its name, got: {:?}",
+            name, err
+        );
+    }
+
+    #[test]
+    fn builtin_print_produces_unsupported_construct_not_unresolved_artifact() {
+        assert_builtin_structured_error("print");
+    }
+
+    #[test]
+    fn builtin_println_produces_unsupported_construct_not_unresolved_artifact() {
+        assert_builtin_structured_error("println");
+    }
+
+    #[test]
+    fn builtin_printn_produces_unsupported_construct_not_unresolved_artifact() {
+        assert_builtin_structured_error("printn");
+    }
+
+    #[test]
+    fn builtin_assert_produces_unsupported_construct_not_unresolved_artifact() {
+        assert_builtin_structured_error("assert");
+    }
+
+    #[test]
+    fn builtin_assert_eq_produces_unsupported_construct_not_unresolved_artifact() {
+        assert_builtin_structured_error("assert_eq");
+    }
+
+    #[test]
+    fn builtin_read_produces_unsupported_construct_not_unresolved_artifact() {
+        assert_builtin_structured_error("read");
+    }
+
+    #[test]
+    fn builtin_input_produces_unsupported_construct_not_unresolved_artifact() {
+        assert_builtin_structured_error("input");
     }
 }


### PR DESCRIPTION
Closes CX-35

## Summary

- Audited every ad-hoc builtin hook in the lowering pipeline (`print`, `println`, `printn`, `read`, `input`, `assert`, `assert_eq`)
- Added `is_cx_builtin()` guard in `src/ir/lower.rs` — builtins now produce `UnsupportedSemanticConstruct` with an explicit "codegen pending (Phase 9)" message instead of the misleading `UnresolvedSemanticArtifact` that a `signature_table` miss previously emitted
- Created `docs/backend/cx_runtime_intrinsics_v0.1.md` — full boundary specification
- Updated roadmap with Phase 9 sub-packet breakdown and blocking conditions

## Files Changed

- `src/ir/lower.rs` — `is_cx_builtin()` function, guards in `ExprStmt` and `lower_expr` call paths, 7 new tests
- `docs/backend/cx_runtime_intrinsics_v0.1.md` — new: runtime intrinsics boundary specification
- `docs/backend/cx_backend_roadmap_v3_1.md` — Phase 9 sub-packet 1 marked done, sub-packets 2–4 defined

## What the audit found

All 7 builtins are set to `FunctionId(u32::MAX)` in `semantic.rs::analyze_call()` (line 1446). They never enter the `signature_table` (only user-defined functions do). Before this PR, any program calling a builtin would hit `UnresolvedSemanticArtifact { artifact: "function 'print'" }` — a misleading error implying a resolver bug.

## Classification (from the new doc)

| Builtin | Category | Blocking condition |
|---|---|---|
| `print`, `println`, `printn` | I/O stdout | Frontend must promote to real functions first |
| `read`, `input` | I/O stdin | Phase 8 str/strref layout must be locked first |
| `assert`, `assert_eq` | Debug/assertion | Abort-vs-panic semantics decision needed |

## Tests Run

```
cargo build --features jit   — success (0 errors, pre-existing warnings only)
cargo test --features jit    — 180 passed, 0 failed
```

7 new tests confirm each builtin produces `UnsupportedSemanticConstruct` containing the builtin name.

## Known Limitations

- No codegen support for any builtin yet — that is the work of Phase 9 sub-packets 2–4
- Sub-packet 2 (print family) is blocked on frontend promoting print to a real function
- Sub-packet 4 (read/input) is blocked on Phase 8 str layout decision

## Linear Ticket

https://linear.app/cx-lang/issue/CX-35/audit-lowering-for-ad-hoc-runtime-hooks-and-document-the-runtime