### PR TITLE
CX-48: Lower assert and assert_eq to abort-on-failure through IR and Cranelift JIT

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -231,7 +231,7 @@ impl std::fmt::Display for JitExecutionError {
 /// The differential harness captures this output by running the compiler as a subprocess.
 /// In-process pipe redirection is a post-scaffold enhancement.
 ///
-/// ## Supported Instructions (Phase 14 sub-packets 1, 2, and 3; Phase 15 float compare)
+/// ## Supported Instructions (Phase 14 sub-packets 1, 2, and 3; Phase 15 float compare; Phase 9 sub-packet 3)
 ///
 /// The JIT implementation (enabled with the `jit` feature) supports:
 /// - `ConstInt` (types: I8, I16, I32, I64 — not I128)
@@ -246,6 +246,7 @@ impl std::fmt::Display for JitExecutionError {
 ///
 /// - `Jump` (unconditional block transfer with optional block-param arguments)
 /// - `Branch` (two-way conditional branch using `brif`, with block-param arguments on both edges)
+/// - `Trap` (unconditional abort — assertion-failure terminator; lowers to Cranelift `trap`)
 ///
 /// Multi-block functions are supported including back-edge control flow (loops).
 ///
@@ -403,7 +404,7 @@ fn build_cl_signature<M: cranelift_module::Module>(
 
 /// Emit Cranelift IR instructions for a single [`IrFunction`] into `builder`.
 ///
-/// Supported instructions (Phase 14 sub-packets 1, 2, and 3; Phase 15 float compare):
+/// Supported instructions (Phase 14 sub-packets 1, 2, and 3; Phase 15 float compare; Phase 9 sub-packet 3):
 /// - [`IrInst::ConstInt`] — integer constants for I8/I16/I32/I64 (not I128)
 /// - [`IrInst::ConstFloat`] — F64 constants via Cranelift `f64const`
 /// - [`IrInst::Binary`] — signed integer arithmetic: Add, Sub, Mul, Div, Rem (integer types only)
@@ -415,6 +416,7 @@ fn build_cl_signature<M: cranelift_module::Module>(
 /// - [`IrTerminator::Return`] — return with or without a value
 /// - [`IrTerminator::Jump`] — unconditional branch with optional block-param arguments
 /// - [`IrTerminator::Branch`] — two-way conditional branch (`brif`) with block-param arguments
+/// - [`IrTerminator::Trap`] — unconditional abort (assertion-failure); lowers to Cranelift `trap`
 ///
 /// Block sealing strategy: all blocks are sealed at once with `seal_all_blocks()` after all
 /// instructions and terminators have been emitted.  This is safe for any control-flow graph
@@ -706,6 +708,13 @@ fn compile_ir_function(
                     })
                     .collect::<Result<_, _>>()?;
                 builder.ins().brif(cond_val, then_cl, &then_cl_args, else_cl, &else_cl_args);
+            }
+            IrTerminator::Trap => {
+                use cranelift_codegen::ir::TrapCode;
+                // User trap code 1 = assertion failure.
+                // TrapCode::unwrap_user panics at compile time if the code is 0 or reserved;
+                // code 1 is always valid (reserved range starts at 251).
+                builder.ins().trap(TrapCode::unwrap_user(1));
             }
         }
     }
@@ -1502,6 +1511,130 @@ mod jit_tests {
         let r = HostBoundary::new().execute(&m);
         assert!(r.is_ok(), "JIT failed: {:?}", r.unwrap_err());
         assert_eq!(r.unwrap().exit_code.raw(), 1);
+    }
+
+    // ── Trap terminator tests ────────────────────────────────────────────────
+
+    #[test]
+    fn jit_trap_in_dead_else_branch_compiles_and_passes() {
+        // Verify that a Trap terminator compiles correctly via Cranelift.
+        // The Trap block is NEVER executed at runtime (the branch condition is
+        // always true), so this test is safe to run in-process.
+        //
+        // CFG:
+        //   block0:
+        //     v0 = const Bool 1    // always true
+        //     branch v0, block1, block2
+        //   block1:               // taken: condition was true
+        //     v1 = const I32 0
+        //     return v1            // → exit code 0
+        //   block2:               // unreachable — Trap (assertion failure path)
+        //     trap
+        let module = IrModule {
+            debug_name: "test_trap_dead".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::Bool,
+                            value: 1,
+                        }],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(0),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(1),
+                            ty: IrType::I32,
+                            value: 0,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(1)) },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Trap,
+                    },
+                ],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 0);
+    }
+
+    #[test]
+    fn jit_assert_pattern_passes_when_condition_is_true() {
+        // Models: assert(1 == 1)
+        // IR: compare 1 == 1 → Bool, branch on result:
+        //   true  → return 0 (pass)
+        //   false → Trap (assertion failure)
+        // Expected: returns 0 (condition is satisfied).
+        use crate::ir::instr::CompareOp;
+        let module = IrModule {
+            debug_name: "test_assert_true".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 1 },
+                            IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 1 },
+                            IrInst::Compare {
+                                dst: ValueId(2),
+                                op: CompareOp::Eq,
+                                lhs: ValueId(0),
+                                rhs: ValueId(1),
+                            },
+                        ],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(2),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(3),
+                            ty: IrType::I32,
+                            value: 0,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Trap,
+                    },
+                ],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 0);
     }
 
     #[test]

--- a/src/backend/cranelift/mod.rs
+++ b/src/backend/cranelift/mod.rs
@@ -230,6 +230,12 @@ fn lower_terminator(term: &IrTerminator) -> Result<(), CraneliftLoweringError> {
                 context: format!("value={value:?}"),
             })
         }
+        IrTerminator::Trap => {
+            Err(CraneliftLoweringError::UnsupportedTerminator {
+                term: "Trap".to_string(),
+                context: "assertion-failure abort".to_string(),
+            })
+        }
     }
 }
 

--- a/src/ir/instr.rs
+++ b/src/ir/instr.rs
@@ -115,6 +115,12 @@ pub enum IrTerminator {
     Return {
         value: Option<ValueId>,
     },
+    /// Unconditional abort — emitted for assertion failures.
+    ///
+    /// In the JIT backend this lowers to a Cranelift `trap` instruction,
+    /// which raises a hardware fault and terminates the process.  No values
+    /// are consumed and no successor block exists.
+    Trap,
 }
 
 #[cfg(test)]
@@ -147,6 +153,15 @@ mod tests {
             }
             other => panic!("unexpected instruction variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn trap_terminator_is_distinct_from_other_variants() {
+        let term = IrTerminator::Trap;
+        assert!(matches!(term, IrTerminator::Trap));
+        assert!(!matches!(term, IrTerminator::Return { .. }));
+        assert!(!matches!(term, IrTerminator::Jump { .. }));
+        assert!(!matches!(term, IrTerminator::Branch { .. }));
     }
 
     #[test]

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -92,10 +92,13 @@ impl std::error::Error for LoweringError {}
 // When Phase 9 sub-packet 2 lands, each builtin here will be replaced by a
 // concrete `IrIntrinsic` opcode or a runtime-call ABI signature — at which
 // point this function will shrink until it is empty.
+//
+// Note: `assert` and `assert_eq` are NOT listed here — they are now fully
+// lowerable to IR (Phase 9 sub-packet 3) and are handled before this gate.
 fn is_cx_builtin(name: &str) -> bool {
     matches!(
         name,
-        "print" | "println" | "printn" | "read" | "input" | "assert" | "assert_eq"
+        "print" | "println" | "printn" | "read" | "input"
     )
 }
 
@@ -601,7 +604,17 @@ fn lower_stmt(
             Ok(Some(current))
         }
         SemanticStmt::ExprStmt { expr, .. } => {
-            // Builtin intrinsics (print, assert, etc.) are not in the signature_table.
+            // Phase 9 sub-packet 3: assert and assert_eq are now fully lowerable.
+            // Intercept them before the is_cx_builtin gate so they are routed to
+            // the dedicated lowering functions rather than returning a structured error.
+            if let SemanticExprKind::Call { callee, args, .. } = &expr.kind {
+                match callee.as_str() {
+                    "assert" => return lower_assert_stmt(args, ctx, current),
+                    "assert_eq" => return lower_assert_eq_stmt(args, ctx, current),
+                    _ => {}
+                }
+            }
+            // Builtin intrinsics (print, etc.) are not in the signature_table.
             // Intercept them here so they produce a structured UnsupportedSemanticConstruct
             // rather than falling through to a misleading UnresolvedSemanticArtifact.
             if let SemanticExprKind::Call { callee, .. } = &expr.kind {
@@ -1504,9 +1517,12 @@ fn lower_expr(
             })
         }
         SemanticExprKind::Call { callee, function: _, args } => {
-            // Builtin intrinsics (print, assert, etc.) are not in the signature_table.
-            // Intercept them before the lookup so the error is structured and actionable
-            // rather than the generic UnresolvedSemanticArtifact produced by a table miss.
+            // Remaining builtin intrinsics (print, println, printn, read, input) are not
+            // in the signature_table.  Intercept them before the lookup so the error is
+            // structured and actionable rather than the generic UnresolvedSemanticArtifact
+            // produced by a table miss.
+            // Note: assert/assert_eq are handled at statement level and should not reach
+            // lower_expr in well-formed programs.
             if is_cx_builtin(callee) {
                 return Err(LoweringError::UnsupportedSemanticConstruct {
                     construct: format!(
@@ -2379,6 +2395,210 @@ fn ensure_type_match(context: &str, expected: IrType, got: IrType) -> Result<(),
             ),
         })
     }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 9 sub-packet 3 — assert / assert_eq lowering
+// ---------------------------------------------------------------------------
+//
+// Both builtins are lowered to a two-branch CFG pattern:
+//
+//   [current block]
+//     ... condition computation ...
+//     Branch { cond, then: pass_block, else: trap_block }
+//
+//   [pass_block]          ← execution continues here after a passing assertion
+//     (empty — caller receives this as the new current block)
+//
+//   [trap_block]
+//     Trap                ← abort; maps to Cranelift `trap` in the JIT backend
+//
+// Supported condition types:
+//   - Bool    → used directly as the branch condition
+//   - I8/I16/I32/I64 → compared != 0 to produce Bool (truthy-integer assert)
+//   - Bool/I8/I16/I32/I64 for assert_eq → compared with Eq to produce Bool
+//
+// Unsupported types (e.g. Ptr, F64, StrRef) produce a structured
+// UnsupportedSemanticConstruct error so the caller gets a clear diagnostic.
+
+/// Lower `assert(cond)` as a void statement.
+///
+/// Emits a two-way branch: the pass branch continues execution; the fail
+/// branch terminates with [`IrTerminator::Trap`].  Returns the pass block
+/// as the new active block so lowering of subsequent statements continues
+/// in the correct CFG position.
+fn lower_assert_stmt(
+    args: &[SemanticCallArg],
+    ctx: &mut LoweringCtx,
+    mut current: ActiveBlock,
+) -> Result<Option<ActiveBlock>, LoweringError> {
+    if args.len() != 1 {
+        return Err(LoweringError::InternalInvariantViolation {
+            detail: format!("assert expects 1 argument, got {}", args.len()),
+        });
+    }
+
+    let cond_expr = match &args[0] {
+        SemanticCallArg::Expr(e) => e,
+        _ => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: "non-Expr argument to assert".to_string(),
+            });
+        }
+    };
+
+    let cond = lower_expr(cond_expr, ctx, &mut current)?;
+
+    // Coerce the condition to Bool (IrType::Bool is the required Branch type).
+    let bool_val = coerce_to_bool(cond, ctx, &mut current)?;
+
+    emit_assert_branch(bool_val, ctx, current)
+}
+
+/// Lower `assert_eq(lhs, rhs)` as a void statement.
+///
+/// Emits a Compare(Eq) followed by the same two-way branch pattern as
+/// [`lower_assert_stmt`].  Both operands must have the same IR type and that
+/// type must be equality-comparable (Bool or integer).
+fn lower_assert_eq_stmt(
+    args: &[SemanticCallArg],
+    ctx: &mut LoweringCtx,
+    mut current: ActiveBlock,
+) -> Result<Option<ActiveBlock>, LoweringError> {
+    if args.len() != 2 {
+        return Err(LoweringError::InternalInvariantViolation {
+            detail: format!("assert_eq expects 2 arguments, got {}", args.len()),
+        });
+    }
+
+    let lhs_expr = match &args[0] {
+        SemanticCallArg::Expr(e) => e,
+        _ => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: "non-Expr first argument to assert_eq".to_string(),
+            });
+        }
+    };
+    let rhs_expr = match &args[1] {
+        SemanticCallArg::Expr(e) => e,
+        _ => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: "non-Expr second argument to assert_eq".to_string(),
+            });
+        }
+    };
+
+    let lhs = lower_expr(lhs_expr, ctx, &mut current)?;
+    let rhs = lower_expr(rhs_expr, ctx, &mut current)?;
+
+    if lhs.ty != rhs.ty {
+        return Err(LoweringError::UnsupportedSemanticConstruct {
+            construct: format!(
+                "assert_eq: lhs has type {:?}, rhs has type {:?} — operand types must match",
+                lhs.ty, rhs.ty
+            ),
+        });
+    }
+
+    // Validate that the type supports equality comparison.
+    match &lhs.ty {
+        IrType::Bool
+        | IrType::I8
+        | IrType::I16
+        | IrType::I32
+        | IrType::I64 => {}
+        other => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: format!(
+                    "assert_eq: type {:?} is not supported for equality comparison in the IR backend",
+                    other
+                ),
+            });
+        }
+    }
+
+    let cmp_dst = ctx.fresh_value();
+    current.emit(IrInst::Compare {
+        dst: cmp_dst,
+        op: CompareOp::Eq,
+        lhs: lhs.value,
+        rhs: rhs.value,
+    })?;
+
+    emit_assert_branch(cmp_dst, ctx, current)
+}
+
+/// Coerce a [`LoweredValue`] to `IrType::Bool` for use as a branch condition.
+///
+/// - If the value is already `Bool`, it is returned unchanged.
+/// - If the value is an integer type (`I8`/`I16`/`I32`/`I64`), a
+///   `Compare { Ne, value, 0 }` is emitted to produce a `Bool` result
+///   (truthy semantics: any non-zero integer is true).
+/// - All other types produce an `UnsupportedSemanticConstruct` error.
+fn coerce_to_bool(
+    val: LoweredValue,
+    ctx: &mut LoweringCtx,
+    active: &mut ActiveBlock,
+) -> Result<ValueId, LoweringError> {
+    match &val.ty {
+        IrType::Bool => Ok(val.value),
+        IrType::I8 | IrType::I16 | IrType::I32 | IrType::I64 => {
+            let zero = ctx.fresh_value();
+            active.emit(IrInst::ConstInt {
+                dst: zero,
+                ty: val.ty.clone(),
+                value: 0,
+            })?;
+            let cmp_dst = ctx.fresh_value();
+            active.emit(IrInst::Compare {
+                dst: cmp_dst,
+                op: CompareOp::Ne,
+                lhs: val.value,
+                rhs: zero,
+            })?;
+            Ok(cmp_dst)
+        }
+        other => Err(LoweringError::UnsupportedSemanticConstruct {
+            construct: format!(
+                "assert condition of type {:?} is not supported in the IR backend",
+                other
+            ),
+        }),
+    }
+}
+
+/// Emit the common Branch + Trap pattern for assertions.
+///
+/// Terminates `current` with a [`IrTerminator::Branch`] on `bool_val`:
+/// - true  → `pass_block` (continues execution; returned as new current)
+/// - false → `trap_block` (terminated with [`IrTerminator::Trap`])
+fn emit_assert_branch(
+    bool_val: ValueId,
+    ctx: &mut LoweringCtx,
+    current: ActiveBlock,
+) -> Result<Option<ActiveBlock>, LoweringError> {
+    let incoming = current.bindings.clone();
+
+    let pass_active = ctx.start_block(vec![], incoming.clone());
+    let pass_block_id = pass_active.id();
+
+    let mut trap_active = ctx.start_block(vec![], incoming);
+    let trap_block_id = trap_active.id();
+
+    let mut current = current;
+    current.terminate(IrTerminator::Branch {
+        cond: bool_val,
+        then_block: pass_block_id,
+        then_args: vec![],
+        else_block: trap_block_id,
+        else_args: vec![],
+    })?;
+    ctx.seal_block(current)?;
+
+    trap_active.terminate(IrTerminator::Trap)?;
+    ctx.seal_block(trap_active)?;
+
+    Ok(Some(pass_active))
 }
 
 /// Lower a void function call as a standalone statement.
@@ -5280,14 +5500,133 @@ mod tests {
         assert_builtin_structured_error("printn");
     }
 
+    // assert and assert_eq are now lowerable (Phase 9 sub-packet 3) so they no
+    // longer trigger the is_cx_builtin gate.  The tests below verify that they
+    // lower correctly to multi-block CFGs with a Trap terminator.
+
     #[test]
-    fn builtin_assert_produces_unsupported_construct_not_unresolved_artifact() {
-        assert_builtin_structured_error("assert");
+    fn assert_true_lowers_to_validated_multi_block_cfg() {
+        // assert(true) → Branch on Bool 1 (pass) / Trap (fail, never taken)
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt("assert", vec![SemanticCallArg::Expr(bool_expr(true))])],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        // Synthetic main must have at least 3 blocks: decision, pass, trap.
+        assert!(
+            module.functions[0].blocks.len() >= 3,
+            "expected at least 3 blocks, got {}",
+            module.functions[0].blocks.len()
+        );
+        // At least one Trap terminator must exist.
+        let has_trap = module.functions[0]
+            .blocks
+            .iter()
+            .any(|b| matches!(b.term, IrTerminator::Trap));
+        assert!(has_trap, "expected a Trap block in the CFG");
     }
 
     #[test]
-    fn builtin_assert_eq_produces_unsupported_construct_not_unresolved_artifact() {
-        assert_builtin_structured_error("assert_eq");
+    fn assert_integer_one_lowers_via_truthy_coercion() {
+        // assert(1) → Compare(Ne, 1, 0) → Branch → Trap on false
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "assert",
+                vec![SemanticCallArg::Expr(int_expr(1, SemanticType::I64))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        // Must contain a Compare(Ne) to coerce the integer to Bool.
+        let has_ne_compare = module.functions[0].blocks.iter().any(|b| {
+            b.insts.iter().any(|inst| {
+                matches!(inst, IrInst::Compare { op: CompareOp::Ne, .. })
+            })
+        });
+        assert!(has_ne_compare, "expected a Ne Compare for truthy-integer coercion");
+        let has_trap = module.functions[0]
+            .blocks
+            .iter()
+            .any(|b| matches!(b.term, IrTerminator::Trap));
+        assert!(has_trap, "expected a Trap block in the CFG");
+    }
+
+    #[test]
+    fn assert_eq_same_integers_lowers_to_validated_cfg() {
+        // assert_eq(1, 1) → Compare(Eq) → Branch → Trap on false
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "assert_eq",
+                vec![
+                    SemanticCallArg::Expr(int_expr(1, SemanticType::I64)),
+                    SemanticCallArg::Expr(int_expr(1, SemanticType::I64)),
+                ],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let has_eq_compare = module.functions[0].blocks.iter().any(|b| {
+            b.insts.iter().any(|inst| {
+                matches!(inst, IrInst::Compare { op: CompareOp::Eq, .. })
+            })
+        });
+        assert!(has_eq_compare, "expected an Eq Compare for assert_eq");
+        let has_trap = module.functions[0]
+            .blocks
+            .iter()
+            .any(|b| matches!(b.term, IrTerminator::Trap));
+        assert!(has_trap, "expected a Trap block in the CFG");
+    }
+
+    #[test]
+    fn assert_eq_bool_true_true_lowers_to_validated_cfg() {
+        // assert_eq(true, true) → Compare(Eq, Bool, Bool) → Branch → Trap on false
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "assert_eq",
+                vec![
+                    SemanticCallArg::Expr(bool_expr(true)),
+                    SemanticCallArg::Expr(bool_expr(true)),
+                ],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let has_trap = module.functions[0]
+            .blocks
+            .iter()
+            .any(|b| matches!(b.term, IrTerminator::Trap));
+        assert!(has_trap, "expected a Trap block in the CFG");
+    }
+
+    #[test]
+    fn assert_with_wrong_arity_produces_invariant_violation() {
+        // assert() with 0 args → InternalInvariantViolation (arity check)
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt("assert", vec![])],
+            enums: vec![],
+        };
+        let err = lower_program(&program).unwrap_err();
+        assert!(
+            matches!(err, LoweringError::InternalInvariantViolation { .. }),
+            "expected InternalInvariantViolation for wrong assert arity, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn assert_eq_with_wrong_arity_produces_invariant_violation() {
+        // assert_eq() with 0 args → InternalInvariantViolation
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt("assert_eq", vec![])],
+            enums: vec![],
+        };
+        let err = lower_program(&program).unwrap_err();
+        assert!(
+            matches!(err, LoweringError::InternalInvariantViolation { .. }),
+            "expected InternalInvariantViolation for wrong assert_eq arity, got: {:?}",
+            err
+        );
     }
 
     #[test]

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -178,6 +178,7 @@ pub fn print_terminator(term: &IrTerminator) -> String {
             Some(v) => format!("ret {}", print_value_id(*v)),
             None => "ret".to_string(),
         },
+        IrTerminator::Trap => "trap".to_string(),
     }
 }
 
@@ -286,6 +287,18 @@ mod tests {
 
         let output = print_module(&module);
         assert!(output.contains("v0 = call get_value(v1, v2) -> i64"));
+    }
+
+    #[test]
+    fn prints_trap_terminator() {
+        let block = IrBlock {
+            id: BlockId(5),
+            params: vec![],
+            insts: vec![],
+            term: IrTerminator::Trap,
+        };
+        let output = print_block(&block);
+        assert!(output.contains("trap"), "expected 'trap' in output, got: {}", output);
     }
 
     #[test]

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -635,6 +635,8 @@ fn validate_terminator(
                 );
             }
         }
+        // Trap is an unconditional abort: no values consumed, no successor block.
+        IrTerminator::Trap => {}
     }
 }
 
@@ -1129,6 +1131,72 @@ mod tests {
         assert!(errors
             .iter()
             .any(|err| matches!(err, IrValidationError::InvalidTypeUsage { detail, .. } if detail.contains("expects 1 args"))));
+    }
+
+    #[test]
+    fn accepts_trap_terminator_in_unreachable_else_branch() {
+        // Models an assertion: branch on bool, pass → Return, fail → Trap.
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "f".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::Bool,
+                            value: 1,
+                        }],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(0),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: None },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Trap,
+                    },
+                ],
+            }],
+        };
+
+        assert_eq!(validate_module(&module), Ok(()));
+    }
+
+    #[test]
+    fn accepts_trap_as_sole_terminator_in_single_block_function() {
+        // A function that unconditionally traps is structurally valid IR.
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "always_fails".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![],
+                    term: IrTerminator::Trap,
+                }],
+            }],
+        };
+
+        assert_eq!(validate_module(&module), Ok(()));
     }
 
     #[test]


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-48/cx-48-lower-assert-and-assert-eq-to-abort-on-failure-through-ir-and

## Summary

Rebased clean implementation of assert/assert_eq lowering through IR and Cranelift JIT onto current submain (resolving prior conflict in host_boundary.rs).

- Adds `IrTerminator::Trap` as a new unconditional-abort IR terminator
- Lowers `assert(cond)` to: condition coercion to Bool + `Branch` (pass → continue, fail → `Trap`)
- Lowers `assert_eq(a, b)` to: `Compare(Eq)` + `Branch` (equal → continue, unequal → `Trap`)
- Maps `IrTerminator::Trap` to Cranelift `trap(TrapCode::unwrap_user(1))` in the JIT backend
- Removes `assert` and `assert_eq` from `is_cx_builtin` gate (they are now fully IR-lowerable)

## Supported cases

| Expression | Result |
|---|---|
| `assert(true)` | pass (Bool path — direct) |
| `assert(1)` | pass (integer truthy coercion: `Compare(Ne, val, 0)`) |
| `assert(false)` | trap (process terminates non-zero) |
| `assert_eq(1, 1)` | pass |
| `assert_eq(true, true)` | pass |
| `assert_eq(1, 2)` | trap |

## Files changed

| File | Change |
|---|---|
| `src/ir/instr.rs` | Add `IrTerminator::Trap` variant + test |
| `src/ir/printer.rs` | Print `"trap"` for `Trap` terminator + test |
| `src/ir/validate.rs` | Accept `Trap` in `validate_terminator` + 2 tests |
| `src/backend/cranelift/mod.rs` | Add `Trap` skeleton arm in `lower_terminator` |
| `src/backend/cranelift/host_boundary.rs` | Emit `trap(TrapCode::unwrap_user(1))` in `compile_ir_function` + 2 JIT tests |
| `src/ir/lower.rs` | Add `lower_assert_stmt`, `lower_assert_eq_stmt`, `coerce_to_bool`, `emit_assert_branch`; wire into `ExprStmt`; update `is_cx_builtin` |

## Validation

```
cargo build --features jit   →  Finished (0 errors, 21 pre-existing warnings)
cargo test --features jit    →  240 passed; 0 failed
```

## Linear ticket reference

CX-48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `assert()` and `assert_eq()` builtin functions are now fully supported and compile correctly, aborting execution when assertions fail.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->