### PR TITLE
CX-75: Apply CodeRabbit I128 assertion-lowering fix on CX-48 PR

### DIFF
--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -2506,7 +2506,8 @@ fn lower_assert_eq_stmt(
         | IrType::I8
         | IrType::I16
         | IrType::I32
-        | IrType::I64 => {}
+        | IrType::I64
+        | IrType::I128 => {}
         other => {
             return Err(LoweringError::UnsupportedSemanticConstruct {
                 construct: format!(
@@ -2531,7 +2532,7 @@ fn lower_assert_eq_stmt(
 /// Coerce a [`LoweredValue`] to `IrType::Bool` for use as a branch condition.
 ///
 /// - If the value is already `Bool`, it is returned unchanged.
-/// - If the value is an integer type (`I8`/`I16`/`I32`/`I64`), a
+/// - If the value is an integer type (`I8`/`I16`/`I32`/`I64`/`I128`), a
 ///   `Compare { Ne, value, 0 }` is emitted to produce a `Bool` result
 ///   (truthy semantics: any non-zero integer is true).
 /// - All other types produce an `UnsupportedSemanticConstruct` error.
@@ -2542,7 +2543,7 @@ fn coerce_to_bool(
 ) -> Result<ValueId, LoweringError> {
     match &val.ty {
         IrType::Bool => Ok(val.value),
-        IrType::I8 | IrType::I16 | IrType::I32 | IrType::I64 => {
+        IrType::I8 | IrType::I16 | IrType::I32 | IrType::I64 | IrType::I128 => {
             let zero = ctx.fresh_value();
             active.emit(IrInst::ConstInt {
                 dst: zero,
@@ -5592,6 +5593,57 @@ mod tests {
             enums: vec![],
         };
         let module = lower_and_validate(&program);
+        let has_trap = module.functions[0]
+            .blocks
+            .iter()
+            .any(|b| matches!(b.term, IrTerminator::Trap));
+        assert!(has_trap, "expected a Trap block in the CFG");
+    }
+
+    #[test]
+    fn assert_i128_nonzero_lowers_via_truthy_coercion() {
+        // assert(1_i128) → Compare(Ne, 1_i128, 0_i128) → Branch → Trap on false
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "assert",
+                vec![SemanticCallArg::Expr(int_expr(1, SemanticType::I128))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let has_ne_compare = module.functions[0].blocks.iter().any(|b| {
+            b.insts.iter().any(|inst| {
+                matches!(inst, IrInst::Compare { op: CompareOp::Ne, .. })
+            })
+        });
+        assert!(has_ne_compare, "expected a Ne Compare for I128 truthy-integer coercion");
+        let has_trap = module.functions[0]
+            .blocks
+            .iter()
+            .any(|b| matches!(b.term, IrTerminator::Trap));
+        assert!(has_trap, "expected a Trap block in the CFG");
+    }
+
+    #[test]
+    fn assert_eq_same_i128_lowers_to_validated_cfg() {
+        // assert_eq(1_i128, 1_i128) → Compare(Eq) → Branch → Trap on false
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "assert_eq",
+                vec![
+                    SemanticCallArg::Expr(int_expr(1, SemanticType::I128)),
+                    SemanticCallArg::Expr(int_expr(1, SemanticType::I128)),
+                ],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let has_eq_compare = module.functions[0].blocks.iter().any(|b| {
+            b.insts.iter().any(|inst| {
+                matches!(inst, IrInst::Compare { op: CompareOp::Eq, .. })
+            })
+        });
+        assert!(has_eq_compare, "expected an Eq Compare for I128 assert_eq");
         let has_trap = module.functions[0]
             .blocks
             .iter()


### PR DESCRIPTION
Closes CX-75

## Summary

- Added `IrType::I128` to the equality-comparable-types guard in `lower_assert_eq_stmt`, so `assert_eq(a, b)` now accepts I128 operands
- Added `IrType::I128` to the integer match arm in `coerce_to_bool`, so `assert(x)` now accepts I128 conditions (emits `Compare(Ne, x, 0_i128)` for truthy coercion)
- Updated the `coerce_to_bool` docstring to reflect I128 support
- Added two IR-level unit tests: `assert_i128_nonzero_lowers_via_truthy_coercion` and `assert_eq_same_i128_lowers_to_validated_cfg`

## Context

CX-48 introduced assertion lowering for `Bool` and `I8/I16/I32/I64` but omitted `I128`. CX-60 subsequently added I128 support to the Cranelift JIT (arithmetic, compare, load/store). CodeRabbit flagged the remaining gap in the assertion-lowering functions. Note: `ConstInt I128` in the Cranelift backend is still a future-packet item; JIT execution of `assert(literal_i128)` will fail at the backend level until that is implemented. The IR-lowering and IR-validation layers are now complete for I128 assertions.

## Files Changed

- `src/ir/lower.rs` — assertion-lowering functions and new tests

## Validation

```
cargo build --features jit  → ok (21 pre-existing warnings, 0 errors)
cargo test --features jit   → 245 passed; 0 failed
```

New tests confirmed passing:
- `ir::lower::tests::assert_i128_nonzero_lowers_via_truthy_coercion`
- `ir::lower::tests::assert_eq_same_i128_lowers_to_validated_cfg`

## Linear

CX-75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended assertion and equality-checking operations to fully support 128-bit integer values, enabling developers to validate i128 conditions and comparisons in test scenarios.

* **Tests**
  * Added unit tests to validate proper assertion behavior with 128-bit integer operands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/118)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->