### PR TITLE
CX-74: Audit Cranelift CLI exit-code propagation after CX-69

### DIFF
--- a/src/backend/cranelift/mod.rs
+++ b/src/backend/cranelift/mod.rs
@@ -1,4 +1,4 @@
-use crate::backend::Backend;
+use crate::backend::{Backend, BackendError};
 use crate::ir::types::{IrBlock, IrFunction, IrModule, IrType};
 use crate::ir::instr::{IrInst, IrTerminator};
 
@@ -242,28 +242,48 @@ fn lower_terminator(term: &IrTerminator) -> Result<(), CraneliftLoweringError> {
 // ── Backend impl ─────────────────────────────────────────────────────────────
 
 impl Backend for CraneliftBackend {
-    fn execute(&self, module: &IrModule) -> Result<(), String> {
+    fn execute(&self, module: &IrModule) -> Result<(), BackendError> {
         #[cfg(feature = "jit")]
         {
+            use host_boundary::JitExecutionError;
             use jit::run_jit;
             match run_jit(module) {
                 Ok(outcome) => {
                     if outcome.exit_code.is_success() {
                         Ok(())
                     } else {
-                        Err(format!(
-                            "JIT: program exited with code {}",
-                            outcome.exit_code
-                        ))
+                        // Propagate the Cx program's own exit code unchanged.
+                        let code = outcome.exit_code.raw();
+                        Err(BackendError {
+                            message: format!("program exited with code {}", code),
+                            exit_code: code,
+                        })
                     }
                 }
-                Err(e) => Err(e.to_string()),
+                Err(e) => {
+                    let exit_code = match &e {
+                        // 127 = JIT_SKIP_EXIT_CODE: the JIT pipeline cannot handle
+                        // this program.  The differential harness counts this as SKIP.
+                        JitExecutionError::UnsupportedConstruct { .. }
+                        | JitExecutionError::CodegenFailure { .. }
+                        | JitExecutionError::MainNotFound => 127,
+                        // 126 = JIT_RUNTIME_FAILURE: program compiled but crashed.
+                        JitExecutionError::RuntimePanic { .. } => 126,
+                    };
+                    Err(BackendError {
+                        message: e.to_string(),
+                        exit_code,
+                    })
+                }
             }
         }
         #[cfg(not(feature = "jit"))]
         {
             let _ = module;
-            Err("Cranelift backend requires the `jit` feature — rebuild with --features jit".to_string())
+            Err(BackendError {
+                message: "Cranelift backend requires the `jit` feature — rebuild with --features jit".to_string(),
+                exit_code: 1,
+            })
         }
     }
 }
@@ -273,7 +293,102 @@ impl Backend for CraneliftBackend {
 #[cfg(all(test, feature = "jit"))]
 mod tests {
     use super::*;
-    use crate::ir::types::IrType;
+    use crate::backend::Backend;
+    use crate::ir::instr::IrTerminator;
+    use crate::ir::types::{BlockId, IrBlock, IrFunction, IrModule, IrType, ValueId};
+
+    // ── BackendError exit-code propagation tests ─────────────────────────────
+
+    #[test]
+    fn cranelift_backend_unsupported_construct_exits_127() {
+        // IrInst::ConstInt with I128 is explicitly unsupported in the JIT backend.
+        // CraneliftBackend::execute must map UnsupportedConstruct → exit_code 127.
+        use crate::ir::instr::IrInst;
+        let module = IrModule {
+            debug_name: "test_unsupported".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![IrInst::ConstInt {
+                        dst: ValueId(0),
+                        ty: IrType::I128,
+                        value: 0,
+                    }],
+                    term: IrTerminator::Return { value: Some(ValueId(0)) },
+                }],
+            }],
+        };
+        let err = CraneliftBackend.execute(&module).unwrap_err();
+        assert_eq!(
+            err.exit_code, 127,
+            "UnsupportedConstruct must map to exit code 127, got {}",
+            err.exit_code
+        );
+    }
+
+    #[test]
+    fn cranelift_backend_nonzero_program_exit_propagates() {
+        // A Cx program that returns 42 must produce BackendError { exit_code: 42 }.
+        use crate::ir::instr::IrInst;
+        let module = IrModule {
+            debug_name: "test_exit42".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![IrInst::ConstInt {
+                        dst: ValueId(0),
+                        ty: IrType::I32,
+                        value: 42,
+                    }],
+                    term: IrTerminator::Return { value: Some(ValueId(0)) },
+                }],
+            }],
+        };
+        let err = CraneliftBackend.execute(&module).unwrap_err();
+        assert_eq!(
+            err.exit_code, 42,
+            "non-zero Cx program exit must propagate as exit_code, got {}",
+            err.exit_code
+        );
+    }
+
+    #[test]
+    fn cranelift_backend_zero_exit_is_ok() {
+        // A program returning 0 must produce Ok(()) — no error, no exit code.
+        use crate::ir::instr::IrInst;
+        let module = IrModule {
+            debug_name: "test_exit0".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![IrInst::ConstInt {
+                        dst: ValueId(0),
+                        ty: IrType::I32,
+                        value: 0,
+                    }],
+                    term: IrTerminator::Return { value: Some(ValueId(0)) },
+                }],
+            }],
+        };
+        assert!(
+            CraneliftBackend.execute(&module).is_ok(),
+            "program exiting 0 must produce Ok(())"
+        );
+    }
+
+    // ── Type mapping tests ───────────────────────────────────────────────────
 
     /// IrType::Void must produce an error from ir_type_to_cranelift, not a
     /// Cranelift type, because Cranelift has no void type.  Void-return

--- a/src/backend/llvm/mod.rs
+++ b/src/backend/llvm/mod.rs
@@ -1,4 +1,4 @@
-use crate::backend::Backend;
+use crate::backend::{Backend, BackendError};
 use crate::ir::IrModule;
 
 pub mod aot;
@@ -6,7 +6,10 @@ pub mod aot;
 pub struct LlvmBackend;
 
 impl Backend for LlvmBackend {
-    fn execute(&self, _module: &IrModule) -> Result<(), String> {
-        Err("LLVM backend not implemented yet; use --backend=interp".to_string())
+    fn execute(&self, _module: &IrModule) -> Result<(), BackendError> {
+        Err(BackendError {
+            message: "LLVM backend not implemented yet; use --backend=interp".to_string(),
+            exit_code: 1,
+        })
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -11,8 +11,27 @@ pub enum BackendKind {
     Validate,
 }
 
+/// Error returned by [`Backend::execute`].
+///
+/// Carries both a human-readable message and the process exit code the CLI
+/// should propagate.  The caller (main.rs) is responsible for calling
+/// `std::process::exit(exit_code)` — backends never call exit directly.
+///
+/// | Scenario                                                   | exit_code |
+/// |------------------------------------------------------------|-----------|
+/// | Cx program ran and returned N                              | N         |
+/// | JIT can't handle it (unsupported construct, codegen gap,   |           |
+/// |   missing main, or IR lowering failure)                    | 127       |
+/// | JIT runtime panic / trap                                   | 126       |
+/// | LLVM or other non-JIT backend failure                      | 1         |
+#[derive(Debug, Clone)]
+pub struct BackendError {
+    pub message: String,
+    pub exit_code: i32,
+}
+
 pub trait Backend {
-    fn execute(&self, module: &crate::ir::IrModule) -> Result<(), String>;
+    fn execute(&self, module: &crate::ir::IrModule) -> Result<(), BackendError>;
 }
 
 pub fn parse_backend_flag(args: &[String]) -> BackendKind {

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -501,16 +501,15 @@ pub fn parity_by_feature(
 
         // Two SKIP signals:
         //
-        // 1. exit 127 (JIT_SKIP_EXIT_CODE): the binary correctly propagated the
-        //    unsupported-construct sentinel. Included for forward compatibility.
+        // 1. exit 127 (JIT_SKIP_EXIT_CODE): the binary propagated the
+        //    unsupported-construct sentinel (JitExitCode::UNSUPPORTED_CONSTRUCT).
+        //    This is the canonical SKIP path after CX-74.
         //
-        // 2. exit 0 with non-empty stderr: the IR lowering or JIT codegen step
-        //    failed and printed an error message to stderr. The binary always
-        //    exits 0 in this case (the Cx main() never ran); a non-empty stderr
-        //    distinguishes this from a successful run that produced no stdout.
-        //    Expected-fail (semantic-error) fixtures take the same path but exit
-        //    non-zero (std::process::exit(1) in the semantic phase), so they are
-        //    not mistakenly classified as SKIP.
+        // 2. exit 0 with non-empty stderr: legacy fallback retained for safety.
+        //    Before CX-74 this fired when IR lowering or JIT codegen failed
+        //    without propagating a non-zero exit code.  After CX-74 all error
+        //    paths in main.rs propagate non-zero exit codes, so this condition
+        //    should no longer fire in practice.
         if outcome.exit_code == JIT_SKIP_EXIT_CODE
             || (outcome.exit_code == 0 && !outcome.stderr.is_empty())
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,15 +229,19 @@ fn run() {
                 Ok(ir) => ir,
                 Err(err) => {
                     eprintln!("{}", err);
-                    return;
+                    // IR lowering failure = this Cx program uses a feature the JIT
+                    // pipeline does not yet lower.  Exit 127 so the differential
+                    // harness counts it as SKIP (unsupported construct), not PARITY_FAIL.
+                    std::process::exit(127);
                 }
             };
             if flags.trace {
                 println!("{}", crate::ir::printer::print_module(&ir));
             }
             let b = backend::cranelift::CraneliftBackend;
-            if let Err(msg) = b.execute(&ir) {
-                eprintln!("{}", msg);
+            if let Err(err) = b.execute(&ir) {
+                eprintln!("{}", err.message);
+                std::process::exit(err.exit_code);
             }
         }
         backend::BackendKind::Llvm => {
@@ -245,12 +249,13 @@ fn run() {
                 Ok(ir) => ir,
                 Err(err) => {
                     eprintln!("{}", err);
-                    return;
+                    std::process::exit(1);
                 }
             };
             let b = backend::llvm::LlvmBackend;
-            if let Err(msg) = b.execute(&ir) {
-                eprintln!("{}", msg);
+            if let Err(err) = b.execute(&ir) {
+                eprintln!("{}", err.message);
+                std::process::exit(err.exit_code);
             }
         }
         backend::BackendKind::Validate => {
@@ -258,7 +263,7 @@ fn run() {
                 Ok(ir) => ir,
                 Err(err) => {
                     eprintln!("Lowering failed: {}", err);
-                    return;
+                    std::process::exit(1);
                 }
             };
             match crate::ir::validate::validate_module(&ir) {
@@ -272,6 +277,7 @@ fn run() {
                     for e in &errors {
                         eprintln!("  {:?}", e);
                     }
+                    std::process::exit(1);
                 }
             }
         }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-74

## Summary

- Adds `BackendError { message, exit_code }` to the `Backend` trait so structured exit codes flow from JIT to CLI without string parsing
- Maps all "JIT can't handle this" failure modes to exit 127 (`JIT_SKIP_EXIT_CODE`): `UnsupportedConstruct`, `CodegenFailure`, `MainNotFound`, and `prepare_ir()` failure in the Cranelift CLI path
- Maps `RuntimePanic` to exit 126 (`JIT_RUNTIME_FAILURE`) for future use
- Propagates non-zero Cx program exit codes unchanged through the Backend trait boundary
- Fixes 6 silent `return;` / no-exit paths in `main.rs` that previously caused all backend errors to silently exit 0
- Updates `diff_harness.rs` SKIP comment: signal-1 (exit 127) is now canonical; signal-2 (exit 0 + stderr) is a legacy safety net
- Adds 3 new `BackendError` exit-code tests in `cranelift/mod.rs`

## Files Changed

| File | Change |
|------|--------|
| `src/backend/mod.rs` | Add `BackendError` struct; update `Backend` trait return type |
| `src/backend/cranelift/mod.rs` | Map `JitExecutionError` variants to exit codes; add 3 tests |
| `src/backend/llvm/mod.rs` | Update `LlvmBackend::execute` to return `BackendError` |
| `src/main.rs` | Fix `return` → `exit(1)`/`exit(127)`; propagate `BackendError::exit_code` |
| `src/diff_harness.rs` | Update SKIP-detection comment |

## Exit Code Map (after this PR)

| Scenario | Exit Code |
|----------|-----------|
| Compilation error (lex/parse/semantic) | 1 |
| IR lowering failure (Cranelift path) | 127 |
| JIT unsupported construct / codegen gap / no main | 127 |
| JIT runtime panic / trap (future) | 126 |
| Cx program exited with code N | N |
| LLVM/other backend not implemented | 1 |

## Notes on JIT Trap Handling

`JitExecutionError::RuntimePanic` (exit 126) is defined and wired in `CraneliftBackend::execute`, but cranelift-jit on Linux uses OS-level SIGILL for traps rather than Rust panics — `std::panic::catch_unwind` does not intercept them. JIT assertion failures currently propagate as SIGILL to the host process. This is a known limitation documented for a future phase.

## Tests Run

```
cargo build --features jit   → OK (21 pre-existing warnings, no new)
cargo test --features jit    → 243 passed, 0 failed
jit_parity_by_feature        → 0 PARITY_FAILs
                               (fixtures previously SKIPped via exit-0+stderr now SKIP via exit-127)
```

## Linear Ticket

CX-74 — https://linear.app/cx-lang/issue/CX-74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Improved error handling with consistent exit codes across the compiler backend, enabling better automation and scripting support.
  * Standardized error messaging and exit code mapping for different failure scenarios (unsupported constructs, runtime errors, validation failures).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->