### PR TITLE
CX-54: Gate IR dump in Cranelift JIT dispatch path behind --debug-trace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,9 @@ fn run() {
                     return;
                 }
             };
-            println!("{}", crate::ir::printer::print_module(&ir));
+            if flags.trace {
+                println!("{}", crate::ir::printer::print_module(&ir));
+            }
             let b = backend::cranelift::CraneliftBackend;
             if let Err(msg) = b.execute(&ir) {
                 eprintln!("{}", msg);


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-54/cx-54-gate-ir-dump-in-cranelift-jit-dispatch-path-behind-debug-trace

## Summary

- The `println!("{}", crate::ir::printer::print_module(&ir))` call in the `BackendKind::Cranelift` arm of `run()` was unconditional, dumping the entire IR module to stdout on every JIT execution.
- It is now gated behind `flags.trace` (set by `--debug-trace` or `--debug`), matching the intent of the debug flag system already present in the codebase.

## Files changed

- `src/main.rs` — wrap the `print_module` call in `if flags.trace { ... }` (3 lines changed)

## Tests run

```
cargo build --features jit
cargo test --features jit
```

## Validation results

- `cargo build --features jit` — **Finished** (0 errors, 21 pre-existing warnings)
- `cargo test --features jit` — **197 passed; 0 failed** (including `interpreter_baseline_all` and all JIT integration tests)

## Known limitations

None. This is a pure gating change with no behavioural impact when `--debug-trace` is not passed.

## Linear ticket

CX-54