### PR TITLE
CX-81: Apply CX-34 numeric lowering fixes

### DIFF
--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -1927,9 +1927,14 @@ fn common_numeric_type(lhs: &SemanticType, rhs: &SemanticType) -> SemanticType {
     if matches!(lhs, SemanticType::F64) || matches!(rhs, SemanticType::F64) {
         return SemanticType::F64;
     }
-    // Both literals — unchanged behavior
+    // Both literals — default to I64 rather than I128.
+    // I64 is the widest signed integer that Cranelift can represent as a single
+    // iconst (I128 requires two i64s and is not yet JIT-supported).  Practical
+    // Cx programs with integer literals that require more than 64 bits declare
+    // their variables with explicit `t128` types, so the widening to I128 is
+    // not needed at the literal level.
     if matches!(lhs, SemanticType::Numeric) && matches!(rhs, SemanticType::Numeric) {
-        return SemanticType::I128;
+        return SemanticType::I64;
     }
     // Numeric (literal) marker — adopt the other side's declared type
     if matches!(lhs, SemanticType::Numeric) {

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1501,8 +1501,23 @@ fn lower_expr(
         }
         SemanticExprKind::Cast { expr, from, to } => {
             let lowered = lower_expr(expr, ctx, active)?;
-            let from_ty = lower_type(from)?;
+            // When the source type is `Numeric`, the semantic layer inserted a
+            // widening cast from an unresolved literal.  The literal has already
+            // been lowered to I64 (see `lower_value`), so we use the actual
+            // lowered type as the IR source rather than trying to lower `Numeric`
+            // (which has no IR equivalent).
+            let from_ty = if *from == SemanticType::Numeric {
+                lowered.ty.clone()
+            } else {
+                lower_type(from)?
+            };
             let to_ty = lower_type(to)?;
+            // Skip no-op casts: if the source and target types already match
+            // (which happens when a Numeric literal was lowered to the same
+            // type as the cast target), emit no instruction.
+            if from_ty == to_ty {
+                return Ok(LoweredValue { value: lowered.value, ty: to_ty });
+            }
             ensure_type_match("cast source", from_ty.clone(), lowered.ty)?;
             let dst = ctx.fresh_value();
             active.emit(IrInst::Cast {
@@ -1770,7 +1785,16 @@ fn lower_value(
     ctx: &mut LoweringCtx,
     active: &mut ActiveBlock,
 ) -> Result<LoweredValue, LoweringError> {
-    let ty = lower_type(semantic_ty)?;
+    // Numeric literals have no explicit type annotation in Cx source.  The
+    // semantic layer uses `SemanticType::Numeric` as a placeholder.  At the IR
+    // level we default unresolved numeric literals to I64, the widest signed
+    // integer type that Cranelift can represent as a single `iconst`.
+    let resolved_ty = if *semantic_ty == SemanticType::Numeric {
+        &SemanticType::I64
+    } else {
+        semantic_ty
+    };
+    let ty = lower_type(resolved_ty)?;
     let dst = ctx.fresh_value();
 
     match value {

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1512,13 +1512,13 @@ fn lower_expr(
                 lower_type(from)?
             };
             let to_ty = lower_type(to)?;
+            ensure_type_match("cast source", from_ty.clone(), lowered.ty)?;
             // Skip no-op casts: if the source and target types already match
             // (which happens when a Numeric literal was lowered to the same
             // type as the cast target), emit no instruction.
             if from_ty == to_ty {
                 return Ok(LoweredValue { value: lowered.value, ty: to_ty });
             }
-            ensure_type_match("cast source", from_ty.clone(), lowered.ty)?;
             let dst = ctx.fresh_value();
             active.emit(IrInst::Cast {
                 dst,
@@ -1799,6 +1799,16 @@ fn lower_value(
 
     match value {
         SemanticValue::Num(n) => {
+            if *semantic_ty == SemanticType::Numeric
+                && !((i64::MIN as i128)..=(i64::MAX as i128)).contains(n)
+            {
+                return Err(LoweringError::UnsupportedSemanticConstruct {
+                    construct: format!(
+                        "integer literal {n} is outside i64 range; \
+                         declare the variable with an explicit t128 type to use wide integers"
+                    ),
+                });
+            }
             let value =
                 i128::try_from(*n).map_err(|_| LoweringError::InternalInvariantViolation {
                     detail: format!("integer literal {n} exceeds i128 IR constant range"),


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-81/cx-81-audit-cx-34-leftovers-numeric-lowering-only-do-not-revive-stale

## Summary

Audited CX-34 leftovers and applied the numeric lowering fixes to submain. The stale harness PR content (diff_harness.rs JIT subprocess runner, .cx fixture files, main.rs exit-code propagation) is excluded per CX-81 scope.

**Three targeted changes:**

1. **`src/frontend/semantic.rs` — `common_numeric_type`**: When both operands are unresolved `Numeric` literals, return `I64` instead of `I128`. Cranelift requires two `i64` values to represent `I128` and cannot emit it as a single `iconst`; programs that need `t128` declare it explicitly.

2. **`src/ir/lower.rs` — `lower_value`**: When `semantic_ty` is `SemanticType::Numeric` (unresolved literal placeholder), resolve it to `I64` before calling `lower_type`. Previously `lower_type(Numeric)` unconditionally returned `UnsupportedSemanticType`, blocking all untyped integer literal lowering.

3. **`src/ir/lower.rs` — `lower_expr` Cast arm**: When the Cast source type is `Numeric`, use the actual lowered type (I64 from `lower_value`) rather than calling `lower_type(Numeric)`. Adds no-op cast elimination: if source and target types match after resolution, return the lowered value directly without emitting a Cast instruction.

## Files Changed

- `src/frontend/semantic.rs` (+7/-2)
- `src/ir/lower.rs` (+26/-2)

## Existing test behaviour

- `ir::lower::tests::rejects_numeric_type` — still passes; the binding's declared type is `Numeric`, which hits `lower_type(Numeric)` at the TypedAssign level (after `lower_value` now succeeds for the expression).
- `ir::lower::tests::rejects_unsupported_semantic_type_inside_if_branch` — same path, still rejects correctly.
- All other 252 tests continue to pass.

## Validation

```
cargo build --features jit    → Finished (warnings only, no errors)
cargo test  --features jit    → test result: ok. 254 passed; 0 failed
```

## Linear ticket

CX-81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Default numeric literals now resolve to a 64-bit integer type for consistency.
  * Cast handling avoids emitting redundant conversions when operand and target types match.
  * Numeric literal validation added: out-of-range integer literals are now rejected during compilation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/126)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->