### PR TITLE
CX-41: implement Jump and Branch terminators — fix 11-test CX-27 regression

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -198,7 +198,7 @@ impl std::fmt::Display for JitExecutionError {
 /// The differential harness captures this output by running the compiler as a subprocess.
 /// In-process pipe redirection is a post-scaffold enhancement.
 ///
-/// ## Supported Instructions (Phase 14 sub-packets 1 and 2)
+/// ## Supported Instructions (Phase 14 sub-packets 1, 2, and 3)
 ///
 /// The JIT implementation (enabled with the `jit` feature) supports:
 /// - `ConstInt` (types: I8, I16, I32, I64 — not I128)
@@ -206,10 +206,16 @@ impl std::fmt::Display for JitExecutionError {
 /// - `Alloca` — stack slot allocation; `dst` receives an I64 pointer to the slot
 /// - `Load` — typed memory load from an Alloca-produced pointer
 /// - `Store` — typed memory store through an Alloca-produced pointer
+/// - `Compare` (Eq, Ne, Lt, Le, Gt, Ge — signed integer comparisons; result is I8)
 /// - `Return` (with or without a value)
 ///
-/// All other IR instructions and terminators return [`JitExecutionError::UnsupportedConstruct`].
-/// Multi-block functions with `Jump`/`Branch` terminators are not yet supported.
+/// - `Jump` (unconditional block transfer with optional block-param arguments)
+/// - `Branch` (two-way conditional branch using `brif`, with block-param arguments on both edges)
+///
+/// Multi-block functions are supported for forward-only control flow (no back-edges).
+/// Loop back-edges are deferred to a later sub-packet.
+///
+/// All other IR instructions return [`JitExecutionError::UnsupportedConstruct`].
 pub struct HostBoundary;
 
 impl HostBoundary {
@@ -363,22 +369,30 @@ fn build_cl_signature<M: cranelift_module::Module>(
 
 /// Emit Cranelift IR instructions for a single [`IrFunction`] into `builder`.
 ///
-/// Supported instructions (Phase 14 sub-packets 1 and 2):
+/// Supported instructions (Phase 14 sub-packets 1, 2, and 3):
 /// - [`IrInst::ConstInt`] — integer constants for I8/I16/I32/I64 (not I128)
 /// - [`IrInst::Binary`] — signed integer arithmetic: Add, Sub, Mul, Div, Rem
 /// - [`IrInst::Alloca`] — stack slot allocation; `dst` receives an I64 pointer
 /// - [`IrInst::Load`] — typed memory load from a pointer
 /// - [`IrInst::Store`] — typed memory store through a pointer
+/// - [`IrInst::Compare`] — signed integer comparisons (Eq/Ne/Lt/Le/Gt/Ge); result is I8
 /// - [`IrTerminator::Return`] — return with or without a value
+/// - [`IrTerminator::Jump`] — unconditional branch with optional block-param arguments
+/// - [`IrTerminator::Branch`] — two-way conditional branch (`brif`) with block-param arguments
 ///
-/// All other instructions and terminators yield [`JitExecutionError::UnsupportedConstruct`].
+/// Block sealing strategy: each block is sealed immediately after `switch_to_block` because
+/// IR blocks are emitted in topological order for forward-only CFGs.  All predecessor edges
+/// (from `jump` / `brif`) are registered before the successor block is visited.
+///
+/// All other instructions yield [`JitExecutionError::UnsupportedConstruct`].
 #[cfg(feature = "jit")]
 fn compile_ir_function(
     builder: &mut cranelift_frontend::FunctionBuilder,
     ir_func: &crate::ir::types::IrFunction,
 ) -> Result<(), JitExecutionError> {
+    use cranelift_codegen::ir::condcodes::IntCC;
     use cranelift_codegen::ir::InstBuilder;
-    use crate::ir::instr::{BinaryOp, IrInst, IrTerminator};
+    use crate::ir::instr::{BinaryOp, CompareOp, IrInst, IrTerminator};
     use crate::ir::types::{BlockId, IrType, ValueId};
     use super::ir_type_to_cranelift;
     use std::collections::HashMap;
@@ -408,8 +422,11 @@ fn compile_ir_function(
     for ir_block in &ir_func.blocks {
         let cl_block = block_map[&ir_block.id];
         builder.switch_to_block(cl_block);
-        // Safe to seal immediately: only Return terminators are supported in this
-        // sub-packet, so no block has a back-edge predecessor.
+        // Blocks are processed in IR order, which is topological for forward-only CFGs.
+        // Each block is sealed immediately after switch_to_block: by the time we visit
+        // block N, all predecessor terminators (jump / brif) referencing block N have
+        // already been emitted in earlier iterations, so all predecessor edges are
+        // registered in Cranelift's internal tracking before the seal call.
         builder.seal_block(cl_block);
 
         for inst in &ir_block.insts {
@@ -419,7 +436,7 @@ fn compile_ir_function(
                     // emulates it as two i64s). Deferred to a future sub-packet.
                     if *ty == IrType::I128 {
                         return Err(JitExecutionError::UnsupportedConstruct {
-                            construct: "ConstInt I128 (not supported in Phase 14 sub-packet 1)"
+                            construct: "ConstInt I128 (not supported)"
                                 .to_string(),
                         });
                     }
@@ -502,6 +519,33 @@ fn compile_ir_function(
                         }
                     })?;
                     builder.ins().store(MemFlags::new(), stored_val, ptr_val, 0);
+                }
+
+                IrInst::Compare { dst, op, lhs, rhs } => {
+                    let lhs_val = *val_map.get(lhs).ok_or_else(|| {
+                        JitExecutionError::CodegenFailure {
+                            detail: format!("undefined value {:?} used as compare lhs", lhs),
+                        }
+                    })?;
+                    let rhs_val = *val_map.get(rhs).ok_or_else(|| {
+                        JitExecutionError::CodegenFailure {
+                            detail: format!("undefined value {:?} used as compare rhs", rhs),
+                        }
+                    })?;
+                    // Map Cx compare ops to Cranelift signed-integer condition codes.
+                    // Unsigned variants are deferred until unsigned integer types are added.
+                    let cc = match op {
+                        CompareOp::Eq => IntCC::Equal,
+                        CompareOp::Ne => IntCC::NotEqual,
+                        CompareOp::Lt => IntCC::SignedLessThan,
+                        CompareOp::Le => IntCC::SignedLessThanOrEqual,
+                        CompareOp::Gt => IntCC::SignedGreaterThan,
+                        CompareOp::Ge => IntCC::SignedGreaterThanOrEqual,
+                    };
+                    // icmp produces an I8 value (0 = false, 1 = true).
+                    // This is used directly as the `brif` condition in Branch terminators.
+                    let result = builder.ins().icmp(cc, lhs_val, rhs_val);
+                    val_map.insert(*dst, result);
                 }
 
                 other => {
@@ -1061,5 +1105,320 @@ mod jit_tests {
         let result = HostBoundary::new().execute(&module);
         assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
         assert_eq!(result.unwrap().exit_code.raw(), 42); // 10 + 32
+    }
+
+    // ── Jump tests ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn jit_jump_passes_value_via_block_param() {
+        // main() -> I32 {
+        //   block0:
+        //     v0 = const 42 : I32
+        //     jump block1(v0)
+        //   block1(v1: I32):
+        //     return v1
+        // }
+        // Expected: 42
+        use crate::ir::types::BlockParam;
+        let module = IrModule {
+            debug_name: "test_jump".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::I32,
+                            value: 42,
+                        }],
+                        term: IrTerminator::Jump {
+                            target: BlockId(1),
+                            args: vec![ValueId(0)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![BlockParam {
+                            value: ValueId(1),
+                            ty: IrType::I32,
+                        }],
+                        insts: vec![],
+                        term: IrTerminator::Return {
+                            value: Some(ValueId(1)),
+                        },
+                    },
+                ],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42);
+    }
+
+    #[test]
+    fn jit_jump_no_args() {
+        // main() -> I32 {
+        //   block0:
+        //     jump block1
+        //   block1:
+        //     v0 = const 7 : I32
+        //     return v0
+        // }
+        // Expected: 7
+        let module = IrModule {
+            debug_name: "test_jump_noarg".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Jump {
+                            target: BlockId(1),
+                            args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::I32,
+                            value: 7,
+                        }],
+                        term: IrTerminator::Return {
+                            value: Some(ValueId(0)),
+                        },
+                    },
+                ],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 7);
+    }
+
+    // ── Compare + Branch tests ───────────────────────────────────────────────
+
+    /// Helper: build a two-block if/else module that compares two I32 constants.
+    ///
+    /// ```text
+    /// main() -> I32 {
+    ///   block0:
+    ///     v0 = const lhs : I32
+    ///     v1 = const rhs : I32
+    ///     v2 = compare op(v0, v1)   // I8
+    ///     branch v2, block1[], block2[]
+    ///   block1:          // true path
+    ///     v3 = const true_val : I32
+    ///     return v3
+    ///   block2:          // false path
+    ///     v4 = const false_val : I32
+    ///     return v4
+    /// }
+    /// ```
+    fn compare_branch_module(
+        lhs: i128,
+        rhs: i128,
+        op: crate::ir::instr::CompareOp,
+        true_val: i128,
+        false_val: i128,
+    ) -> IrModule {
+        IrModule {
+            debug_name: "test_compare_branch".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: lhs },
+                            IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: rhs },
+                            IrInst::Compare {
+                                dst: ValueId(2),
+                                op,
+                                lhs: ValueId(0),
+                                rhs: ValueId(1),
+                            },
+                        ],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(2),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(3),
+                            ty: IrType::I32,
+                            value: true_val,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(4),
+                            ty: IrType::I32,
+                            value: false_val,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(4)) },
+                    },
+                ],
+            }],
+        }
+    }
+
+    #[test]
+    fn jit_branch_compare_eq_takes_true_path() {
+        // 5 == 5 → true → return 1
+        use crate::ir::instr::CompareOp;
+        let m = compare_branch_module(5, 5, CompareOp::Eq, 1, 0);
+        let r = HostBoundary::new().execute(&m);
+        assert!(r.is_ok(), "JIT failed: {:?}", r.unwrap_err());
+        assert_eq!(r.unwrap().exit_code.raw(), 1);
+    }
+
+    #[test]
+    fn jit_branch_compare_eq_takes_false_path() {
+        // 5 == 6 → false → return 0
+        use crate::ir::instr::CompareOp;
+        let m = compare_branch_module(5, 6, CompareOp::Eq, 1, 0);
+        let r = HostBoundary::new().execute(&m);
+        assert!(r.is_ok(), "JIT failed: {:?}", r.unwrap_err());
+        assert_eq!(r.unwrap().exit_code.raw(), 0);
+    }
+
+    #[test]
+    fn jit_branch_compare_ne_true() {
+        // 5 != 10 → true → return 42
+        use crate::ir::instr::CompareOp;
+        let m = compare_branch_module(5, 10, CompareOp::Ne, 42, 99);
+        let r = HostBoundary::new().execute(&m);
+        assert!(r.is_ok(), "JIT failed: {:?}", r.unwrap_err());
+        assert_eq!(r.unwrap().exit_code.raw(), 42);
+    }
+
+    #[test]
+    fn jit_branch_compare_lt_true() {
+        // 3 < 7 → true → return 1
+        use crate::ir::instr::CompareOp;
+        let m = compare_branch_module(3, 7, CompareOp::Lt, 1, 0);
+        let r = HostBoundary::new().execute(&m);
+        assert!(r.is_ok(), "JIT failed: {:?}", r.unwrap_err());
+        assert_eq!(r.unwrap().exit_code.raw(), 1);
+    }
+
+    #[test]
+    fn jit_branch_compare_lt_false() {
+        // 7 < 3 → false → return 0
+        use crate::ir::instr::CompareOp;
+        let m = compare_branch_module(7, 3, CompareOp::Lt, 1, 0);
+        let r = HostBoundary::new().execute(&m);
+        assert!(r.is_ok(), "JIT failed: {:?}", r.unwrap_err());
+        assert_eq!(r.unwrap().exit_code.raw(), 0);
+    }
+
+    #[test]
+    fn jit_branch_compare_le_equal_is_true() {
+        // 5 <= 5 → true → return 1
+        use crate::ir::instr::CompareOp;
+        let m = compare_branch_module(5, 5, CompareOp::Le, 1, 0);
+        let r = HostBoundary::new().execute(&m);
+        assert!(r.is_ok(), "JIT failed: {:?}", r.unwrap_err());
+        assert_eq!(r.unwrap().exit_code.raw(), 1);
+    }
+
+    #[test]
+    fn jit_branch_compare_gt_true() {
+        // 10 > 3 → true → return 42
+        use crate::ir::instr::CompareOp;
+        let m = compare_branch_module(10, 3, CompareOp::Gt, 42, 0);
+        let r = HostBoundary::new().execute(&m);
+        assert!(r.is_ok(), "JIT failed: {:?}", r.unwrap_err());
+        assert_eq!(r.unwrap().exit_code.raw(), 42);
+    }
+
+    #[test]
+    fn jit_branch_compare_ge_true() {
+        // 10 >= 10 → true → return 1
+        use crate::ir::instr::CompareOp;
+        let m = compare_branch_module(10, 10, CompareOp::Ge, 1, 0);
+        let r = HostBoundary::new().execute(&m);
+        assert!(r.is_ok(), "JIT failed: {:?}", r.unwrap_err());
+        assert_eq!(r.unwrap().exit_code.raw(), 1);
+    }
+
+    #[test]
+    fn jit_branch_with_block_args_on_both_edges() {
+        // main() -> I32 {
+        //   block0:
+        //     v0 = const 1 : I32    // condition value (nonzero → true)
+        //     v1 = const 42 : I32
+        //     v2 = const 99 : I32
+        //     branch v0, block1(v1), block2(v2)
+        //   block1(v3: I32):
+        //     return v3        // taken: returns 42
+        //   block2(v4: I32):
+        //     return v4        // not taken
+        // }
+        // Expected: 42
+        use crate::ir::types::BlockParam;
+        let module = IrModule {
+            debug_name: "test_branch_args".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 1 },
+                            IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 42 },
+                            IrInst::ConstInt { dst: ValueId(2), ty: IrType::I32, value: 99 },
+                        ],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(0),
+                            then_block: BlockId(1),
+                            then_args: vec![ValueId(1)],
+                            else_block: BlockId(2),
+                            else_args: vec![ValueId(2)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![BlockParam { value: ValueId(3), ty: IrType::I32 }],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![BlockParam { value: ValueId(4), ty: IrType::I32 }],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: Some(ValueId(4)) },
+                    },
+                ],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42);
     }
 }

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -568,10 +568,67 @@ fn compile_ir_function(
             IrTerminator::Return { value: None } => {
                 builder.ins().return_(&[]);
             }
-            other => {
-                return Err(JitExecutionError::UnsupportedConstruct {
-                    construct: format!("{:?}", other),
-                });
+            IrTerminator::Jump { target, args } => {
+                let target_cl = *block_map.get(target).ok_or_else(|| {
+                    JitExecutionError::CodegenFailure {
+                        detail: format!("Jump targets undefined block {:?}", target),
+                    }
+                })?;
+                let cl_args: Vec<cranelift_codegen::ir::Value> = args
+                    .iter()
+                    .map(|vid| {
+                        val_map.get(vid).copied().ok_or_else(|| {
+                            JitExecutionError::CodegenFailure {
+                                detail: format!("undefined value {:?} used as Jump arg", vid),
+                            }
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                builder.ins().jump(target_cl, &cl_args);
+            }
+            IrTerminator::Branch { cond, then_block, then_args, else_block, else_args } => {
+                let cond_val = *val_map.get(cond).ok_or_else(|| {
+                    JitExecutionError::CodegenFailure {
+                        detail: format!("undefined condition value {:?} in Branch", cond),
+                    }
+                })?;
+                let then_cl = *block_map.get(then_block).ok_or_else(|| {
+                    JitExecutionError::CodegenFailure {
+                        detail: format!("Branch then-block {:?} not found", then_block),
+                    }
+                })?;
+                let else_cl = *block_map.get(else_block).ok_or_else(|| {
+                    JitExecutionError::CodegenFailure {
+                        detail: format!("Branch else-block {:?} not found", else_block),
+                    }
+                })?;
+                let then_cl_args: Vec<cranelift_codegen::ir::Value> = then_args
+                    .iter()
+                    .map(|vid| {
+                        val_map.get(vid).copied().ok_or_else(|| {
+                            JitExecutionError::CodegenFailure {
+                                detail: format!(
+                                    "undefined value {:?} used as Branch then-arg",
+                                    vid
+                                ),
+                            }
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                let else_cl_args: Vec<cranelift_codegen::ir::Value> = else_args
+                    .iter()
+                    .map(|vid| {
+                        val_map.get(vid).copied().ok_or_else(|| {
+                            JitExecutionError::CodegenFailure {
+                                detail: format!(
+                                    "undefined value {:?} used as Branch else-arg",
+                                    vid
+                                ),
+                            }
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                builder.ins().brif(cond_val, then_cl, &then_cl_args, else_cl, &else_cl_args);
             }
         }
     }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-41/re-validate-all-8-rebased-prs-and-fix-cx-27-regression-11-tests

## Summary

- CX-27 added `Compare` instruction support and 11 new JIT tests (Jump/Branch/Compare) but left `IrTerminator::Jump` and `IrTerminator::Branch` unimplemented in `compile_ir_function`. All 11 tests failed with `UnsupportedConstruct`.
- The CX-39 rebase attempt (commit 228a06b) was an empty commit — identical tree to submain — so the CX-27 regression was never fixed there.
- This PR cherry-picks the CX-27 commit and adds the missing Jump/Branch terminator implementations to fix all 11 failing tests.

## Root Cause

`compile_ir_function` in `host_boundary.rs` had a `match &ir_block.term` block that only handled `IrTerminator::Return`. The `Jump` and `Branch` arms fell through to `UnsupportedConstruct`, causing 11 test failures.

## Changes

**File:** `src/backend/cranelift/host_boundary.rs`

Added two new arms to the `IrTerminator` match in `compile_ir_function`:

- **`Jump { target, args }`** — emits Cranelift `jump(target_block, &cl_args)`, resolving BlockId → Cranelift Block and ValueId → Cranelift Value from existing maps.
- **`Branch { cond, then_block, then_args, else_block, else_args }`** — emits Cranelift `brif(cond_val, then_cl, &then_cl_args, else_cl, &else_cl_args)` with full block-parameter argument support on both edges.

The existing seal-immediately strategy (seal each block right after `switch_to_block`) remains valid: IR blocks are emitted in topological order for forward-only CFGs, so all predecessor jump/brif edges for block N are registered before block N is sealed.

## Tests Run

```
cargo build --features jit   → ok (0 errors, 21 warnings)
cargo test --features jit    → 191 passed, 0 failed
```

## Validation Results

- Before fix: 180 passed, **11 failed** (all CX-27 Jump/Branch/Compare tests)
- After fix: **191 passed, 0 failed**

New tests now passing:
- `jit_jump_passes_value_via_block_param`
- `jit_jump_no_args`
- `jit_branch_compare_eq_takes_true_path`
- `jit_branch_compare_eq_takes_false_path`
- `jit_branch_compare_ne_true`
- `jit_branch_compare_lt_true`
- `jit_branch_compare_lt_false`
- `jit_branch_compare_le_equal_is_true`
- `jit_branch_compare_gt_true`
- `jit_branch_compare_ge_true`
- `jit_branch_with_block_args_on_both_edges`

## Known Limitations

- Loop back-edges (cycles in CFG) are not supported — deferred to a future sub-packet per the existing design.
- The other 7 rebased PRs (cx-30, cx-31, cx-32, cx-33, cx-34, cx-36, cx-38) each compile and pass tests independently on their own branches; they remain open as separate PRs awaiting their own merges.

## Linear Ticket

CX-41 — https://linear.app/cx-lang/issue/CX-41/re-validate-all-8-rebased-prs-and-fix-cx-27-regression-11-tests