### PR TITLE
CX-53: Add IrType::Void and wire void-return function lowering through IR and JIT

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -1754,6 +1754,55 @@ mod jit_tests {
         assert!(result.is_ok(), "JIT back-edge loop failed: {:?}", result.unwrap_err());
         assert_eq!(result.unwrap().exit_code.raw(), 42);
     }
+    // ── IrType::Void wiring (CX-53) ─────────────────────────────────────────
+
+    /// A module containing a void-return helper alongside a non-void `main`
+    /// must compile without error.  The helper function emits a Cranelift
+    /// signature with an empty return list; `main` returns 42 as usual.
+    ///
+    /// This verifies the end-to-end path: `return_ty: None` (void in IR) →
+    /// empty Cranelift return list → `builder.ins().return_(&[])`.
+    #[test]
+    fn jit_void_return_function_compiles_alongside_main() {
+        let module = IrModule {
+            debug_name: "test_void_func".to_string(),
+            functions: vec![
+                // Void-return helper — compiled but never called in this test.
+                IrFunction {
+                    name: "do_nothing".to_string(),
+                    params: vec![],
+                    return_ty: None,
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: None },
+                    }],
+                },
+                // Non-void main that the JIT executes.
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::I32,
+                            value: 42,
+                        }],
+                        term: IrTerminator::Return {
+                            value: Some(ValueId(0)),
+                        },
+                    }],
+                },
+            ],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42);
+    }
 }
 
 // ── JIT determinism tests (require the `jit` feature) ────────────────────────

--- a/src/backend/cranelift/mod.rs
+++ b/src/backend/cranelift/mod.rs
@@ -53,19 +53,21 @@ impl std::fmt::Display for CraneliftLoweringError {
 /// Map an [`IrType`] to its Cranelift [`cranelift_codegen::ir::types::Type`]
 /// equivalent.
 ///
-/// All nine `IrType` variants are handled:
+/// All ten `IrType` variants are handled:
 ///
-/// | IrType  | Cranelift type | Notes                                    |
-/// |---------|---------------|------------------------------------------|
-/// | I8      | I8            | direct mapping                           |
-/// | I16     | I16           | direct mapping                           |
-/// | I32     | I32           | direct mapping                           |
-/// | I64     | I64           | direct mapping                           |
-/// | I128    | I128          | direct mapping                           |
-/// | F64     | F64           | direct mapping                           |
-/// | Bool    | I8            | booleans are 0/1, no native bool in CL   |
-/// | TBool   | I8            | three-state (0/1/2) fits in i8           |
-/// | Ptr     | I64           | 64-bit pointer on all supported targets  |
+/// | IrType  | Cranelift type | Notes                                                      |
+/// |---------|---------------|------------------------------------------------------------|
+/// | I8      | I8            | direct mapping                                             |
+/// | I16     | I16           | direct mapping                                             |
+/// | I32     | I32           | direct mapping                                             |
+/// | I64     | I64           | direct mapping                                             |
+/// | I128    | I128          | direct mapping                                             |
+/// | F64     | F64           | direct mapping                                             |
+/// | Bool    | I8            | booleans are 0/1, no native bool in CL                     |
+/// | TBool   | I8            | three-state (0/1/2) fits in i8                             |
+/// | Ptr     | I64           | 64-bit pointer on all supported targets                    |
+/// | Void    | —             | error: Cranelift has no void type; void functions use an   |
+/// |         |               | empty return list in their signature (no ABI param at all) |
 #[cfg(feature = "jit")]
 pub fn ir_type_to_cranelift(
     ty: &IrType,
@@ -81,6 +83,13 @@ pub fn ir_type_to_cranelift(
         IrType::Bool  => types::I8,
         IrType::TBool => types::I8,
         IrType::Ptr   => types::I64,
+        IrType::Void  => {
+            return Err(CraneliftLoweringError::InvalidIrType {
+                ty: "Void (Cranelift has no void type; void-return functions use an empty \
+                     return list — IrType::Void must never reach the signature builder)"
+                    .to_string(),
+            });
+        }
     })
 }
 
@@ -249,6 +258,47 @@ impl Backend for CraneliftBackend {
         {
             let _ = module;
             Err("Cranelift backend requires the `jit` feature — rebuild with --features jit".to_string())
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "jit"))]
+mod tests {
+    use super::*;
+    use crate::ir::types::IrType;
+
+    /// IrType::Void must produce an error from ir_type_to_cranelift, not a
+    /// Cranelift type, because Cranelift has no void type.  Void-return
+    /// functions skip the return-type ABI param entirely in build_cl_signature.
+    #[test]
+    fn ir_type_to_cranelift_void_returns_error() {
+        let result = ir_type_to_cranelift(&IrType::Void);
+        assert!(
+            matches!(result, Err(CraneliftLoweringError::InvalidIrType { .. })),
+            "expected InvalidIrType for Void, got {:?}",
+            result
+        );
+    }
+
+    /// All non-void scalar types must map successfully.
+    #[test]
+    fn ir_type_to_cranelift_scalar_types_succeed() {
+        for ty in &[
+            IrType::I8,
+            IrType::I16,
+            IrType::I32,
+            IrType::I64,
+            IrType::F64,
+            IrType::Bool,
+            IrType::TBool,
+            IrType::Ptr,
+        ] {
+            assert!(
+                ir_type_to_cranelift(ty).is_ok(),
+                "expected Ok for {ty:?}, got Err"
+            );
         }
     }
 }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -138,6 +138,9 @@ fn build_signature_table(program: &SemanticProgram) -> HashMap<String, FunctionS
 
             let return_ty = match &function.return_ty {
                 Some(ty) => match lower_type(ty) {
+                    // IrType::Void in return position is canonicalised to None
+                    // (the IR uses Option<IrType> where None = void).
+                    Ok(IrType::Void) => None,
                     Ok(ir_ty) => Some(ir_ty),
                     Err(_) => continue,
                 },
@@ -393,7 +396,15 @@ fn lower_semantic_function(
     let mut ir_params = Vec::with_capacity(function.params.len());
     let mut block_params = Vec::with_capacity(function.params.len());
     let mut bindings = HashMap::new();
-    let return_ty = function.return_ty.as_ref().map(lower_type).transpose()?;
+    let return_ty = {
+        let raw = function.return_ty.as_ref().map(lower_type).transpose()?;
+        // Canonicalise: IrType::Void in return position is equivalent to no return value.
+        // IrFunction::return_ty uses Option<IrType> where None already encodes void.
+        match raw {
+            Some(IrType::Void) => None,
+            other => other,
+        }
+    };
 
     let mut ctx = LoweringCtx::new(signature_table.clone(), struct_table.clone(), trace);
     for param in &function.params {
@@ -2351,7 +2362,10 @@ fn lower_type(ty: &SemanticType) -> Result<IrType, LoweringError> {
         SemanticType::Struct(_) => Ok(IrType::Ptr),
         SemanticType::Array(_, _) => Ok(IrType::Ptr),
         SemanticType::Result(_) => { unsupported_type!("Result") },
-        SemanticType::Void => { unsupported_type!("Void") },
+        // Void is a first-class IR type used to represent the absence of a return value.
+        // Callers that use lower_type for return-type lowering must canonicalise
+        // Some(IrType::Void) to None before placing it in IrFunction::return_ty.
+        SemanticType::Void => Ok(IrType::Void),
     }
 }
 
@@ -4839,6 +4853,49 @@ mod tests {
     fn lower_type_array_maps_to_ptr() {
         let result = lower_type(&SemanticType::Array(4, Box::new(SemanticType::I64)));
         assert_eq!(result, Ok(IrType::Ptr));
+    }
+
+    // lower_type must map SemanticType::Void to IrType::Void (not an error).
+    // Callers (lower_semantic_function, build_signature_table) canonicalise
+    // Some(IrType::Void) → None before it enters IrFunction::return_ty.
+    #[test]
+    fn lower_type_void_maps_to_irtype_void() {
+        let result = lower_type(&SemanticType::Void);
+        assert_eq!(result, Ok(IrType::Void));
+    }
+
+    // A user-defined void-return function (SemanticType::Void return type)
+    // must lower to an IrFunction with return_ty: None (canonicalised).
+    #[test]
+    fn lower_semantic_function_void_return_canonicalises_to_none() {
+        use crate::frontend::semantic_types::{
+            FunctionId, SemanticFunction, SemanticStmt, SemanticType,
+        };
+        // Build a minimal program: fn do_nothing() -> void {}
+        let func = SemanticFunction {
+            id: FunctionId(0),
+            name: "do_nothing".to_string(),
+            type_params: vec![],
+            params: vec![],
+            return_ty: Some(SemanticType::Void),
+            body: vec![],
+            ret_expr: None,
+            is_test: false,
+            pos: 0,
+        };
+        let program = crate::frontend::semantic_types::SemanticProgram {
+            stmts: vec![SemanticStmt::FuncDef(func)],
+            enums: vec![],
+        };
+        let module = lower_program(&program).expect("lowering must succeed");
+        assert_eq!(module.functions.len(), 1);
+        let ir_func = &module.functions[0];
+        assert_eq!(ir_func.name, "do_nothing");
+        // Void return must be canonicalised to None, not Some(IrType::Void).
+        assert_eq!(
+            ir_func.return_ty, None,
+            "void-return function must have return_ty: None in IR"
+        );
     }
 
     // Index lowering on an i64 array with an i64 literal index must emit:

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -192,6 +192,7 @@ fn print_type(ty: &IrType) -> &'static str {
         IrType::Bool => "bool",
         IrType::TBool => "tbool",
         IrType::Ptr => "ptr",
+        IrType::Void => "void",
     }
 }
 

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -11,6 +11,16 @@ pub enum IrType {
     Bool,
     TBool,
     Ptr,
+    /// Void — the absence of a value.
+    ///
+    /// Used in `lower_type` to represent `SemanticType::Void` within the type
+    /// system.  `Void` is **not** a storable or loadable type; it must never
+    /// appear in block parameters, instruction operands, or `IrFunction::return_ty`
+    /// (which uses `Option<IrType>` where `None` already encodes void).
+    ///
+    /// At the function-lowering boundary, `IrType::Void` returned by `lower_type`
+    /// is canonicalised to `None` before being placed in the IR.
+    Void,
 }
 
 impl IrType {
@@ -25,6 +35,7 @@ impl IrType {
             IrType::Bool => 1,
             IrType::TBool => 1,
             IrType::Ptr => 8,
+            IrType::Void => 0,
         }
     }
 
@@ -39,6 +50,7 @@ impl IrType {
             IrType::Bool => 1,
             IrType::TBool => 1,
             IrType::Ptr => 8,
+            IrType::Void => 1,
         }
     }
 }
@@ -354,5 +366,12 @@ mod tests {
         // Enum tags are stored as I8 — 1 byte, align 1, values 0..255
         assert_eq!(IrType::I8.size_bytes(), 1);
         assert_eq!(IrType::I8.align_bytes(), 1);
+    }
+
+    #[test]
+    fn void_has_zero_size_and_unit_alignment() {
+        // Void is not storable; size is 0. Alignment is 1 (neutral for layout math).
+        assert_eq!(IrType::Void.size_bytes(), 0);
+        assert_eq!(IrType::Void.align_bytes(), 1);
     }
 }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-53/add-irtypevoid-and-wire-void-return-function-lowering-through-ir-and

## Summary

- Add `IrType::Void` variant to the `IrType` enum with `size_bytes() = 0` and `align_bytes() = 1`
- Wire `lower_type(SemanticType::Void)` to return `Ok(IrType::Void)` instead of an unsupported-type error
- Canonicalize `Some(IrType::Void)` → `None` at the lowering boundary in `lower_semantic_function` and `build_signature_table` (IR uses `Option<IrType>` where `None` = void)
- Add `IrType::Void` arm to `ir_type_to_cranelift()` returning `Err(InvalidIrType)` — Cranelift has no void type; void-return functions use an empty return list in their signature
- Add `"void"` arm to `print_type()` in `printer.rs`

## Files Changed

- `src/ir/types.rs` — Add `Void` variant, `size_bytes`/`align_bytes` arms, test
- `src/ir/lower.rs` — `lower_type(SemanticType::Void)` → `Ok(IrType::Void)`, canonicalization in `lower_semantic_function` and `build_signature_table`, two new tests
- `src/ir/printer.rs` — Add `"void"` to `print_type`
- `src/backend/cranelift/mod.rs` — Add `IrType::Void` error arm, update comment table 9→10, two new tests
- `src/backend/cranelift/host_boundary.rs` — Add JIT end-to-end test for void-return function alongside `main`

## Design Decision

`IrFunction::return_ty` remains `Option<IrType>` where `None` encodes void. `IrType::Void` is an IR-level type used by `lower_type` to represent `SemanticType::Void`; it is canonicalized to `None` before being stored in the IR. This keeps the existing IR contracts stable while making void a proper first-class IR type.

## Tests Run

```
cargo build --features jit   → ok (21 warnings, no errors)
cargo test --features jit    → 203 passed; 0 failed
```

New tests added:
- `ir::types::tests::void_has_zero_size_and_unit_alignment`
- `backend::cranelift::tests::ir_type_to_cranelift_void_returns_error`
- `backend::cranelift::tests::ir_type_to_cranelift_scalar_types_succeed`
- `ir::lower::tests::lower_type_void_maps_to_irtype_void`
- `ir::lower::tests::lower_semantic_function_void_return_canonicalises_to_none`
- `backend::cranelift::jit_tests::jit_void_return_function_compiles_alongside_main`

## Linear

CX-53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Void-return functions are now properly supported throughout the compilation pipeline with correct type handling

* **Tests**
  * Added test coverage for void-return function compilation and execution

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->