### PR TITLE
CX-67: add .coderabbit.yaml to repo root

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,54 +1,41 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-language: "en-US"
 
-early_access: false
+language: en-US
 
 reviews:
-  profile: "chill"
-  request_changes_workflow: false
+  profile: chill
+  request_changes_workflow: true
   high_level_summary: true
-  poem: false
+  poem: true
   review_status: true
-  collapse_walkthrough: false
   auto_review:
     enabled: true
-    auto_incremental_review: true
     drafts: false
     base_branches:
       - submain
       - main
-
-path_filters:
-  - "!**/*.lock"
-  - "!daily_log/**"
-  - "!examples/**"
-
-path_instructions:
-  - path: "src/backend/**"
-    instructions: |
-      Cranelift JIT/AOT backend. Verify: IR generation correctness, host_boundary
-      ABI stability, and that backend-only symbols stay behind the `jit` feature
-      flag (cranelift-* crates are optional dependencies).
-  - path: "src/frontend/**"
-    instructions: |
-      Lexer, parser, semantic analysis, resolver, diagnostics. Check that AST
-      transformations are complete and that user-facing diagnostics use the
-      `colored` crate rather than raw ANSI escapes.
-  - path: "src/ir/**"
-    instructions: |
-      IR instruction layer. Verify builder invariants and that instruction
-      semantics match the spec in docs/backend/.
-  - path: "src/tests/**"
-    instructions: |
-      Test files. Ensure test names are descriptive. Verification matrix tests
-      live in src/tests/verification_matrix/ and are executed by CI against every
-      PR — do not mark them expected_fail unless a corresponding .expected_fail
-      sentinel file is committed alongside.
-  - path: ".github/workflows/**"
-    instructions: |
-      CI config. Confirm the `jit` feature is present for backend build and test
-      steps. Do not remove the stale-base check (>20 commits behind submain) or
-      the branch-guard that blocks direct pushes to main.
+  path_filters:
+    - "!Cargo.lock"
+    - "!daily_log/**"
+    - "!examples/**"
+    - "!target/**"
+    - "!**/*.lock"
+    - "!tests/snapshots/**"
+    - "!**/generated/**"
+  path_instructions:
+    - path: "src/backend/**"
+      instructions: "Backend developer owns this directory. Flag changes here for extra scrutiny — verify they don't break IR contracts or Cranelift lowering. Confirm test matrix still passes."
+    - path: "src/ir/**"
+      instructions: "Backend territory. Verify IrType variants, SSA invariants, and ABI/data layout decisions are preserved."
+    - path: "src/frontend/**"
+      instructions: "Check parser/lexer changes against locked syntax decisions: fnc declarations, optional semicolons, #![imports] system, strict UTF-8, wrapping arithmetic at declared integer width."
+    - path: "src/tests/**"
+      instructions: "Verify new tests match existing patterns in verification_matrix and diff_harness. Don't accept tests that mask failures with overly broad assertions."
+    - path: ".github/workflows/**"
+      instructions: "CI changes need extra scrutiny. Verify no secret leaks, correct branch triggers, and that the change preserves all existing matrix coverage."
+  tools:
+    github-checks:
+      enabled: true
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+
+early_access: false
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    base_branches:
+      - submain
+      - main
+
+path_filters:
+  - "!**/*.lock"
+  - "!daily_log/**"
+  - "!examples/**"
+
+path_instructions:
+  - path: "src/backend/**"
+    instructions: |
+      Cranelift JIT/AOT backend. Verify: IR generation correctness, host_boundary
+      ABI stability, and that backend-only symbols stay behind the `jit` feature
+      flag (cranelift-* crates are optional dependencies).
+  - path: "src/frontend/**"
+    instructions: |
+      Lexer, parser, semantic analysis, resolver, diagnostics. Check that AST
+      transformations are complete and that user-facing diagnostics use the
+      `colored` crate rather than raw ANSI escapes.
+  - path: "src/ir/**"
+    instructions: |
+      IR instruction layer. Verify builder invariants and that instruction
+      semantics match the spec in docs/backend/.
+  - path: "src/tests/**"
+    instructions: |
+      Test files. Ensure test names are descriptive. Verification matrix tests
+      live in src/tests/verification_matrix/ and are executed by CI against every
+      PR — do not mark them expected_fail unless a corresponding .expected_fail
+      sentinel file is committed alongside.
+  - path: ".github/workflows/**"
+    instructions: |
+      CI config. Confirm the `jit` feature is present for backend build and test
+      steps. Do not remove the stale-base check (>20 commits behind submain) or
+      the branch-guard that blocks direct pushes to main.
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
Configures the CodeRabbit AI reviewer with: en-US language, chill review profile, auto-review targeting submain and main, path filters suppressing Cargo.lock/daily_log/examples noise, and per-path instructions for backend, frontend, IR, test, and CI subdirectories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configuration for automated code reviews with a relaxed profile, high-level summaries, poem output, review status reporting, and chat auto-replies.
  * Enabled auto-review on primary branches and adjusted workflow request behavior.
  * Scoped review instructions by project area and excluded lock files, logs, generated artifacts, snapshots, and examples from analysis.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/109)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->