### PR TITLE
CX-86: Apply CodeRabbit fixes on CX-81 numeric lowering PR

### DIFF
--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -1927,9 +1927,14 @@ fn common_numeric_type(lhs: &SemanticType, rhs: &SemanticType) -> SemanticType {
     if matches!(lhs, SemanticType::F64) || matches!(rhs, SemanticType::F64) {
         return SemanticType::F64;
     }
-    // Both literals — unchanged behavior
+    // Both literals — default to I64 rather than I128.
+    // I64 is the widest signed integer that Cranelift can represent as a single
+    // iconst (I128 requires two i64s and is not yet JIT-supported).  Practical
+    // Cx programs with integer literals that require more than 64 bits declare
+    // their variables with explicit `t128` types, so the widening to I128 is
+    // not needed at the literal level.
     if matches!(lhs, SemanticType::Numeric) && matches!(rhs, SemanticType::Numeric) {
-        return SemanticType::I128;
+        return SemanticType::I64;
     }
     // Numeric (literal) marker — adopt the other side's declared type
     if matches!(lhs, SemanticType::Numeric) {

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1501,8 +1501,23 @@ fn lower_expr(
         }
         SemanticExprKind::Cast { expr, from, to } => {
             let lowered = lower_expr(expr, ctx, active)?;
-            let from_ty = lower_type(from)?;
+            // When the source type is `Numeric`, the semantic layer inserted a
+            // widening cast from an unresolved literal.  The literal has already
+            // been lowered to I64 (see `lower_value`), so we use the actual
+            // lowered type as the IR source rather than trying to lower `Numeric`
+            // (which has no IR equivalent).
+            let from_ty = if *from == SemanticType::Numeric {
+                lowered.ty.clone()
+            } else {
+                lower_type(from)?
+            };
             let to_ty = lower_type(to)?;
+            // Skip no-op casts: if the source and target types already match
+            // (which happens when a Numeric literal was lowered to the same
+            // type as the cast target), emit no instruction.
+            if from_ty == to_ty {
+                return Ok(LoweredValue { value: lowered.value, ty: to_ty });
+            }
             ensure_type_match("cast source", from_ty.clone(), lowered.ty)?;
             let dst = ctx.fresh_value();
             active.emit(IrInst::Cast {
@@ -1770,7 +1785,16 @@ fn lower_value(
     ctx: &mut LoweringCtx,
     active: &mut ActiveBlock,
 ) -> Result<LoweredValue, LoweringError> {
-    let ty = lower_type(semantic_ty)?;
+    // Numeric literals have no explicit type annotation in Cx source.  The
+    // semantic layer uses `SemanticType::Numeric` as a placeholder.  At the IR
+    // level we default unresolved numeric literals to I64, the widest signed
+    // integer type that Cranelift can represent as a single `iconst`.
+    let resolved_ty = if *semantic_ty == SemanticType::Numeric {
+        &SemanticType::I64
+    } else {
+        semantic_ty
+    };
+    let ty = lower_type(resolved_ty)?;
     let dst = ctx.fresh_value();
 
     match value {

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1500,18 +1500,25 @@ fn lower_expr(
             lower_binary(lhs, *op, rhs, &expr.ty, ctx, active)
         }
         SemanticExprKind::Cast { expr, from, to } => {
+            let to_ty = lower_type(to)?;
+            // When the source is a bare Numeric literal, lower it directly with
+            // the concrete cast target type.  This avoids the Numeric→I64 default
+            // in lower_value and its I64 bounds check, which would reject large
+            // literals (e.g. values > i64::MAX) that are valid for wider targets
+            // such as I128.
+            if *from == SemanticType::Numeric {
+                if let SemanticExprKind::Value(value) = &expr.kind {
+                    return lower_value(value, to, ctx, active);
+                }
+            }
             let lowered = lower_expr(expr, ctx, active)?;
-            // When the source type is `Numeric`, the semantic layer inserted a
-            // widening cast from an unresolved literal.  The literal has already
-            // been lowered to I64 (see `lower_value`), so we use the actual
-            // lowered type as the IR source rather than trying to lower `Numeric`
-            // (which has no IR equivalent).
             let from_ty = if *from == SemanticType::Numeric {
+                // Non-literal Numeric source — not expected in well-formed IR;
+                // fall back gracefully using the actual lowered type.
                 lowered.ty.clone()
             } else {
                 lower_type(from)?
             };
-            let to_ty = lower_type(to)?;
             ensure_type_match("cast source", from_ty.clone(), lowered.ty)?;
             // Skip no-op casts only after validating source type invariants.
             if from_ty == to_ty {
@@ -2964,6 +2971,81 @@ mod tests {
                 }
             )
         }));
+    }
+
+    #[test]
+    fn numeric_literal_cast_to_i128_allows_large_values() {
+        // Numeric literal > i64::MAX cast to I128 must succeed — the literal
+        // is wider than I64's range but fits in I128.
+        let large: i128 = i64::MAX as i128 + 1;
+        let program = SemanticProgram {
+            stmts: vec![typed_assign(
+                BindingId(1),
+                "x",
+                SemanticType::I128,
+                SemanticExpr {
+                    ty: SemanticType::I128,
+                    kind: SemanticExprKind::Cast {
+                        expr: Box::new(SemanticExpr {
+                            ty: SemanticType::Numeric,
+                            kind: SemanticExprKind::Value(SemanticValue::Num(large)),
+                        }),
+                        from: SemanticType::Numeric,
+                        to: SemanticType::I128,
+                    },
+                },
+            )],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let insts = &module.functions[0].blocks[0].insts;
+        assert!(
+            insts.iter().any(|inst| matches!(
+                inst,
+                IrInst::ConstInt { ty: IrType::I128, value: v, .. } if *v == large
+            )),
+            "expected ConstInt I128 with value {large}, got: {insts:?}"
+        );
+    }
+
+    #[test]
+    fn numeric_literal_cast_to_i64_in_range_emits_const_int() {
+        // A Numeric literal within I64 range cast to I64 must produce a
+        // ConstInt (not a Cast instruction) and no error.
+        let program = SemanticProgram {
+            stmts: vec![typed_assign(
+                BindingId(1),
+                "x",
+                SemanticType::I64,
+                SemanticExpr {
+                    ty: SemanticType::I64,
+                    kind: SemanticExprKind::Cast {
+                        expr: Box::new(SemanticExpr {
+                            ty: SemanticType::Numeric,
+                            kind: SemanticExprKind::Value(SemanticValue::Num(42)),
+                        }),
+                        from: SemanticType::Numeric,
+                        to: SemanticType::I64,
+                    },
+                },
+            )],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let insts = &module.functions[0].blocks[0].insts;
+        assert!(
+            insts.iter().any(|inst| matches!(
+                inst,
+                IrInst::ConstInt { ty: IrType::I64, value: 42, .. }
+            )),
+            "expected ConstInt I64 value=42"
+        );
+        assert!(
+            !insts.iter().any(|inst| matches!(inst, IrInst::Cast { .. })),
+            "unexpected Cast instruction for Numeric→I64 literal"
+        );
     }
 
     #[test]

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1512,13 +1512,11 @@ fn lower_expr(
                 lower_type(from)?
             };
             let to_ty = lower_type(to)?;
-            // Skip no-op casts: if the source and target types already match
-            // (which happens when a Numeric literal was lowered to the same
-            // type as the cast target), emit no instruction.
+            ensure_type_match("cast source", from_ty.clone(), lowered.ty)?;
+            // Skip no-op casts only after validating source type invariants.
             if from_ty == to_ty {
                 return Ok(LoweredValue { value: lowered.value, ty: to_ty });
             }
-            ensure_type_match("cast source", from_ty.clone(), lowered.ty)?;
             let dst = ctx.fresh_value();
             active.emit(IrInst::Cast {
                 dst,
@@ -1799,10 +1797,16 @@ fn lower_value(
 
     match value {
         SemanticValue::Num(n) => {
-            let value =
-                i128::try_from(*n).map_err(|_| LoweringError::InternalInvariantViolation {
-                    detail: format!("integer literal {n} exceeds i128 IR constant range"),
-                })?;
+            let value = *n;
+            if ty == IrType::I64
+                && (value < i64::MIN as i128 || value > i64::MAX as i128)
+            {
+                return Err(LoweringError::UnsupportedSemanticConstruct {
+                    construct: format!(
+                        "integer literal {value} exceeds default I64 literal range during lowering"
+                    ),
+                });
+            }
             active.emit(IrInst::ConstInt {
                 dst,
                 ty: ty.clone(),


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-86/cx-86-apply-coderabbit-fixes-on-cx-81-numeric-lowering-pr

## Summary

Applies the two actionable CodeRabbit fixes from PR #126 (CX-81 numeric lowering):

1. **Validate cast source before no-op fast path** — `ensure_type_match` now runs before the `if from_ty == to_ty` early return in `SemanticExprKind::Cast`. Previously, malformed semantic cast metadata could bypass type-invariant validation and leak a mislabeled value type. Now both the no-op and real-cast paths run through the check.

2. **Add i64 range guard for Numeric literals** — `lower_value` now checks that an integer literal fits in i64 range before resolving `SemanticType::Numeric` to `IrType::I64`. Out-of-range literals return a clear `UnsupportedSemanticConstruct` error instead of silently producing invalid IR. The dead `i128::try_from` call (which was always a no-op since `n: i128`) is replaced by a direct dereference.

## Files Changed

- `src/ir/lower.rs` — two localised edits, no other files touched

## Validation

```
cargo build --features jit   ✅  (warnings unchanged from pre-existing)
cargo test --features jit    ✅  254 passed; 0 failed
```

## Notes

- This branch is based on `stokowski/CX-81` (PR #126) since the CX-81 changes are not yet merged to submain. The PR is opened against `submain`; base can be adjusted to submain directly once CX-81 merges.
- Linear ticket: CX-86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Untyped numeric literals now default to 64-bit integers, improving consistency in inference and casting.

* **Behavioral Improvements**
  * Casting large untyped numeric literals to wider integer types now succeeds and produces appropriately sized constants without unnecessary intermediate casts.

* **Tests**
  * Added coverage validating untyped-literal casting and emitted integer constant behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/129)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->