### PR TITLE
CX-69: Add per-feature parity classification to JIT differential harness (Phase 12)

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -1,0 +1,187 @@
+# CX JIT Parity Checklist — Phase 12
+
+**Ticket:** CX-69  
+**Roadmap:** Phase 12, Differential Backend Harness — "Per-feature parity checklist"
+
+This document records the per-feature JIT parity classification scheme, the
+current baseline from a real run, and the gate semantics used by the
+`jit_parity_by_feature` test.
+
+---
+
+## 1. Feature Classification Scheme
+
+Every fixture in `src/tests/verification_matrix/` maps to exactly one
+`FeatureCategory` variant. The mapping is defined by `feature_of()` in
+`src/diff_harness.rs`. The 15 categories cover the full 0.1 supported construct
+set:
+
+| Category       | Description                                  | Key fixtures |
+|----------------|----------------------------------------------|--------------|
+| Arithmetic     | Integer arithmetic, overflow, eval order     | t01, t89–t96, t103, t114_eval_order_binary_arith, t115_eval_order_compare, t116 |
+| VariableDecl   | Variable/const declarations, scope, type errors | t15, t56, t57, t101, t102 |
+| IfElse         | Conditional branches                         | t44, t45, t46 |
+| WhileLoop      | While loops and while-in construct           | t23, t34, t35, t105, t107, t108 |
+| ForLoop        | For-in loops                                 | t48, t104 |
+| InfiniteLoop   | `loop { ... break }` (infinite loop + break) | t25, t106 |
+| DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
+| Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject |
+| Array          | Array literals and array-of-result           | t33, t112 |
+| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41 |
+| Unary          | Unary operators (negation, etc.)             | t96 |
+| Cast           | Explicit type casts (no fixtures yet in 0.1 matrix) | — |
+| FloatOps       | f64 operations                               | t55 |
+| BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
+| Other          | Enums, generics, when-blocks, handles, macros, imports, Result/try, string interp, semicolons, copy semantics, and any fixture not matching a named category | t09–t22, t24, t27–t32, t37–t38, t42, t47, t49, t51–t54, t58–t76, t81–t88, t97–t100, t111 |
+
+Fixtures not explicitly listed in `feature_of()` fall into `Other`.
+
+---
+
+## 2. PASS / SKIP / PARITY_FAIL Semantics
+
+Each fixture is run through `Cx_0V --backend=cranelift <fixture>` as a
+subprocess. The outcome is classified as follows:
+
+### SKIP
+
+A fixture is SKIP when the JIT backend could not compile or execute it due to
+an unsupported construct. Two signals indicate SKIP:
+
+1. **Exit code 127** (`JitExitCode::UNSUPPORTED_CONSTRUCT`): the binary
+   propagated the unsupported-construct sentinel to the process exit code.
+   This is the forward-compatible path once the binary is updated to call
+   `std::process::exit(127)` on JIT codegen failure.
+
+2. **Exit code 0 with non-empty stderr**: the IR lowering or JIT codegen step
+   failed, printed an error message to stderr, and returned without running the
+   Cx program. The process exits 0 because `CraneliftBackend::execute` returns
+   `Err(msg)` which is logged via `eprintln!` in `main.rs` without setting an
+   exit code. A non-empty stderr distinguishes this from a successful JIT run
+   that produced no stdout output. Expected-fail (semantic-error) fixtures take
+   a different path — they fail before reaching the JIT and exit non-zero via
+   `std::process::exit(1)` — so they are not mistakenly classified as SKIP.
+
+SKIP is not a failure. It records that the JIT has not yet gained coverage for
+that construct and is expected during early Phase 12–14 development.
+
+### PASS
+
+A fixture is PASS when the JIT outcome matches the stored expectation:
+
+- **Expected-fail** fixture: the subprocess exits non-zero (semantic analysis
+  rejected the program, as expected). Both interpreter and JIT reject it.
+- **Pass-any** fixture: the subprocess exits 0 with empty stderr (the JIT ran
+  the program and it returned 0).
+- **Pass-with-output** fixture: the subprocess exits 0 with empty stderr and
+  stdout (after CRLF normalisation and trailing-whitespace trim) matches the
+  stored `.expected_output` content.
+
+### PARITY_FAIL
+
+A fixture is PARITY_FAIL when the JIT outcome diverges from the stored
+expectation and neither SKIP signal is set:
+
+- Expected-fail fixture that the JIT accepted (exit 0, empty stderr)
+- Pass-any fixture that the JIT rejected (exit non-zero, empty stderr)
+- Pass-with-output fixture where stdout does not match (either wrong output or
+  JIT crashed after having already written partial output to stdout)
+
+A non-zero PARITY_FAIL count in any category causes `jit_parity_by_feature`
+to fail. PARITY_FAIL represents a real divergence between the JIT and the
+expected program behavior and must be investigated and fixed.
+
+---
+
+## 3. Current Per-Feature Baseline
+
+Captured from:
+
+```
+cargo build --features jit && cargo test --features jit jit_parity_by_feature --nocapture
+```
+
+Run on branch `stokowski/CX-69` (submain as of CX-69 merge window, 2026-05-09).
+
+```
+Feature                PASS   SKIP  PARITY_FAIL
+------------------------------------------------
+Arithmetic                1     11            0
+VariableDecl              2      3            0
+IfElse                    0      3            0
+WhileLoop                 0      6            0
+ForLoop                   0      2            0
+InfiniteLoop              0      2            0
+DirectCall                5      6            0
+Struct                    2      6            0
+Array                     0      2            0
+CompoundAssign            0      2            0
+Unary                     0      1            0
+Cast                      0      0            0
+FloatOps                  0      1            0
+BuiltinAssert             0      4            0
+Other                    13     48            0
+------------------------------------------------
+Total: 120 fixtures, 0 PARITY_FAILs
+```
+
+### Interpretation
+
+**PASS fixtures** are those where parity is confirmed today:
+
+- **Expected-fail fixtures** in any category exit non-zero (semantic error),
+  matching the expectation. Both interpreter and JIT correctly reject them.
+- A small number of **pass-any fixtures** where the JIT happened to compile
+  and execute successfully (no stderr error, exit 0) also appear as PASS.
+
+**SKIP fixtures** are those where IR lowering or JIT codegen has not yet been
+implemented for the construct used. At this baseline the primary gap is that
+the `print` builtin is not yet lowerable to IR (Phase 9 pending). This affects
+nearly all categories since most verification matrix fixtures call `print`.
+As Phase 9, Phase 14, and subsequent phases land, SKIP counts will decrease
+and PASS counts will increase.
+
+**PARITY_FAIL = 0** across all categories. The gate holds.
+
+**Cast has no fixtures** in the current verification matrix. The category
+exists in the classification to accommodate future fixtures.
+
+---
+
+## 4. Gate Criteria
+
+`jit_parity_by_feature` (in `src/diff_harness.rs`) enforces:
+
+- **Zero PARITY_FAILs** across all feature categories.
+- Any non-zero PARITY_FAIL count causes the test to fail with a diagnostic
+  table showing which categories diverged.
+
+SKIP counts are informational only — they do not cause the test to fail.
+
+Run the gate with:
+
+```
+cargo build --features jit && cargo test --features jit jit_parity_by_feature --nocapture
+```
+
+Or as part of the full suite:
+
+```
+cargo build --features jit && cargo test --features jit
+```
+
+---
+
+## 5. Updating This Document
+
+When new Phase 14+ work lands and JIT coverage expands:
+
+1. Run `cargo test --features jit jit_parity_by_feature --nocapture` to
+   capture the new baseline.
+2. Update the table in Section 3 with the new counts.
+3. Update the interpretation note to reflect which new categories have moved
+   from SKIP to PASS.
+
+When new fixtures are added to the verification matrix, update the
+classification table in Section 1 and the `feature_of()` function in
+`src/diff_harness.rs` to keep every fixture mapped to exactly one category.

--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -18,7 +18,7 @@ set:
 
 | Category       | Description                                  | Key fixtures |
 |----------------|----------------------------------------------|--------------|
-| Arithmetic     | Integer arithmetic, overflow, eval order     | t01, t89–t96, t103, t114_eval_order_binary_arith, t115_eval_order_compare, t116 |
+| Arithmetic     | Integer arithmetic, overflow, eval order     | t01, t89–t95, t103, t114_eval_order_binary_arith, t115_eval_order_compare, t116 |
 | VariableDecl   | Variable/const declarations, scope, type errors | t15, t56, t57, t101, t102 |
 | IfElse         | Conditional branches                         | t44, t45, t46 |
 | WhileLoop      | While loops and while-in construct           | t23, t34, t35, t105, t107, t108 |

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -42,6 +42,195 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+// ── Feature classification ────────────────────────────────────────────────────
+
+/// Language feature categories for the Phase 12 parity checklist.
+///
+/// Each `t*.cx` fixture maps to exactly one category. This mapping lets the
+/// differential harness report per-feature pass / skip / PARITY_FAIL counts
+/// rather than a single aggregate total.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum FeatureCategory {
+    Arithmetic,
+    VariableDecl,
+    IfElse,
+    WhileLoop,
+    ForLoop,
+    InfiniteLoop,
+    DirectCall,
+    Struct,
+    Array,
+    CompoundAssign,
+    Unary,
+    Cast,
+    FloatOps,
+    BuiltinAssert,
+    Other,
+}
+
+impl FeatureCategory {
+    /// All category variants in a stable order for table output.
+    pub fn all() -> &'static [FeatureCategory] {
+        &[
+            FeatureCategory::Arithmetic,
+            FeatureCategory::VariableDecl,
+            FeatureCategory::IfElse,
+            FeatureCategory::WhileLoop,
+            FeatureCategory::ForLoop,
+            FeatureCategory::InfiniteLoop,
+            FeatureCategory::DirectCall,
+            FeatureCategory::Struct,
+            FeatureCategory::Array,
+            FeatureCategory::CompoundAssign,
+            FeatureCategory::Unary,
+            FeatureCategory::Cast,
+            FeatureCategory::FloatOps,
+            FeatureCategory::BuiltinAssert,
+            FeatureCategory::Other,
+        ]
+    }
+}
+
+impl std::fmt::Display for FeatureCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            FeatureCategory::Arithmetic     => "Arithmetic",
+            FeatureCategory::VariableDecl   => "VariableDecl",
+            FeatureCategory::IfElse         => "IfElse",
+            FeatureCategory::WhileLoop      => "WhileLoop",
+            FeatureCategory::ForLoop        => "ForLoop",
+            FeatureCategory::InfiniteLoop   => "InfiniteLoop",
+            FeatureCategory::DirectCall     => "DirectCall",
+            FeatureCategory::Struct         => "Struct",
+            FeatureCategory::Array          => "Array",
+            FeatureCategory::CompoundAssign => "CompoundAssign",
+            FeatureCategory::Unary          => "Unary",
+            FeatureCategory::Cast           => "Cast",
+            FeatureCategory::FloatOps       => "FloatOps",
+            FeatureCategory::BuiltinAssert  => "BuiltinAssert",
+            FeatureCategory::Other          => "Other",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+/// Map a fixture stem (e.g. `"t01_arith_eq_mod"`) to its feature category.
+///
+/// Every `t*.cx` fixture maps to exactly one category. Fixtures not matching
+/// a named entry map to [`FeatureCategory::Other`].
+pub fn feature_of(fixture_name: &str) -> FeatureCategory {
+    match fixture_name {
+        // ── Arithmetic ────────────────────────────────────────────────────────
+        "t01_arith_eq_mod"
+        | "t89_overflow_t8_add"
+        | "t90_overflow_t8_mul"
+        | "t91_overflow_t8_chain"
+        | "t92_overflow_t8_compare"
+        | "t93_overflow_t16_wrap"
+        | "t94_overflow_mixed_widths"
+        | "t95_overflow_t128_unchanged"
+        | "t103_arithmetic_on_strings"
+        | "t114_eval_order_binary_arith"
+        | "t115_eval_order_compare"
+        | "t116_eval_order_nested"
+            => FeatureCategory::Arithmetic,
+
+        // ── VariableDecl ──────────────────────────────────────────────────────
+        "t15_block_scope_shadow"
+        | "t56_const_basic"
+        | "t57_const_reassign_reject"
+        | "t101_undefined_var_hint"
+        | "t102_type_mismatch_uses_cx_names"
+            => FeatureCategory::VariableDecl,
+
+        // ── IfElse ────────────────────────────────────────────────────────────
+        "t44_if_else_basic"
+        | "t45_if_else_in_func"
+        | "t46_if_not"
+            => FeatureCategory::IfElse,
+
+        // ── WhileLoop ─────────────────────────────────────────────────────────
+        "t23_while_loop"
+        | "t34_while_in"
+        | "t35_while_in_then"
+        | "t105_while_in_func"
+        | "t107_continue_in_func"
+        | "t108_nested_loops_in_func"
+            => FeatureCategory::WhileLoop,
+
+        // ── ForLoop ───────────────────────────────────────────────────────────
+        "t48_for_loop"
+        | "t104_for_in_func"
+            => FeatureCategory::ForLoop,
+
+        // ── InfiniteLoop ──────────────────────────────────────────────────────
+        "t25_loop_break"
+        | "t106_loop_break_in_func"
+            => FeatureCategory::InfiniteLoop,
+
+        // ── DirectCall ────────────────────────────────────────────────────────
+        "t02_implicit_return"
+        | "t03_explicit_return"
+        | "t04_wrong_return_type"
+        | "t05_missing_return_value"
+        | "t06_void_unexpected_return"
+        | "t07_arg_count_mismatch"
+        | "t08_arg_type_mismatch"
+        | "t14_nested_5_deep"
+        | "t29_forward_decl"
+        | "t50_nested_func_no_leak"
+        | "t113_recursive_fib"
+            => FeatureCategory::DirectCall,
+
+        // ── Struct ────────────────────────────────────────────────────────────
+        "t36_struct_probe"
+        | "t39_impl_basic"
+        | "t40_impl_return"
+        | "t43_multi_alias_impl"
+        | "t109_struct_field_overflow"
+        | "t110_struct_field_assign_overflow"
+        | "t114_field_type_mismatch_reject"
+        | "t115_strref_in_struct_reject"
+            => FeatureCategory::Struct,
+
+        // ── Array ─────────────────────────────────────────────────────────────
+        "t33_arrays"
+        | "t112_array_of_result"
+            => FeatureCategory::Array,
+
+        // ── CompoundAssign ────────────────────────────────────────────────────
+        "t26_compound_add_two"
+        | "t41_compound_assign_dot"
+            => FeatureCategory::CompoundAssign,
+
+        // ── Unary ─────────────────────────────────────────────────────────────
+        "t96_overflow_t8_unary_neg"
+            => FeatureCategory::Unary,
+
+        // Cast — no fixtures in the current matrix explicitly target casts.
+        // The variant exists for completeness when new cast fixtures are added.
+
+        // ── FloatOps ──────────────────────────────────────────────────────────
+        "t55_f64_basic"
+            => FeatureCategory::FloatOps,
+
+        // ── BuiltinAssert ─────────────────────────────────────────────────────
+        "t77_assert_basic"
+        | "t78_assert_eq_strings"
+        | "t79_assert_false_reject"
+        | "t80_assert_eq_mismatch_reject"
+            => FeatureCategory::BuiltinAssert,
+
+        // ── Other (everything not assigned to a named category) ───────────────
+        _ => FeatureCategory::Other,
+    }
+}
+
+/// Exit code produced by the Cx JIT binary when codegen encounters an
+/// unsupported construct. Matches `JitExitCode::UNSUPPORTED_CONSTRUCT` in
+/// `backend::cranelift::host_boundary`.
+const JIT_SKIP_EXIT_CODE: i32 = 127;
+
 // ── Fixture types ─────────────────────────────────────────────────────────────
 
 /// What the interpreter is expected to do when given this fixture.
@@ -215,6 +404,100 @@ pub fn cx_binary_path() -> PathBuf {
         .join(exe)
 }
 
+// ── JIT subprocess runner ─────────────────────────────────────────────────────
+
+/// Run the Cx binary in JIT mode on `fixture` and return the captured outcome.
+///
+/// Spawns `<binary> --backend=cranelift <fixture_path>` as a subprocess.
+/// An exit code of [`JIT_SKIP_EXIT_CODE`] (127) means codegen encountered an
+/// unsupported construct — callers should count this as SKIP, not PARITY_FAIL.
+///
+/// Requires the binary to have been built with `--features jit`.
+#[cfg(feature = "jit")]
+pub fn run_jit_subprocess(binary: &Path, fixture: &TestFixture) -> InterpOutcome {
+    let output = Command::new(binary)
+        .arg("--backend=cranelift")
+        .arg(&fixture.path)
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "failed to spawn JIT binary {:?} for fixture {:?}: {}",
+                binary, fixture.path, e
+            )
+        });
+
+    InterpOutcome {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code().unwrap_or(-1),
+    }
+}
+
+/// Run all matrix fixtures through the Cranelift JIT subprocess and aggregate
+/// results by [`FeatureCategory`].
+///
+/// Returns a map from category to `(pass, skip, parity_fail)` counts:
+///
+/// - **pass** — JIT outcome matched the stored fixture expectation
+/// - **skip** — JIT subprocess exited with [`JIT_SKIP_EXIT_CODE`] (127);
+///   codegen does not yet support the construct (expected, not a failure)
+/// - **parity_fail** — JIT outcome diverged from the stored expectation
+///
+/// All 15 [`FeatureCategory`] variants are present in the returned map even
+/// when no fixture maps to that category (zero counts).
+#[cfg(feature = "jit")]
+pub fn parity_by_feature(
+    binary: &Path,
+) -> std::collections::HashMap<FeatureCategory, (usize, usize, usize)> {
+    use std::collections::HashMap;
+
+    let fixtures = collect_matrix_tests();
+    let mut map: HashMap<FeatureCategory, (usize, usize, usize)> = HashMap::new();
+    for &cat in FeatureCategory::all() {
+        map.insert(cat, (0, 0, 0));
+    }
+
+    for fixture in &fixtures {
+        let cat = feature_of(&fixture.name);
+        let outcome = run_jit_subprocess(binary, fixture);
+        let entry = map.entry(cat).or_insert((0, 0, 0));
+
+        // Two SKIP signals:
+        //
+        // 1. exit 127 (JIT_SKIP_EXIT_CODE): the binary correctly propagated the
+        //    unsupported-construct sentinel. Included for forward compatibility.
+        //
+        // 2. exit 0 with non-empty stderr: the IR lowering or JIT codegen step
+        //    failed and printed an error message to stderr. The binary always
+        //    exits 0 in this case (the Cx main() never ran); a non-empty stderr
+        //    distinguishes this from a successful run that produced no stdout.
+        //    Expected-fail (semantic-error) fixtures take the same path but exit
+        //    non-zero (std::process::exit(1) in the semantic phase), so they are
+        //    not mistakenly classified as SKIP.
+        if outcome.exit_code == JIT_SKIP_EXIT_CODE
+            || (outcome.exit_code == 0 && !outcome.stderr.is_empty())
+        {
+            entry.1 += 1; // skip
+        } else {
+            let is_parity_fail = match &fixture.expectation {
+                TestExpectation::Fail => outcome.exit_code == 0,
+                TestExpectation::PassAny => outcome.exit_code != 0,
+                TestExpectation::PassWithOutput(expected) => {
+                    outcome.exit_code != 0 || normalise(&outcome.stdout) != *expected
+                }
+            };
+            if is_parity_fail {
+                entry.2 += 1; // PARITY_FAIL
+            } else {
+                entry.0 += 1; // pass
+            }
+        }
+    }
+
+    map
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -384,6 +667,64 @@ mod tests {
             "interpreter_baseline_all: {}/{} fixtures passed",
             fixtures.len(),
             fixtures.len()
+        );
+    }
+
+    // ── JIT parity by feature ─────────────────────────────────────────────────
+
+    /// Per-feature JIT parity gate (Phase 12 checklist).
+    ///
+    /// Runs every matrix fixture through the Cranelift JIT subprocess and
+    /// reports pass / skip / PARITY_FAIL counts per [`FeatureCategory`].
+    ///
+    /// A PARITY_FAIL occurs when the JIT outcome diverges from the stored
+    /// fixture expectation. A SKIP (exit 127) means codegen does not yet
+    /// support the construct — skips are expected and do not fail the test.
+    ///
+    /// Run with:
+    ///
+    /// ```text
+    /// cargo build --features jit && cargo test --features jit jit_parity_by_feature --nocapture
+    /// ```
+    #[test]
+    #[cfg(feature = "jit")]
+    fn jit_parity_by_feature() {
+        let binary = cx_binary_path();
+
+        if !binary.exists() {
+            eprintln!(
+                "SKIP jit_parity_by_feature — binary not found at {:?}.\n\
+                 Build with `cargo build --features jit` then re-run tests.",
+                binary
+            );
+            return;
+        }
+
+        let results = parity_by_feature(&binary);
+
+        println!("\njit_parity_by_feature results:");
+        println!("{:<20} {:>6} {:>6} {:>12}", "Feature", "PASS", "SKIP", "PARITY_FAIL");
+        println!("{}", "-".repeat(48));
+        for cat in FeatureCategory::all() {
+            let (pass, skip, fail) = results[cat];
+            println!("{:<20} {:>6} {:>6} {:>12}", cat, pass, skip, fail);
+        }
+        println!("{}", "-".repeat(48));
+
+        let total: usize = results.values().map(|(p, s, f)| p + s + f).sum();
+        let total_fail: usize = results.values().map(|(_, _, f)| *f).sum();
+
+        assert_eq!(
+            total_fail,
+            0,
+            "{} PARITY_FAIL(s) detected across all feature categories (see table above)",
+            total_fail
+        );
+
+        eprintln!(
+            "jit_parity_by_feature: {} fixtures checked across {} feature categories, 0 PARITY_FAILs",
+            total,
+            results.len()
         );
     }
 }


### PR DESCRIPTION
Closes CX-69

## Summary

- Adds `FeatureCategory` enum (15 variants: Arithmetic, VariableDecl, IfElse, WhileLoop, ForLoop, InfiniteLoop, DirectCall, Struct, Array, CompoundAssign, Unary, Cast, FloatOps, BuiltinAssert, Other) to `src/diff_harness.rs`
- Adds `feature_of(fixture_name: &str) -> FeatureCategory` — static mapping of all 120 `t*.cx` fixtures to exactly one category
- Adds `JIT_SKIP_EXIT_CODE = 127` constant (matches `JitExitCode::UNSUPPORTED_CONSTRUCT` in `host_boundary.rs`)
- Adds `run_jit_subprocess()` (gated `#[cfg(feature = "jit")]`) — spawns `Cx_0V --backend=cranelift <fixture>` subprocess exactly as `run_interpreter` does for the interpreter baseline
- Adds `parity_by_feature(binary: &Path) -> HashMap<FeatureCategory, (pass, skip, fail)>` (gated) — runs all fixtures through JIT and aggregates per-category
- Adds `#[test] fn jit_parity_by_feature` (gated `#[cfg(feature = "jit")]`) — prints per-feature table and asserts zero PARITY_FAILs
- Creates `docs/backend/cx_jit_parity_checklist.md` with classification table, PASS/SKIP/PARITY_FAIL semantics, and real baseline

## SKIP Detection Design

The JIT binary currently exits 0 even for unsupported constructs (IR lowering or JIT codegen failures go through `eprintln!` + implicit return, not `std::process::exit(127)`). SKIP is therefore detected via two signals:

1. **Exit code 127** (`JIT_SKIP_EXIT_CODE`) — forward-compatible for when the binary correctly propagates the sentinel
2. **Exit code 0 with non-empty stderr** — current behavior: lowering/codegen error is printed to stderr, process exits 0. Expected-fail fixtures take a different path (exit 1 from `std::process::exit(1)` in the semantic phase) so they are not falsely classified as SKIP.

No changes to `run_jit()`, `run_interpreter()`, or the sentinel value (127).

## Files Changed

- `src/diff_harness.rs` — 341 lines added (FeatureCategory, feature_of, JIT_SKIP_EXIT_CODE, run_jit_subprocess, parity_by_feature, jit_parity_by_feature test)
- `docs/backend/cx_jit_parity_checklist.md` — new file (classification scheme, baseline, gate criteria)

## Validation

```
cargo build --features jit   → OK, zero new warnings
cargo test --features jit    → 212 passed, 0 failed
```

Specific gate:
```
cargo test --features jit jit_parity_by_feature --nocapture
```

Result (2026-05-09 baseline, submain at CX-69 merge window):
```
Feature                PASS   SKIP  PARITY_FAIL
------------------------------------------------
Arithmetic                1     11            0
VariableDecl              2      3            0
IfElse                    0      3            0
WhileLoop                 0      6            0
ForLoop                   0      2            0
InfiniteLoop              0      2            0
DirectCall                5      6            0
Struct                    2      6            0
Array                     0      2            0
CompoundAssign            0      2            0
Unary                     0      1            0
Cast                      0      0            0
FloatOps                  0      1            0
BuiltinAssert             0      4            0
Other                    13     48            0
------------------------------------------------
120 fixtures, 0 PARITY_FAILs
```

SKIP counts reflect current JIT scope (print builtin not yet lowerable to IR, Phase 9 pending). PASS counts are expected-fail fixtures correctly rejected at semantic phase plus any fixtures the JIT can already compile end-to-end. Zero PARITY_FAILs = gate holds.

## Linear Ticket

CX-69: https://linear.app/cx-lang/issue/CX-69/add-per-feature-parity-classification-to-jit-differential-harness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 12 CX JIT parity checklist documenting baseline test metrics, per-fixture feature classification, gate semantics (PASS/SKIP/PARITY_FAIL), and guidance for future Phase updates.

* **Tests**
  * Added a JIT parity test that runs the JIT backend against interpreter expectations, reports per-feature-category PASS/SKIP/PARITY_FAIL counts, and enforces zero parity failures across categories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/111)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->