### PR TITLE
CX-38: Implement runtime intrinsics dispatch mechanism (Phase 9 sub-packet 2)

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -198,7 +198,7 @@ impl std::fmt::Display for JitExecutionError {
 /// The differential harness captures this output by running the compiler as a subprocess.
 /// In-process pipe redirection is a post-scaffold enhancement.
 ///
-/// ## Supported Instructions (Phase 14 sub-packets 1, 2, and 3)
+/// ## Supported Instructions (Phase 14 sub-packets 1, 2, and 3; Phase 9 sub-packet 2)
 ///
 /// The JIT implementation (enabled with the `jit` feature) supports:
 /// - `ConstInt` (types: I8, I16, I32, I64 — not I128)
@@ -207,6 +207,9 @@ impl std::fmt::Display for JitExecutionError {
 /// - `Load` — typed memory load from an Alloca-produced pointer
 /// - `Store` — typed memory store through an Alloca-produced pointer
 /// - `Compare` (Eq, Ne, Lt, Le, Gt, Ge — signed integer comparisons; result is I8)
+/// - `Call` — direct calls to user-defined functions in the IR module and to registered
+///   runtime intrinsics (Phase 9 sub-packet 2); argument types must match the declared
+///   callee signature or Cranelift will reject the module at definition time.
 /// - `Return` (with or without a value)
 ///
 /// - `Jump` (unconditional block transfer with optional block-param arguments)
@@ -216,6 +219,14 @@ impl std::fmt::Display for JitExecutionError {
 /// Loop back-edges are deferred to a later sub-packet.
 ///
 /// All other IR instructions return [`JitExecutionError::UnsupportedConstruct`].
+///
+/// ## Runtime Intrinsics
+///
+/// The following Cx runtime intrinsics are registered in every JIT module:
+///
+/// | Intrinsic   | C signature             | Cx builtin | Notes                     |
+/// |-------------|-------------------------|------------|---------------------------|
+/// | `cx_printn` | `void cx_printn(i64)`   | `printn`   | Prints integer to stdout. |
 pub struct HostBoundary;
 
 impl HostBoundary {
@@ -229,11 +240,24 @@ impl HostBoundary {
     /// Returns [`JitOutcome`] when `main` returns (including non-zero exit codes).
     /// Returns [`JitExecutionError`] only for JIT-level failures: codegen errors,
     /// missing symbols, or runtime panics inside JIT-compiled code.
+    ///
+    /// ## Two-pass compilation
+    ///
+    /// To support cross-function calls (including forward references), compilation
+    /// uses two passes:
+    ///
+    /// 1. **Pass 1 — declare**: all runtime intrinsics (as imports) and all module
+    ///    functions (as exports) are declared and their `FuncId`s collected into a
+    ///    shared `func_id_map`.
+    /// 2. **Pass 2 — compile**: each module function's body is compiled using
+    ///    `func_id_map` to resolve callees.  Both intrinsic calls and module-level
+    ///    function calls are supported in this pass.
     #[cfg(feature = "jit")]
     pub fn execute(&self, ir: &crate::ir::IrModule) -> Result<JitOutcome, JitExecutionError> {
         use cranelift_codegen::settings::{self, Configurable};
         use cranelift_jit::{JITBuilder, JITModule};
         use cranelift_module::{Linkage, Module};
+        use std::collections::HashMap;
 
         // Build the native ISA.
         let mut flag_builder = settings::builder();
@@ -257,21 +281,43 @@ impl HostBoundary {
                 detail: e.to_string(),
             })?;
 
-        let jit_builder =
+        // Register runtime intrinsic shim pointers so the JIT can resolve them.
+        let mut jit_builder =
             JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+        jit_builder.symbol("cx_printn", cx_printn as *const u8);
         let mut module = JITModule::new(jit_builder);
 
-        let mut main_id = None;
+        // ── Pass 1: declare all intrinsics (import) and module functions (export) ──
+        let mut func_id_map: HashMap<String, cranelift_module::FuncId> = HashMap::new();
 
-        for (func_idx, ir_func) in ir.functions.iter().enumerate() {
+        // Declare runtime intrinsics as imports.
+        let intrinsic_ids = declare_intrinsics(&mut module)?;
+        for (name, id) in intrinsic_ids {
+            func_id_map.insert(name, id);
+        }
+
+        // Declare all module functions as exports.
+        let mut module_func_ids: Vec<cranelift_module::FuncId> = Vec::new();
+        let mut main_id = None;
+        for ir_func in &ir.functions {
             let sig = build_cl_signature(&module, ir_func)?;
             let func_id = module
                 .declare_function(&ir_func.name, Linkage::Export, &sig)
                 .map_err(|e| JitExecutionError::CodegenFailure {
                     detail: e.to_string(),
                 })?;
+            func_id_map.insert(ir_func.name.clone(), func_id);
+            module_func_ids.push(func_id);
+            if ir_func.name == "main" {
+                main_id = Some(func_id);
+            }
+        }
 
-            // Build the Cranelift IR for this function.
+        // ── Pass 2: compile each function body ───────────────────────────────────
+        for (func_idx, ir_func) in ir.functions.iter().enumerate() {
+            let func_id = module_func_ids[func_idx];
+            let sig = build_cl_signature(&module, ir_func)?;
+
             let mut cl_func = cranelift_codegen::ir::Function::with_name_signature(
                 cranelift_codegen::ir::UserFuncName::user(0, func_idx as u32),
                 sig,
@@ -280,11 +326,10 @@ impl HostBoundary {
                 let mut fbc = cranelift_frontend::FunctionBuilderContext::new();
                 let mut builder =
                     cranelift_frontend::FunctionBuilder::new(&mut cl_func, &mut fbc);
-                compile_ir_function(&mut builder, ir_func)?;
+                compile_ir_function(&mut builder, ir_func, &mut module, &func_id_map)?;
                 builder.finalize();
             }
 
-            // Define the function in the JIT module.
             let mut ctx = module.make_context();
             ctx.func = cl_func;
             module
@@ -293,10 +338,6 @@ impl HostBoundary {
                     detail: e.to_string(),
                 })?;
             module.clear_context(&mut ctx);
-
-            if ir_func.name == "main" {
-                main_id = Some(func_id);
-            }
         }
 
         module
@@ -334,6 +375,64 @@ impl Default for HostBoundary {
 
 // ── JIT helpers (only compiled when the `jit` feature is active) ─────────────
 
+// ── Runtime intrinsic shims ──────────────────────────────────────────────────
+
+/// Print a signed 64-bit integer to the host process stdout, without a trailing
+/// newline.
+///
+/// This is the C-ABI shim for the Cx `printn` builtin.  JIT-compiled code calls
+/// it via `IrInst::Call { callee: "cx_printn", ... }` after the IR lowering maps
+/// the `printn` builtin to this stable intrinsic name.
+///
+/// # Safety
+///
+/// Called only from JIT-compiled code with a single `i64` argument.  Writing
+/// to stdout is a standard host-process operation and is safe in this context.
+#[cfg(feature = "jit")]
+extern "C" fn cx_printn(n: i64) {
+    print!("{}", n);
+}
+
+// ── Intrinsics declaration ───────────────────────────────────────────────────
+
+/// Declare all known Cx runtime intrinsics in `module` as imported functions.
+///
+/// Returns a map from intrinsic name to the Cranelift [`FuncId`] assigned by
+/// the module.  The caller must also register the corresponding shim pointers
+/// with the [`JITBuilder`] before creating the module (so the JIT linker can
+/// resolve the import at finalization time).
+///
+/// ## Registered intrinsics
+///
+/// | Name        | C signature           | Cx builtin | Notes               |
+/// |-------------|-----------------------|------------|---------------------|
+/// | `cx_printn` | `void cx_printn(i64)` | `printn`   | Prints integer.     |
+#[cfg(feature = "jit")]
+fn declare_intrinsics(
+    module: &mut cranelift_jit::JITModule,
+) -> Result<std::collections::HashMap<String, cranelift_module::FuncId>, JitExecutionError> {
+    use cranelift_codegen::ir::AbiParam;
+    use cranelift_codegen::ir::types;
+    use cranelift_module::{Linkage, Module};
+
+    let call_conv = module.target_config().default_call_conv;
+    let mut map = std::collections::HashMap::new();
+
+    // cx_printn: (i64) -> void
+    {
+        let mut sig = cranelift_codegen::ir::Signature::new(call_conv);
+        sig.params.push(AbiParam::new(types::I64));
+        let id = module
+            .declare_function("cx_printn", Linkage::Import, &sig)
+            .map_err(|e| JitExecutionError::CodegenFailure {
+                detail: e.to_string(),
+            })?;
+        map.insert("cx_printn".to_string(), id);
+    }
+
+    Ok(map)
+}
+
 /// Build a Cranelift [`Signature`] from an [`IrFunction`]'s parameter and return-type list.
 #[cfg(feature = "jit")]
 fn build_cl_signature<M: cranelift_module::Module>(
@@ -369,13 +468,15 @@ fn build_cl_signature<M: cranelift_module::Module>(
 
 /// Emit Cranelift IR instructions for a single [`IrFunction`] into `builder`.
 ///
-/// Supported instructions (Phase 14 sub-packets 1, 2, and 3):
+/// Supported instructions (Phase 14 sub-packets 1, 2, and 3; Phase 9 sub-packet 2):
 /// - [`IrInst::ConstInt`] — integer constants for I8/I16/I32/I64 (not I128)
 /// - [`IrInst::Binary`] — signed integer arithmetic: Add, Sub, Mul, Div, Rem
 /// - [`IrInst::Alloca`] — stack slot allocation; `dst` receives an I64 pointer
 /// - [`IrInst::Load`] — typed memory load from a pointer
 /// - [`IrInst::Store`] — typed memory store through a pointer
 /// - [`IrInst::Compare`] — signed integer comparisons (Eq/Ne/Lt/Le/Gt/Ge); result is I8
+/// - [`IrInst::Call`] — direct call to any function declared in `func_id_map`;
+///   this includes both user-defined module functions and runtime intrinsics
 /// - [`IrTerminator::Return`] — return with or without a value
 /// - [`IrTerminator::Jump`] — unconditional branch with optional block-param arguments
 /// - [`IrTerminator::Branch`] — two-way conditional branch (`brif`) with block-param arguments
@@ -385,10 +486,20 @@ fn build_cl_signature<M: cranelift_module::Module>(
 /// (from `jump` / `brif`) are registered before the successor block is visited.
 ///
 /// All other instructions yield [`JitExecutionError::UnsupportedConstruct`].
+///
+/// ## Parameters
+///
+/// - `module` — mutably borrowed to call [`Module::declare_func_in_func`] when
+///   emitting `Call` instructions (`declare_func_in_func` takes `&mut self`).
+///   The caller must ensure no other borrow of `module` is live during this call.
+/// - `func_id_map` — maps every callee name (both intrinsics and module functions)
+///   to its Cranelift [`FuncId`].  Built in Pass 1 of `execute`.
 #[cfg(feature = "jit")]
 fn compile_ir_function(
     builder: &mut cranelift_frontend::FunctionBuilder,
     ir_func: &crate::ir::types::IrFunction,
+    module: &mut cranelift_jit::JITModule,
+    func_id_map: &std::collections::HashMap<String, cranelift_module::FuncId>,
 ) -> Result<(), JitExecutionError> {
     use cranelift_codegen::ir::condcodes::IntCC;
     use cranelift_codegen::ir::InstBuilder;
@@ -546,6 +657,44 @@ fn compile_ir_function(
                     // This is used directly as the `brif` condition in Branch terminators.
                     let result = builder.ins().icmp(cc, lhs_val, rhs_val);
                     val_map.insert(*dst, result);
+                }
+
+                IrInst::Call { dst, callee, args, return_ty } => {
+                    use cranelift_module::Module;
+
+                    // Resolve the callee from the pre-built map (intrinsics + module fns).
+                    let callee_id = *func_id_map.get(callee.as_str()).ok_or_else(|| {
+                        JitExecutionError::CodegenFailure {
+                            detail: format!(
+                                "undefined callee '{callee}' — \
+                                 not a module function or registered runtime intrinsic"
+                            ),
+                        }
+                    })?;
+
+                    // Introduce a local reference to the callee inside this function.
+                    let callee_ref = module.declare_func_in_func(callee_id, builder.func);
+
+                    // Collect argument values from the SSA map.
+                    let mut arg_vals = Vec::with_capacity(args.len());
+                    for a in args {
+                        let v = *val_map.get(a).ok_or_else(|| {
+                            JitExecutionError::CodegenFailure {
+                                detail: format!(
+                                    "undefined value {a:?} in call args for '{callee}'"
+                                ),
+                            }
+                        })?;
+                        arg_vals.push(v);
+                    }
+
+                    let call_inst = builder.ins().call(callee_ref, &arg_vals);
+
+                    // Capture the return value if the call produces one.
+                    if let (Some(d), Some(_)) = (dst, return_ty) {
+                        let results = builder.inst_results(call_inst);
+                        val_map.insert(*d, results[0]);
+                    }
                 }
 
                 other => {
@@ -1202,6 +1351,7 @@ mod jit_tests {
                         params: vec![BlockParam {
                             value: ValueId(1),
                             ty: IrType::I32,
+                            read_only: false,
                         }],
                         insts: vec![],
                         term: IrTerminator::Return {
@@ -1461,13 +1611,13 @@ mod jit_tests {
                     },
                     IrBlock {
                         id: BlockId(1),
-                        params: vec![BlockParam { value: ValueId(3), ty: IrType::I32 }],
+                        params: vec![BlockParam { value: ValueId(3), ty: IrType::I32, read_only: false }],
                         insts: vec![],
                         term: IrTerminator::Return { value: Some(ValueId(3)) },
                     },
                     IrBlock {
                         id: BlockId(2),
-                        params: vec![BlockParam { value: ValueId(4), ty: IrType::I32 }],
+                        params: vec![BlockParam { value: ValueId(4), ty: IrType::I32, read_only: false }],
                         insts: vec![],
                         term: IrTerminator::Return { value: Some(ValueId(4)) },
                     },
@@ -1477,5 +1627,143 @@ mod jit_tests {
         let result = HostBoundary::new().execute(&module);
         assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
         assert_eq!(result.unwrap().exit_code.raw(), 42);
+    }
+
+    // ── Sub-packet 2 (Phase 9): runtime intrinsics dispatch ──────────────────
+
+    #[test]
+    fn jit_intrinsic_cx_printn_executes_without_error() {
+        // main(): i32 {
+        //   v0 = 99_i64
+        //   call cx_printn(v0)   // writes "99" to stdout (side-effect, not captured here)
+        //   v1 = 0_i32
+        //   return v1
+        // }
+        //
+        // This test verifies that the intrinsics dispatch mechanism routes the
+        // IrInst::Call correctly and the JIT module compiles and executes without
+        // errors.  The actual printed output ("99") is observable in the test
+        // runner's stdout but not asserted here (subprocess capture is post-scaffold).
+        let module = IrModule {
+            debug_name: "test_cx_printn".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I64, value: 99 },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn".to_string(),
+                            args: vec![ValueId(0)],
+                            return_ty: None,
+                        },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 0 },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(1)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 0);
+    }
+
+    #[test]
+    fn jit_call_user_function_returns_value() {
+        // Two functions: `add(a: i32, b: i32) -> i32` and `main() -> i32`.
+        // main calls add(10, 32) and returns the result (42).
+        //
+        // This exercises the two-pass compilation path for module-to-module calls.
+        let module = IrModule {
+            debug_name: "test_user_call".to_string(),
+            functions: vec![
+                // add(a: i32, b: i32) -> i32 { return a + b }
+                IrFunction {
+                    name: "add".to_string(),
+                    params: vec![
+                        crate::ir::types::IrParam { name: "a".to_string(), ty: IrType::I32 },
+                        crate::ir::types::IrParam { name: "b".to_string(), ty: IrType::I32 },
+                    ],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![
+                            crate::ir::types::BlockParam { value: ValueId(0), ty: IrType::I32, read_only: false },
+                            crate::ir::types::BlockParam { value: ValueId(1), ty: IrType::I32, read_only: false },
+                        ],
+                        insts: vec![IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Add,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(2)) },
+                    }],
+                },
+                // main() -> i32 { return add(10, 32) }
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstInt { dst: ValueId(3), ty: IrType::I32, value: 10 },
+                            IrInst::ConstInt { dst: ValueId(4), ty: IrType::I32, value: 32 },
+                            IrInst::Call {
+                                dst: Some(ValueId(5)),
+                                callee: "add".to_string(),
+                                args: vec![ValueId(3), ValueId(4)],
+                                return_ty: Some(IrType::I32),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(5)) },
+                    }],
+                },
+            ],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42); // 10 + 32
+    }
+
+    #[test]
+    fn jit_unknown_callee_returns_codegen_error() {
+        // Calling a function not in the module and not a registered intrinsic
+        // must produce CodegenFailure, not a panic.
+        let module = IrModule {
+            debug_name: "test_unknown_callee".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 0 },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_nonexistent_function".to_string(),
+                            args: vec![],
+                            return_ty: None,
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(0)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(
+            matches!(result, Err(JitExecutionError::CodegenFailure { .. })),
+            "expected CodegenFailure for unknown callee, got: {:?}",
+            result
+        );
     }
 }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -66,39 +66,6 @@ impl fmt::Display for LoweringError {
 
 impl std::error::Error for LoweringError {}
 
-// ---------------------------------------------------------------------------
-// Runtime intrinsics boundary — Phase 9 audit
-// ---------------------------------------------------------------------------
-//
-// These names are Cx language builtins. They are recognized at the semantic
-// layer (semantic.rs `analyze_call`) and assigned `FunctionId(u32::MAX)` to
-// flag them as non-user-defined. They do NOT appear in the `signature_table`,
-// which only holds user-defined functions.
-//
-// Classification (see docs/backend/cx_runtime_intrinsics_v0.1.md for the
-// full boundary specification):
-//
-//   Category          | Builtins
-//   ──────────────────┼────────────────────────────────
-//   I/O (stdout)      | print, println, printn
-//   I/O (stdin)       | read, input
-//   Debug / assertion | assert, assert_eq
-//
-// None of these have codegen support yet. Lowering them through the normal
-// `signature_table` path would produce a misleading `UnresolvedSemanticArtifact`
-// error. Instead, `is_cx_builtin` gates the call paths so they produce a
-// structured `UnsupportedSemanticConstruct` with an explicit Phase 9 note.
-//
-// When Phase 9 sub-packet 2 lands, each builtin here will be replaced by a
-// concrete `IrIntrinsic` opcode or a runtime-call ABI signature — at which
-// point this function will shrink until it is empty.
-fn is_cx_builtin(name: &str) -> bool {
-    matches!(
-        name,
-        "print" | "println" | "printn" | "read" | "input" | "assert" | "assert_eq"
-    )
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct LoweredValue {
     value: ValueId,
@@ -590,23 +557,19 @@ fn lower_stmt(
             Ok(Some(current))
         }
         SemanticStmt::ExprStmt { expr, .. } => {
-            // Builtin intrinsics (print, assert, etc.) are not in the signature_table.
-            // Intercept them here so they produce a structured UnsupportedSemanticConstruct
-            // rather than falling through to a misleading UnresolvedSemanticArtifact.
-            if let SemanticExprKind::Call { callee, .. } = &expr.kind {
-                if is_cx_builtin(callee) {
-                    return Err(LoweringError::UnsupportedSemanticConstruct {
-                        construct: format!(
-                            "builtin '{}' is not yet lowerable to IR — codegen pending (Phase 9)",
-                            callee
-                        ),
-                    });
-                }
-            }
             // Void function calls cannot go through lower_expr because that function
             // must return a LoweredValue, and void calls produce no value.
-            // Detect and lower void calls here before falling through to lower_expr.
+            // Check builtins first (FunctionId(u32::MAX)), then the signature table.
             if let SemanticExprKind::Call { callee, function: _, args } = &expr.kind {
+                // Cx builtins are not in the signature table — dispatch them directly
+                // through the runtime intrinsics boundary.
+                if is_cx_builtin(callee.as_str()) {
+                    let callee = callee.clone();
+                    let args = args.clone();
+                    lower_builtin_stmt(&callee, &args, ctx, &mut current)?;
+                    return Ok(Some(current));
+                }
+
                 let sig_info = ctx.signature_table.get(callee.as_str())
                     .map(|s| (s.return_ty.clone(), s.param_types.clone()));
                 if let Some((None, param_types)) = sig_info {
@@ -1493,15 +1456,19 @@ fn lower_expr(
             })
         }
         SemanticExprKind::Call { callee, function: _, args } => {
-            // Builtin intrinsics (print, assert, etc.) are not in the signature_table.
-            // Intercept them before the lookup so the error is structured and actionable
-            // rather than the generic UnresolvedSemanticArtifact produced by a table miss.
-            if is_cx_builtin(callee) {
+            // Builtins are void (except read/input which return Str, also unsupported).
+            // Neither kind can appear in a value-producing expression position.
+            if is_cx_builtin(callee.as_str()) {
                 return Err(LoweringError::UnsupportedSemanticConstruct {
-                    construct: format!(
-                        "builtin '{}' is not yet lowerable to IR — codegen pending (Phase 9)",
-                        callee
-                    ),
+                    construct: match callee.as_str() {
+                        "read" | "input" => format!(
+                            "builtin '{callee}' returns Str — \
+                             string builtins are not yet supported in the backend"
+                        ),
+                        _ => format!(
+                            "builtin '{callee}' is void and cannot be used in value position"
+                        ),
+                    },
                 });
             }
             let (param_types, return_ty) = {
@@ -2364,6 +2331,106 @@ fn ensure_type_match(context: &str, expected: IrType, got: IrType) -> Result<(),
                 "{context} type mismatch after semantic analysis: expected {expected:?}, got {got:?}"
             ),
         })
+    }
+}
+
+// ── Runtime intrinsics dispatch ───────────────────────────────────────────────
+
+/// Returns `true` if `name` is a Cx builtin that bypasses the user function
+/// signature table.
+///
+/// Builtins are recognized in semantic analysis with `FunctionId(u32::MAX)`
+/// and require special lowering to runtime intrinsic calls.  They are not
+/// present in the signature table because the frontend promotes them before
+/// any user-defined function lookup.
+fn is_cx_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "print" | "println" | "printn" | "read" | "input" | "assert" | "assert_eq"
+    )
+}
+
+/// Lower a Cx builtin call as a void statement.
+///
+/// Builtins that map to a supported runtime intrinsic emit `IrInst::Call`
+/// directly with the intrinsic's stable name (e.g. `cx_printn`).  Builtins
+/// that depend on unsupported types or are not yet implemented return a
+/// structured `UnsupportedSemanticConstruct` error.
+///
+/// ## Currently supported builtins
+///
+/// | Cx builtin | IR intrinsic | Notes                              |
+/// |------------|--------------|------------------------------------|
+/// | `printn`   | `cx_printn`  | Accepts any integer type (I8–I64). |
+///
+/// ## Currently unsupported builtins
+///
+/// | Cx builtin   | Reason                                                        |
+/// |--------------|---------------------------------------------------------------|
+/// | `print`      | String arguments require str/strref layout (unresolved).      |
+/// | `println`    | Same as `print`.                                              |
+/// | `assert`     | Not yet implemented in the backend.                           |
+/// | `assert_eq`  | Not yet implemented in the backend.                           |
+/// | `read`       | Returns Str — string builtins unsupported.                    |
+/// | `input`      | Returns Str — string builtins unsupported.                    |
+fn lower_builtin_stmt(
+    callee: &str,
+    args: &[SemanticCallArg],
+    ctx: &mut LoweringCtx,
+    active: &mut ActiveBlock,
+) -> Result<(), LoweringError> {
+    match callee {
+        "printn" => {
+            // printn(n: integer) → cx_printn(n)
+            // The runtime shim cx_printn has the C signature `void cx_printn(i64)`.
+            // Any integer argument type (I8/I16/I32/I64) is accepted here;
+            // the JIT backend is responsible for matching the shim's i64 parameter.
+            if args.len() != 1 {
+                return Err(LoweringError::InternalInvariantViolation {
+                    detail: format!(
+                        "printn expects 1 argument, got {}",
+                        args.len()
+                    ),
+                });
+            }
+            let arg = match &args[0] {
+                SemanticCallArg::Expr(e) => lower_expr(e, ctx, active)?,
+                _ => {
+                    return Err(LoweringError::UnsupportedSemanticConstruct {
+                        construct: "non-expression argument to printn".to_string(),
+                    })
+                }
+            };
+            active.emit(IrInst::Call {
+                dst: None,
+                callee: "cx_printn".to_string(),
+                args: vec![arg.value],
+                return_ty: None,
+            })
+        }
+
+        "print" | "println" => Err(LoweringError::UnsupportedSemanticConstruct {
+            construct: format!(
+                "builtin '{callee}' requires string arguments — \
+                 str/strref layout is not yet resolved in the backend"
+            ),
+        }),
+
+        "assert" | "assert_eq" => Err(LoweringError::UnsupportedSemanticConstruct {
+            construct: format!(
+                "builtin '{callee}' is not yet implemented in the backend"
+            ),
+        }),
+
+        "read" | "input" => Err(LoweringError::UnsupportedSemanticConstruct {
+            construct: format!(
+                "builtin '{callee}' returns Str — string builtins are not yet supported in the backend"
+            ),
+        }),
+
+        other => Err(LoweringError::UnsupportedSemanticConstruct {
+            construct: format!("unknown builtin '{other}'"),
+        }),
     }
 }
 
@@ -5168,15 +5235,141 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Phase 9 — Runtime intrinsics boundary audit (CX-35)
-    //
-    // Each builtin must produce UnsupportedSemanticConstruct (not the
-    // generic UnresolvedSemanticArtifact that a signature_table miss gives).
-    // -----------------------------------------------------------------------
+    // ── Runtime intrinsics dispatch (Phase 9 sub-packet 2) ──────────────────
 
-    // Helper: build a top-level ExprStmt that calls a builtin with the given
-    // args. `FunctionId(u32::MAX)` is the semantic-layer sentinel for builtins.
+    /// Helper: build a one-statement program whose only statement is an
+    /// expression-statement that calls `callee` with a single I64 argument.
+    fn builtin_call_stmt(callee: &str, arg: SemanticExpr) -> SemanticProgram {
+        SemanticProgram {
+            stmts: vec![SemanticStmt::ExprStmt {
+                expr: SemanticExpr {
+                    ty: SemanticType::Void,
+                    kind: SemanticExprKind::Call {
+                        callee: callee.to_string(),
+                        function: crate::frontend::semantic_types::FunctionId(u32::MAX),
+                        args: vec![SemanticCallArg::Expr(arg)],
+                    },
+                },
+                pos: 0,
+            }],
+            enums: vec![],
+        }
+    }
+
+    #[test]
+    fn builtin_printn_lowers_to_cx_printn_call() {
+        // `printn(42_i64)` as a statement should lower to
+        // `IrInst::Call { callee: "cx_printn", args: [v0], return_ty: None }`.
+        let program = builtin_call_stmt("printn", int_expr(42, SemanticType::I64));
+        let module = lower_and_validate(&program);
+
+        let insts = &module.functions[0].blocks[0].insts;
+        // Expect: ConstInt(42) + Call(cx_printn)
+        assert_eq!(insts.len(), 2, "expected ConstInt + Call, got: {:?}", insts);
+        match &insts[1] {
+            IrInst::Call { callee, args, dst, return_ty } => {
+                assert_eq!(callee, "cx_printn");
+                assert_eq!(args.len(), 1);
+                assert!(dst.is_none(), "cx_printn is void — dst must be None");
+                assert!(return_ty.is_none(), "cx_printn is void — return_ty must be None");
+            }
+            other => panic!("expected Call instruction, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn builtin_print_produces_unsupported_error() {
+        let program = builtin_call_stmt(
+            "print",
+            SemanticExpr {
+                ty: SemanticType::Str,
+                kind: SemanticExprKind::Value(SemanticValue::Str("hi".to_string())),
+            },
+        );
+        let err = lower_program(&program).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                LoweringError::UnsupportedSemanticConstruct { construct }
+                if construct.contains("print") && construct.contains("string")
+            ),
+            "expected structured error mentioning 'print' and 'string', got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn builtin_println_produces_unsupported_error() {
+        let program = builtin_call_stmt(
+            "println",
+            SemanticExpr {
+                ty: SemanticType::Str,
+                kind: SemanticExprKind::Value(SemanticValue::Str("hi".to_string())),
+            },
+        );
+        let err = lower_program(&program).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                LoweringError::UnsupportedSemanticConstruct { construct }
+                if construct.contains("println") && construct.contains("string")
+            ),
+            "expected structured error mentioning 'println' and 'string', got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn builtin_assert_produces_unsupported_error() {
+        let program = builtin_call_stmt("assert", bool_expr(true));
+        let err = lower_program(&program).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                LoweringError::UnsupportedSemanticConstruct { construct }
+                if construct.contains("assert")
+            ),
+            "expected structured error mentioning 'assert', got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn builtin_in_value_position_produces_structured_error() {
+        // Using `printn` in an expression (value) position should give a
+        // structured UnsupportedSemanticConstruct, not UnresolvedSemanticArtifact.
+        let program = SemanticProgram {
+            stmts: vec![typed_assign(
+                BindingId(99),
+                "x",
+                SemanticType::I64,
+                SemanticExpr {
+                    ty: SemanticType::Void,
+                    kind: SemanticExprKind::Call {
+                        callee: "printn".to_string(),
+                        function: crate::frontend::semantic_types::FunctionId(u32::MAX),
+                        args: vec![SemanticCallArg::Expr(int_expr(1, SemanticType::I64))],
+                    },
+                },
+            )],
+            enums: vec![],
+        };
+        let err = lower_program(&program).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                LoweringError::UnsupportedSemanticConstruct { construct }
+                if construct.contains("printn")
+            ),
+            "expected UnsupportedSemanticConstruct mentioning 'printn', got: {:?}",
+            err
+        );
+    }
+
+    // ── Phase 9 audit tests (CX-35) ──────────────────────────────────────────
+    // These helpers verify that unsupported builtins produce structured errors,
+    // not the generic UnresolvedSemanticArtifact from a signature_table miss.
+
     fn builtin_stmt(name: &str, args: Vec<SemanticCallArg>) -> SemanticStmt {
         SemanticStmt::ExprStmt {
             expr: SemanticExpr {
@@ -5218,10 +5411,7 @@ mod tests {
         assert_builtin_structured_error("println");
     }
 
-    #[test]
-    fn builtin_printn_produces_unsupported_construct_not_unresolved_artifact() {
-        assert_builtin_structured_error("printn");
-    }
+    // printn is dispatched as of Phase 9 sub-packet 2 — no longer unsupported.
 
     #[test]
     fn builtin_assert_produces_unsupported_construct_not_unresolved_artifact() {

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -64,10 +64,41 @@ struct ValidatorFunctionSig {
     has_return: bool,
 }
 
+/// Signatures for Cx runtime intrinsics that the validator recognises as valid
+/// callees without requiring them to be defined in the IR module.
+///
+/// Each intrinsic is linked by the JIT backend at execution time (registered as
+/// a Cranelift `Import` and resolved via `JITBuilder::symbol`).  The validator
+/// must accept them here so that IR containing intrinsic calls passes validation
+/// before reaching the backend.
+///
+/// Keep this table in sync with `declare_intrinsics` in
+/// `src/backend/cranelift/host_boundary.rs`.
+fn known_intrinsic_sigs() -> HashMap<String, ValidatorFunctionSig> {
+    let mut map = HashMap::new();
+
+    // cx_printn: (i64) -> void
+    // Cx builtin: printn(n)
+    map.insert(
+        "cx_printn".to_string(),
+        ValidatorFunctionSig {
+            param_count: 1,
+            param_types: vec![IrType::I64],
+            has_return: false,
+        },
+    );
+
+    map
+}
+
 pub fn validate_module(module: &IrModule) -> Result<(), Vec<IrValidationError>> {
     let mut errors = Vec::new();
 
-    let mut function_sigs: HashMap<String, ValidatorFunctionSig> = HashMap::new();
+    // Seed the signature table with known runtime intrinsics so that calls to
+    // them are accepted without requiring a matching function definition in the
+    // IR module.
+    let mut function_sigs: HashMap<String, ValidatorFunctionSig> = known_intrinsic_sigs();
+
     for function in &module.functions {
         function_sigs.insert(function.name.clone(), ValidatorFunctionSig {
             param_count: function.params.len(),


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-38/implement-runtime-intrinsics-dispatch-mechanism-phase-9-sub-packet-2

## Summary

Implements the runtime intrinsics dispatch mechanism for Phase 9 sub-packet 2. This is the infrastructure that routes Cx builtin function calls through a clean, testable boundary between the IR lowering layer and the JIT backend.

- IR lowering recognises all Cx builtins by name and routes `printn` to `IrInst::Call { callee: "cx_printn" }`. Other builtins (print/println/assert/assert_eq/read/input) produce structured `UnsupportedSemanticConstruct` errors with clear explanations.
- IR validator pre-seeds the intrinsics registry so calls to `cx_printn` pass validation without a matching IR function definition.
- JIT backend uses a two-pass compilation model: Pass 1 declares all intrinsics (as Cranelift imports) and all module functions (as exports) into a shared `func_id_map`; Pass 2 compiles function bodies using that map. `IrInst::Call` is now fully handled for both intrinsic and cross-module user function calls.
- `cx_printn` runtime shim implemented as `extern "C" fn cx_printn(n: i64)` and registered with `JITBuilder::symbol`.

## Files changed

- `src/ir/lower.rs` — `is_cx_builtin()`, `lower_builtin_stmt()`, ExprStmt and lower_expr Call dispatch
- `src/ir/validate.rs` — `known_intrinsic_sigs()` pre-seeded into validator
- `src/backend/cranelift/host_boundary.rs` — `cx_printn` shim, `declare_intrinsics()`, two-pass `execute()`, `IrInst::Call` in `compile_ir_function`

## Tests run

```
cargo build --features jit
cargo test  --features jit
```

## Validation results

```
test result: ok. 181 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

8 new tests added:
- `lower::builtin_printn_lowers_to_cx_printn_call`
- `lower::builtin_print_produces_unsupported_error`
- `lower::builtin_println_produces_unsupported_error`
- `lower::builtin_assert_produces_unsupported_error`
- `lower::builtin_in_value_position_produces_structured_error`
- `jit::jit_intrinsic_cx_printn_executes_without_error`
- `jit::jit_call_user_function_returns_value`
- `jit::jit_unknown_callee_returns_codegen_error`

## Known limitations

- `print` and `println` produce `UnsupportedSemanticConstruct` — str/strref layout unresolved (cross-roadmap dependency on frontend promoting `print` to a proper function)
- `assert`, `assert_eq` produce `UnsupportedSemanticConstruct` — not yet implemented
- `read`, `input` produce `UnsupportedSemanticConstruct` — return Str (unsupported)
- Automatic widening (e.g. I32 arg to I64 param) not performed; Cranelift's verifier will reject type mismatches at codegen time

## Linear ticket

CX-38 — Phase 9 sub-packet 2