### PR TITLE
CX-82: Apply CodeRabbit fixes on CX-77 runtime intrinsics PR

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -263,7 +263,9 @@ impl std::fmt::Display for JitExecutionError {
 /// via `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
 /// The symbol is pre-declared as an Import in every JIT module (see `execute`).
 extern "C" fn cx_printn(n: i64) {
-    println!("{}", n);
+    use std::io::{self, Write};
+    let mut stdout = io::stdout().lock();
+    let _ = writeln!(stdout, "{n}");
 }
 
 pub struct HostBoundary;

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -231,18 +231,21 @@ impl std::fmt::Display for JitExecutionError {
 /// The differential harness captures this output by running the compiler as a subprocess.
 /// In-process pipe redirection is a post-scaffold enhancement.
 ///
-/// ## Supported Instructions (Phase 14 sub-packets 1, 2, and 3; Phase 15 float compare; Phase 9 sub-packet 3; Phase 15 direct calls; CX-32 PtrOffset/PtrAdd)
+/// ## Supported Instructions (Phase 14 sub-packets 1, 2, and 3; Phase 15 float compare; Phase 9 sub-packets 2 and 3; CX-32 PtrOffset/PtrAdd)
 ///
 /// The JIT implementation (enabled with the `jit` feature) supports:
 /// - `ConstInt` (types: I8, I16, I32, I64 — not I128)
 /// - `ConstFloat` — F64 constant via Cranelift `f64const`
 /// - `Binary` (Add, Sub, Mul, Div, Rem — signed integer operations; F64 is not yet supported)
+/// - `SsaBind` — SSA value alias; `dst` inherits the Cranelift value of `src`
 /// - `Alloca` — stack slot allocation; `dst` receives an I64 pointer to the slot
 /// - `Load` — typed memory load from an Alloca-produced pointer
 /// - `Store` — typed memory store through an Alloca-produced pointer
 /// - `Compare` on integers (Eq, Ne, Lt, Le, Gt, Ge — signed integer `icmp`; result is I8)
 /// - `Compare` on F64 (Eq, Ne, Lt, Le, Gt, Ge — ordered float `fcmp`; result is I8)
-/// - `Call` — direct call to a function declared in the same module (value-returning or void)
+/// - `Call` — direct call to a user-defined or runtime-intrinsic function; dispatches via
+///   a two-pass `func_id_map` built before compilation; runtime intrinsics (e.g. `cx_printn`)
+///   are pre-declared as imported symbols and resolved at `finalize_definitions` time
 /// - `PtrOffset` — compile-time pointer advance: zero-offset aliases base; nonzero emits `iadd` with an `iconst`
 /// - `PtrAdd` — runtime pointer advance: emits `iadd(base, offset_val)` where both operands are I64
 /// - `Return` (with or without a value)
@@ -252,9 +255,17 @@ impl std::fmt::Display for JitExecutionError {
 /// - `Trap` (unconditional abort — assertion-failure terminator; lowers to Cranelift `trap`)
 ///
 /// Multi-block functions are supported including back-edge control flow (loops).
-/// Multi-function modules are supported: each function may call any other function in the module.
 ///
 /// All other IR instructions return [`JitExecutionError::UnsupportedConstruct`].
+/// Runtime intrinsic: print an integer to stdout followed by a newline.
+///
+/// Exported as `cx_printn` in the JIT symbol table. JIT-compiled Cx code calls this
+/// via `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
+/// The symbol is pre-declared as an Import in every JIT module (see `execute`).
+extern "C" fn cx_printn(n: i64) {
+    println!("{}", n);
+}
+
 pub struct HostBoundary;
 
 impl HostBoundary {
@@ -273,6 +284,7 @@ impl HostBoundary {
         use cranelift_codegen::settings::{self, Configurable};
         use cranelift_jit::{JITBuilder, JITModule};
         use cranelift_module::{FuncId, Linkage, Module};
+        use std::collections::HashMap;
 
         // Build the native ISA.
         let mut flag_builder = settings::builder();
@@ -296,15 +308,31 @@ impl HostBoundary {
                 detail: e.to_string(),
             })?;
 
-        let jit_builder =
+        // Register runtime intrinsic symbols so the JIT linker can resolve them.
+        let mut jit_builder =
             JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+        jit_builder.symbol("cx_printn", cx_printn as *const u8);
         let mut module = JITModule::new(jit_builder);
 
-        // Pass 1: declare every function and collect its FuncId.  All declarations must
-        // precede body compilation so that IrInst::Call can reference any callee regardless
-        // of declaration order.
-        let mut func_id_map: std::collections::HashMap<String, FuncId> =
-            std::collections::HashMap::new();
+        // Pass 1: declare every user-defined function AND runtime intrinsics into
+        // func_id_map before any function body is compiled.  compile_ir_function
+        // needs the complete map so that IrInst::Call can resolve all callees.
+        let mut func_id_map: HashMap<String, FuncId> = HashMap::new();
+
+        // Pre-declare runtime intrinsics as imported symbols.
+        {
+            use cranelift_codegen::ir::AbiParam;
+            let call_conv = module.target_config().default_call_conv;
+            let mut sig = cranelift_codegen::ir::Signature::new(call_conv);
+            sig.params.push(AbiParam::new(cranelift_codegen::ir::types::I64));
+            let id = module
+                .declare_function("cx_printn", Linkage::Import, &sig)
+                .map_err(|e| JitExecutionError::CodegenFailure {
+                    detail: e.to_string(),
+                })?;
+            func_id_map.insert("cx_printn".to_string(), id);
+        }
+
         for ir_func in &ir.functions {
             let sig = build_cl_signature(&module, ir_func)?;
             let func_id = module
@@ -315,8 +343,7 @@ impl HostBoundary {
             func_id_map.insert(ir_func.name.clone(), func_id);
         }
 
-        // Pass 2: compile each function body with access to the full func_id_map so
-        // that IrInst::Call can emit cross-function call instructions.
+        // Pass 2: compile each function body with the complete func_id_map.
         let mut main_id = None;
         for (func_idx, ir_func) in ir.functions.iter().enumerate() {
             let func_id = func_id_map[&ir_func.name];
@@ -464,7 +491,7 @@ fn compile_ir_function(
 ) -> Result<(), JitExecutionError> {
     use cranelift_codegen::ir::condcodes::IntCC;
     use cranelift_codegen::ir::InstBuilder;
-    use cranelift_module::Module as CraneliftModule;
+    use cranelift_module::Module;
     use crate::ir::instr::{BinaryOp, CompareOp, IrInst, IrTerminator};
     use crate::ir::types::{BlockId, IrType, ValueId};
     use super::ir_type_to_cranelift;
@@ -652,15 +679,25 @@ fn compile_ir_function(
                     val_map.insert(*dst, result);
                 }
 
+                IrInst::SsaBind { dst, src, .. } => {
+                    // SsaBind is a pure SSA alias: the destination inherits the
+                    // Cranelift value of the source with no instruction emitted.
+                    let val = *val_map.get(src).ok_or_else(|| {
+                        JitExecutionError::CodegenFailure {
+                            detail: format!("undefined value {:?} used as SsaBind source", src),
+                        }
+                    })?;
+                    val_map.insert(*dst, val);
+                }
+
                 IrInst::Call { dst, callee, args, return_ty: _ } => {
                     let callee_id = *func_id_map.get(callee.as_str()).ok_or_else(|| {
                         JitExecutionError::CodegenFailure {
                             detail: format!("call to undefined function '{}'", callee),
                         }
                     })?;
-                    let func_ref =
-                        module.declare_func_in_func(callee_id, builder.func);
-                    let call_args: Vec<cranelift_codegen::ir::Value> = args
+                    let func_ref = module.declare_func_in_func(callee_id, builder.func);
+                    let cl_args: Vec<cranelift_codegen::ir::Value> = args
                         .iter()
                         .map(|vid| {
                             val_map.get(vid).copied().ok_or_else(|| {
@@ -673,9 +710,17 @@ fn compile_ir_function(
                             })
                         })
                         .collect::<Result<_, _>>()?;
-                    let call_inst = builder.ins().call(func_ref, &call_args);
+                    let call_inst = builder.ins().call(func_ref, &cl_args);
                     if let Some(dst_vid) = dst {
                         let results = builder.inst_results(call_inst);
+                        if results.is_empty() {
+                            return Err(JitExecutionError::CodegenFailure {
+                                detail: format!(
+                                    "call to '{}' expected return value but callee returned void",
+                                    callee
+                                ),
+                            });
+                        }
                         val_map.insert(*dst_vid, results[0]);
                     }
                 }
@@ -1152,7 +1197,7 @@ mod jit_tests {
 
     #[test]
     fn jit_unsupported_inst_returns_error() {
-        // SsaBind is not supported in sub-packet 1.
+        // Cast is not yet supported in the JIT backend and triggers UnsupportedConstruct.
         let module = IrModule {
             debug_name: "test_unsupported".to_string(),
             functions: vec![IrFunction {
@@ -1164,10 +1209,11 @@ mod jit_tests {
                     params: vec![],
                     insts: vec![
                         IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 0 },
-                        IrInst::SsaBind {
+                        IrInst::Cast {
                             dst: ValueId(1),
-                            ty: IrType::I32,
-                            src: ValueId(0),
+                            from: IrType::I32,
+                            to: IrType::I64,
+                            value: ValueId(0),
                         },
                     ],
                     term: IrTerminator::Return { value: Some(ValueId(1)) },
@@ -3802,5 +3848,129 @@ mod determinism_tests {
             ],
         };
         assert_deterministic(&module);
+    }
+
+    // ── SsaBind support (CX-77 Phase 9 sub-packet 2) ─────────────────────────
+
+    #[test]
+    fn jit_ssabind_aliases_value() {
+        // SsaBind(dst, src) must act as a pure alias:  val_map[dst] = val_map[src].
+        // main() -> i32 {
+        //   v0 = 42i32
+        //   v1 = SsaBind(I32, v0)   // v1 aliases v0
+        //   return v1               // → 42
+        // }
+        let module = IrModule {
+            debug_name: "test_ssabind".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 42 },
+                        IrInst::SsaBind { dst: ValueId(1), ty: IrType::I32, src: ValueId(0) },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(1)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 42);
+    }
+
+    // ── cx_printn intrinsic dispatch (CX-77 Phase 9 sub-packet 2) ────────────
+
+    #[test]
+    fn jit_call_cx_printn_executes_without_error() {
+        // Verifies that the JIT can:
+        //   1. Pre-declare cx_printn as an imported symbol.
+        //   2. Resolve IrInst::Call{callee:"cx_printn"} via func_id_map.
+        //   3. Execute and return exit code 0.
+        //
+        // main() -> i32 {
+        //   v0 = 42i64
+        //   cx_printn(v0)           // side-effect: prints to stdout
+        //   v1 = 0i32
+        //   return v1
+        // }
+        let module = IrModule {
+            debug_name: "test_cx_printn".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I64, value: 42 },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn".to_string(),
+                            args: vec![ValueId(0)],
+                            return_ty: None,
+                        },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 0 },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(1)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    #[test]
+    fn jit_call_cx_printn_with_computed_value() {
+        // cx_printn receives the result of a Binary Add, not a direct ConstInt.
+        // This exercises the arg-value lookup through val_map in the Call handler.
+        //
+        // main() -> i32 {
+        //   v0 = 30i64
+        //   v1 = 12i64
+        //   v2 = Add(I64, v0, v1)   // 42
+        //   cx_printn(v2)
+        //   v3 = 0i32
+        //   return v3
+        // }
+        let module = IrModule {
+            debug_name: "test_cx_printn_computed".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I64, value: 30 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I64, value: 12 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Add,
+                            ty: IrType::I64,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn".to_string(),
+                            args: vec![ValueId(2)],
+                            return_ty: None,
+                        },
+                        IrInst::ConstInt { dst: ValueId(3), ty: IrType::I32, value: 0 },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
     }
 }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -78,28 +78,21 @@ impl std::error::Error for LoweringError {}
 // Classification (see docs/backend/cx_runtime_intrinsics_v0.1.md for the
 // full boundary specification):
 //
-//   Category          | Builtins
-//   ──────────────────┼────────────────────────────────
-//   I/O (stdout)      | print, println, printn
-//   I/O (stdin)       | read, input
-//   Debug / assertion | assert, assert_eq
+//   Category          | Builtins          | Status
+//   ──────────────────┼───────────────────┼──────────────────────────────────
+//   I/O (stdout)      | print, println    | blocked on frontend string ABI
+//   I/O (stdout)      | printn            | LOWERABLE — see lower_printn_stmt
+//   I/O (stdin)       | read, input       | blocked on Phase 8 str layout
+//   Debug / assertion | assert, assert_eq | LOWERABLE — Phase 9 sub-packet 3
 //
-// None of these have codegen support yet. Lowering them through the normal
-// `signature_table` path would produce a misleading `UnresolvedSemanticArtifact`
-// error. Instead, `is_cx_builtin` gates the call paths so they produce a
-// structured `UnsupportedSemanticConstruct` with an explicit Phase 9 note.
+// Builtins that remain in `is_cx_builtin` produce a structured
+// `UnsupportedSemanticConstruct` error instead of a misleading
+// `UnresolvedSemanticArtifact` from a signature_table miss.
 //
-// When Phase 9 sub-packet 2 lands, each builtin here will be replaced by a
-// concrete `IrIntrinsic` opcode or a runtime-call ABI signature — at which
-// point this function will shrink until it is empty.
-//
-// Note: `assert` and `assert_eq` are NOT listed here — they are now fully
-// lowerable to IR (Phase 9 sub-packet 3) and are handled before this gate.
+// Builtins that are handled before this gate (assert, assert_eq, printn)
+// are intercepted in `lower_stmt` and never reach `is_cx_builtin`.
 fn is_cx_builtin(name: &str) -> bool {
-    matches!(
-        name,
-        "print" | "println" | "printn" | "read" | "input"
-    )
+    matches!(name, "print" | "println" | "read" | "input")
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -316,6 +309,8 @@ pub fn lower_program(program: &SemanticProgram) -> Result<IrModule, LoweringErro
 }
 
 fn lower_program_inner(program: &SemanticProgram, trace: bool) -> Result<IrModule, LoweringError> {
+    const RESERVED_RUNTIME_INTRINSICS: &[&str] = &["cx_printn"];
+
     if program.stmts.is_empty() {
         return Ok(IrModule {
             debug_name: "cxir_v0".into(),
@@ -335,6 +330,14 @@ fn lower_program_inner(program: &SemanticProgram, trace: bool) -> Result<IrModul
     for stmt in &program.stmts {
         match stmt {
             SemanticStmt::FuncDef(function) => {
+                if RESERVED_RUNTIME_INTRINSICS.contains(&function.name.as_str()) {
+                    return Err(LoweringError::UnsupportedSemanticConstruct {
+                        construct: format!(
+                            "function name '{}' is reserved for runtime intrinsics",
+                            function.name
+                        ),
+                    });
+                }
                 if function.name == "main" {
                     has_real_main = true;
                 }
@@ -604,13 +607,15 @@ fn lower_stmt(
             Ok(Some(current))
         }
         SemanticStmt::ExprStmt { expr, .. } => {
-            // Phase 9 sub-packet 3: assert and assert_eq are now fully lowerable.
-            // Intercept them before the is_cx_builtin gate so they are routed to
-            // the dedicated lowering functions rather than returning a structured error.
+            // Phase 9 sub-packets 2 and 3: assert/assert_eq and printn are now
+            // fully lowerable.  Intercept them before the is_cx_builtin gate so
+            // they are routed to the dedicated lowering functions rather than
+            // returning a structured error.
             if let SemanticExprKind::Call { callee, args, .. } = &expr.kind {
                 match callee.as_str() {
                     "assert" => return lower_assert_stmt(args, ctx, current),
                     "assert_eq" => return lower_assert_eq_stmt(args, ctx, current),
+                    "printn" => return lower_printn_stmt(args, ctx, current),
                     _ => {}
                 }
             }
@@ -2420,6 +2425,49 @@ fn ensure_type_match(context: &str, expected: IrType, got: IrType) -> Result<(),
 //
 // Unsupported types (e.g. Ptr, F64, StrRef) produce a structured
 // UnsupportedSemanticConstruct error so the caller gets a clear diagnostic.
+
+/// Lower `printn(n)` to `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
+///
+/// `printn` is a Cx builtin that prints an integer to stdout.  At the IR level
+/// it lowers to a call to the `cx_printn` runtime intrinsic, which is pre-declared
+/// in the JIT module as an imported C-ABI symbol.
+///
+/// Only `I64` arguments are accepted; other types produce a structured error.
+fn lower_printn_stmt(
+    args: &[SemanticCallArg],
+    ctx: &mut LoweringCtx,
+    mut current: ActiveBlock,
+) -> Result<Option<ActiveBlock>, LoweringError> {
+    if args.len() != 1 {
+        return Err(LoweringError::InternalInvariantViolation {
+            detail: format!("printn expects 1 argument, got {}", args.len()),
+        });
+    }
+    let arg_expr = match &args[0] {
+        SemanticCallArg::Expr(e) => e,
+        _ => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: "non-Expr argument to printn".to_string(),
+            });
+        }
+    };
+    let arg = lower_expr(arg_expr, ctx, &mut current)?;
+    if arg.ty != IrType::I64 {
+        return Err(LoweringError::UnsupportedSemanticConstruct {
+            construct: format!(
+                "printn argument must be I64, got {:?} — other types not yet supported",
+                arg.ty
+            ),
+        });
+    }
+    current.emit(IrInst::Call {
+        dst: None,
+        callee: "cx_printn".to_string(),
+        args: vec![arg.value],
+        return_ty: None,
+    })?;
+    Ok(Some(current))
+}
 
 /// Lower `assert(cond)` as a void statement.
 ///
@@ -5497,8 +5545,55 @@ mod tests {
     }
 
     #[test]
-    fn builtin_printn_produces_unsupported_construct_not_unresolved_artifact() {
-        assert_builtin_structured_error("printn");
+    fn printn_lowers_to_cx_printn_call() {
+        // printn(42i64) must lower to IrInst::Call{callee:"cx_printn"} and pass validation.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "printn",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I64))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let cx_printn_calls: Vec<_> = main_fn
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn"))
+            .collect();
+        assert_eq!(cx_printn_calls.len(), 1, "expected exactly one cx_printn call");
+        match cx_printn_calls[0] {
+            IrInst::Call { dst, callee, args, return_ty } => {
+                assert!(dst.is_none(), "cx_printn is void — no destination");
+                assert_eq!(callee, "cx_printn");
+                assert_eq!(args.len(), 1, "cx_printn takes one argument");
+                assert!(return_ty.is_none(), "cx_printn returns void");
+            }
+            _ => panic!("expected Call instruction"),
+        }
+    }
+
+    #[test]
+    fn printn_with_non_i64_arg_returns_error() {
+        // printn with an I32 argument must return UnsupportedSemanticConstruct.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "printn",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I32))],
+            )],
+            enums: vec![],
+        };
+        let err = lower_program(&program).expect_err("lowering should fail for non-I64 printn arg");
+        assert!(
+            matches!(
+                &err,
+                LoweringError::UnsupportedSemanticConstruct { construct }
+                if construct.contains("I64")
+            ),
+            "expected UnsupportedSemanticConstruct mentioning I64, got: {:?}",
+            err
+        );
     }
 
     // assert and assert_eq are now lowerable (Phase 9 sub-packet 3) so they no

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -402,6 +402,17 @@ fn validate_inst(
                         }
                     }
                 }
+
+                if !sig.has_return && (dst.is_some() || return_ty.is_some()) {
+                    errors.push(IrValidationError::InvalidTypeUsage {
+                        function: function.name.clone(),
+                        block,
+                        detail: format!(
+                            "Call to '{}': callee returns void but call provides destination/return_ty",
+                            callee
+                        ),
+                    });
+                }
             } else {
                 errors.push(IrValidationError::InvalidTypeUsage {
                     function: function.name.clone(),
@@ -1541,6 +1552,45 @@ mod tests {
                     && detail.contains("expected I64")
             )),
             "expected type-mismatch error for cx_printn, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn validator_rejects_void_intrinsic_call_with_dst_or_return_ty() {
+        // cx_printn is void; a Call that assigns its result to a dst or declares
+        // a return_ty must be rejected.
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I64, value: 42 },
+                        IrInst::Call {
+                            dst: Some(ValueId(1)),
+                            callee: "cx_printn".to_string(),
+                            args: vec![ValueId(0)],
+                            return_ty: Some(IrType::I64),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: None },
+                }],
+            }],
+        };
+        let errors = validate_module(&module)
+            .expect_err("validator must reject void intrinsic call with dst/return_ty");
+        assert!(
+            errors.iter().any(|err| matches!(
+                err,
+                IrValidationError::InvalidTypeUsage { detail, .. }
+                if detail.contains("Call to 'cx_printn': callee returns void")
+            )),
+            "expected void-return shape error for cx_printn, got: {:?}",
             errors
         );
     }

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -64,10 +64,30 @@ struct ValidatorFunctionSig {
     has_return: bool,
 }
 
+/// Return the signatures of every known runtime intrinsic.
+///
+/// These are pre-seeded into the validator's `function_sigs` map so that
+/// `IrInst::Call` to an intrinsic like `cx_printn` passes validation even
+/// though it has no `IrFunction` entry in the module.
+fn known_intrinsic_sigs() -> HashMap<String, ValidatorFunctionSig> {
+    let mut sigs = HashMap::new();
+    // cx_printn(n: I64) -> void — Phase 9 sub-packet 2 print-integer intrinsic.
+    sigs.insert(
+        "cx_printn".to_string(),
+        ValidatorFunctionSig {
+            param_count: 1,
+            param_types: vec![IrType::I64],
+            has_return: false,
+        },
+    );
+    sigs
+}
+
 pub fn validate_module(module: &IrModule) -> Result<(), Vec<IrValidationError>> {
     let mut errors = Vec::new();
 
-    let mut function_sigs: HashMap<String, ValidatorFunctionSig> = HashMap::new();
+    // Seed known runtime intrinsic signatures before scanning user-defined functions.
+    let mut function_sigs: HashMap<String, ValidatorFunctionSig> = known_intrinsic_sigs();
     for function in &module.functions {
         function_sigs.insert(function.name.clone(), ValidatorFunctionSig {
             param_count: function.params.len(),
@@ -1451,6 +1471,76 @@ mod tests {
                 IrValidationError::LoopVariableReassignment { .. }
             )),
             "expected LoopVariableReassignment error, got: {:?}",
+            errors
+        );
+    }
+
+    // ── Runtime intrinsic signature tests (CX-77) ────────────────────────────
+
+    #[test]
+    fn validator_accepts_cx_printn_call_with_i64_arg() {
+        // A call to `cx_printn(i64)` must pass validation even though cx_printn
+        // has no IrFunction entry in the module — it is seeded by known_intrinsic_sigs.
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I64, value: 42 },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn".to_string(),
+                            args: vec![ValueId(0)],
+                            return_ty: None,
+                        },
+                    ],
+                    term: IrTerminator::Return { value: None },
+                }],
+            }],
+        };
+        assert_eq!(validate_module(&module), Ok(()));
+    }
+
+    #[test]
+    fn validator_rejects_cx_printn_call_with_wrong_arg_type() {
+        // cx_printn expects I64; passing I32 must produce a type-mismatch error.
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 42 },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn".to_string(),
+                            args: vec![ValueId(0)],
+                            return_ty: None,
+                        },
+                    ],
+                    term: IrTerminator::Return { value: None },
+                }],
+            }],
+        };
+        let errors = validate_module(&module)
+            .expect_err("validator must reject wrong-type arg to cx_printn");
+        assert!(
+            errors.iter().any(|err| matches!(
+                err,
+                IrValidationError::InvalidTypeUsage { detail, .. }
+                if detail.contains("Call to 'cx_printn': argument 0 has type")
+                    && detail.contains("expected I64")
+            )),
+            "expected type-mismatch error for cx_printn, got: {:?}",
             errors
         );
     }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-82/cx-82-apply-coderabbit-fixes-on-cx-77-runtime-intrinsics-pr

## Summary

Applies four CodeRabbit fixes from the review of PR #121 (CX-77 runtime intrinsics dispatch) onto current submain (which has CX-76 direct calls and CX-78 PtrOffset/PtrAdd already merged).

### CodeRabbit fixes applied

1. **`host_boundary.rs` — defensive check before `results[0]`** (actionable): Added `results.is_empty()` guard in the `IrInst::Call` handler before indexing `results[0]`. Returns `CodegenFailure` with a descriptive message when the callee's return is unexpectedly empty, upholding the no-panic guarantee documented in the module.

2. **`lower.rs` — reserve runtime intrinsic symbol names** (actionable): Added `RESERVED_RUNTIME_INTRINSICS: &[&str] = &["cx_printn"]` as a const in `lower_program_inner`. The `FuncDef` arm now rejects user-defined functions named `cx_printn` with `UnsupportedSemanticConstruct`, preventing ABI collisions.

3. **`host_boundary.rs` — remove redundant `#[cfg(feature = "jit")]`** (nitpick): The three new tests (`jit_ssabind_aliases_value`, `jit_call_cx_printn_executes_without_error`, `jit_call_cx_printn_with_computed_value`) are added without the inner `#[cfg(feature = "jit")]` attribute — the `determinism_tests` module is already gated by `#[cfg(all(test, feature = "jit"))]`.

4. **`validate.rs` — tighten wrong-arg-type assertion** (nitpick): Updated the `validator_rejects_cx_printn_call_with_wrong_arg_type` test to assert both `detail.contains("Call to 'cx_printn': argument 0 has type")` and `detail.contains("expected I64")` rather than just `detail.contains("cx_printn")`, matching the validator's exact error format and preventing false positives.

### CX-77 implementation rebased onto current submain

Since CX-77 (PR #121) was branched from pre-CX-76 submain, the following implementation was also applied cleanly on top of current submain:

- `cx_printn` extern "C" runtime intrinsic function
- Two-pass JIT execution with `cx_printn` pre-declared as `Linkage::Import`
- `IrInst::SsaBind` handler in `compile_ir_function` (pure SSA alias)
- `lower_printn_stmt()` lowering `printn` to `IrInst::Call{callee:"cx_printn"}`
- `known_intrinsic_sigs()` pre-seeding `cx_printn(I64)->void` into the validator
- `jit_unsupported_inst_returns_error` updated to use `Cast` (not `SsaBind`)
- `use cranelift_module::Module` (was aliased as `CraneliftModule`)
- `use std::collections::HashMap` in `execute()`

## Files changed

| File | Changes |
|------|---------|
| `src/backend/cranelift/host_boundary.rs` | `cx_printn` shim, two-pass execute with intrinsic pre-declaration, SsaBind + Call handlers, defensive results check, 3 new tests, updated unsupported_inst test |
| `src/ir/lower.rs` | `lower_printn_stmt()`, `is_cx_builtin` update, `RESERVED_RUNTIME_INTRINSICS` check, 2 new tests replacing old printn unsupported test |
| `src/ir/validate.rs` | `known_intrinsic_sigs()`, seeded into `validate_module`, 2 new tests with tightened assertion |

## Tests run

```
cargo build --features jit   ✅
cargo test --features jit    ✅  260 passed; 0 failed
```

## New tests added

- `ir::lower::tests::printn_lowers_to_cx_printn_call`
- `ir::lower::tests::printn_with_non_i64_arg_returns_error`
- `ir::validate::tests::validator_accepts_cx_printn_call_with_i64_arg`
- `ir::validate::tests::validator_rejects_cx_printn_call_with_wrong_arg_type`
- `backend::cranelift::host_boundary::determinism_tests::jit_ssabind_aliases_value`
- `backend::cranelift::host_boundary::determinism_tests::jit_call_cx_printn_executes_without_error`
- `backend::cranelift::host_boundary::determinism_tests::jit_call_cx_printn_with_computed_value`

## Known limitations

- `print`, `println`: still blocked on frontend string ABI promotion.
- `read`, `input`: still blocked on Phase 8 `str`/`strref` layout.
- `printn` only accepts `I64` args; other integer widths produce a structured error.
- No stdout-capture test: the JIT tests verify successful execution (exit code 0) but not the text printed to stdout.

## Linear ticket

CX-82 — https://linear.app/cx-lang/issue/CX-82/cx-82-apply-coderabbit-fixes-on-cx-77-runtime-intrinsics-pr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added printn(i64) as a language-level statement to print 64-bit integers at runtime.

* **Runtime / Execution**
  * JIT execution now supports the runtime print intrinsic so printn works when using the JIT.

* **Validation / Error Handling**
  * Strict checks for printn: enforces single i64 argument and disallows expecting a return value.

* **Tests**
  * Added unit and JIT integration tests covering printn lowering, validation, and execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/124)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->