### PR TITLE
CX-94: Add JIT parity fixtures for DotAccess struct field reads and writes

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -388,36 +388,56 @@ impl HostBoundary {
         let main_id = main_id.ok_or(JitExecutionError::MainNotFound)?;
         let main_ptr = module.get_finalized_function(main_id);
 
-        // Dispatch based on whether `main` has an explicit return type.
+        // Validate `main`'s full signature before dispatching.
         //
-        // Real Cx programs always produce a synthetic `main` with no return type
-        // (`return_ty: None`).  The validator enforces this.  Calling a void
-        // function as `fn() -> i32` is UB — the register file is indeterminate
-        // after `ret`.  Instead, call as `fn()` and return exit code 0.
+        // Real Cx programs always produce a synthetic `main` with no parameters
+        // and no return type (`return_ty: None`).  The validator enforces this.
+        // Calling a void function as `fn() -> i32` is UB — the register file is
+        // indeterminate after `ret`.  Instead, call as `fn()` and return exit code 0.
         //
         // Manually-constructed IR (e.g. JIT unit tests) may declare `main` with
         // `return_ty: Some(IrType::I32)` to exercise non-zero exit codes.  In
         // that case the Cranelift signature has an I32 return, so calling as
         // `fn() -> i32` is correct and the return value becomes the exit code.
         //
+        // Any other signature (parameters present, or unsupported return type) is
+        // rejected as UnsupportedConstruct rather than transmuted unsafely.
+        //
         // SAFETY: `module` is still alive here, keeping the JIT code mapped.
-        let main_returns_value = ir
+        let main_func = ir
             .functions
             .iter()
             .find(|f| f.name == "main")
-            .map(|f| f.return_ty.is_some())
-            .unwrap_or(false);
+            .ok_or(JitExecutionError::MainNotFound)?;
 
-        if main_returns_value {
-            let main_fn: unsafe extern "C" fn() -> i32 =
-                unsafe { std::mem::transmute(main_ptr) };
-            let ret = unsafe { main_fn() };
-            Ok(JitOutcome::from_main_return(ret))
-        } else {
-            let main_fn: unsafe extern "C" fn() =
-                unsafe { std::mem::transmute(main_ptr) };
-            unsafe { main_fn() };
-            Ok(JitOutcome::success())
+        if !main_func.params.is_empty() {
+            return Err(JitExecutionError::UnsupportedConstruct {
+                construct: format!(
+                    "main has {} parameter(s); entry point must be parameter-free",
+                    main_func.params.len()
+                ),
+            });
+        }
+
+        match &main_func.return_ty {
+            None => {
+                let main_fn: unsafe extern "C" fn() =
+                    unsafe { std::mem::transmute(main_ptr) };
+                unsafe { main_fn() };
+                Ok(JitOutcome::success())
+            }
+            Some(crate::ir::types::IrType::I32) => {
+                let main_fn: unsafe extern "C" fn() -> i32 =
+                    unsafe { std::mem::transmute(main_ptr) };
+                let ret = unsafe { main_fn() };
+                Ok(JitOutcome::from_main_return(ret))
+            }
+            Some(other) => Err(JitExecutionError::UnsupportedConstruct {
+                construct: format!(
+                    "main has unsupported return type {:?}; only () and i32 are valid entry-point signatures",
+                    other
+                ),
+            }),
         }
     }
 

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -388,13 +388,37 @@ impl HostBoundary {
         let main_id = main_id.ok_or(JitExecutionError::MainNotFound)?;
         let main_ptr = module.get_finalized_function(main_id);
 
+        // Dispatch based on whether `main` has an explicit return type.
+        //
+        // Real Cx programs always produce a synthetic `main` with no return type
+        // (`return_ty: None`).  The validator enforces this.  Calling a void
+        // function as `fn() -> i32` is UB — the register file is indeterminate
+        // after `ret`.  Instead, call as `fn()` and return exit code 0.
+        //
+        // Manually-constructed IR (e.g. JIT unit tests) may declare `main` with
+        // `return_ty: Some(IrType::I32)` to exercise non-zero exit codes.  In
+        // that case the Cranelift signature has an I32 return, so calling as
+        // `fn() -> i32` is correct and the return value becomes the exit code.
+        //
         // SAFETY: `module` is still alive here, keeping the JIT code mapped.
-        // The function signature () -> i32 matches the IR declaration of `main`.
-        let main_fn: unsafe extern "C" fn() -> i32 =
-            unsafe { std::mem::transmute(main_ptr) };
-        let ret = unsafe { main_fn() };
+        let main_returns_value = ir
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .map(|f| f.return_ty.is_some())
+            .unwrap_or(false);
 
-        Ok(JitOutcome::from_main_return(ret))
+        if main_returns_value {
+            let main_fn: unsafe extern "C" fn() -> i32 =
+                unsafe { std::mem::transmute(main_ptr) };
+            let ret = unsafe { main_fn() };
+            Ok(JitOutcome::from_main_return(ret))
+        } else {
+            let main_fn: unsafe extern "C" fn() =
+                unsafe { std::mem::transmute(main_ptr) };
+            unsafe { main_fn() };
+            Ok(JitOutcome::success())
+        }
     }
 
     /// Stub used when the `jit` feature is not enabled.

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -200,6 +200,9 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t110_struct_field_assign_overflow"
         | "t114_field_type_mismatch_reject"
         | "t115_strref_in_struct_reject"
+        | "t125_struct_field_read_exit"
+        | "t126_struct_second_field_read_exit"
+        | "t127_struct_field_write_exit"
             => FeatureCategory::Struct,
 
         // ── Array ─────────────────────────────────────────────────────────────
@@ -210,6 +213,7 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── CompoundAssign ────────────────────────────────────────────────────
         "t26_compound_add_two"
         | "t41_compound_assign_dot"
+        | "t128_struct_compound_assign_exit"
             => FeatureCategory::CompoundAssign,
 
         // ── Unary ─────────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t125_struct_field_read_exit.cx
+++ b/src/tests/verification_matrix/t125_struct_field_read_exit.cx
@@ -1,0 +1,5 @@
+// CX-94: exit-code-based JIT parity — struct field read, first field (no PtrOffset).
+// Correctness verified by exit code only (0 = all asserts held).
+struct Point { x: t64, y: t64 }
+p: Point = Point { x: 10, y: 20 }
+assert_eq(p.x, 10)

--- a/src/tests/verification_matrix/t126_struct_second_field_read_exit.cx
+++ b/src/tests/verification_matrix/t126_struct_second_field_read_exit.cx
@@ -1,0 +1,5 @@
+// CX-94: exit-code-based JIT parity — struct field read, second field (PtrOffset + Load).
+// Correctness verified by exit code only (0 = all asserts held).
+struct Point { x: t64, y: t64 }
+p: Point = Point { x: 10, y: 20 }
+assert_eq(p.y, 20)

--- a/src/tests/verification_matrix/t127_struct_field_write_exit.cx
+++ b/src/tests/verification_matrix/t127_struct_field_write_exit.cx
@@ -1,0 +1,6 @@
+// CX-94: exit-code-based JIT parity — struct field write then read-back.
+// Correctness verified by exit code only (0 = all asserts held).
+struct Counter { value: t64 }
+c: Counter = Counter { value: 0 }
+c.value = 42
+assert_eq(c.value, 42)

--- a/src/tests/verification_matrix/t128_struct_compound_assign_exit.cx
+++ b/src/tests/verification_matrix/t128_struct_compound_assign_exit.cx
@@ -1,0 +1,7 @@
+// CX-94: exit-code-based JIT parity — compound assign on a struct field.
+// Verifies the Load + Binary + Store pattern emitted by DotAccess compound assign.
+// Correctness verified by exit code only (0 = all asserts held).
+struct Player { health: t64 }
+p: Player = Player { health: 100 }
+p.health -= 30
+assert_eq(p.health, 70)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-94/lower-dotaccess-struct-field-reads-and-writes-in-ir-lowering-phase-11

## Summary

- Fix JIT host: void synthetic `main` was being called as `fn() -> i32` (UB). The register file after a void `ret` is indeterminate, causing struct programs to exit with garbage exit codes. Now dispatches on `main.return_ty`: void → call as `fn()` and return exit 0; `Some(I32)` → call as `fn() -> i32` and use the return value as the exit code. Existing JIT unit tests (which construct `main` with `return_ty: Some(I32)`) are unaffected.

- Four new PassAny parity fixtures verify DotAccess IR lowering end-to-end through the Cranelift JIT:
  - `t125_struct_field_read_exit.cx` — first-field read (Alloca + Store + Load, no PtrOffset)
  - `t126_struct_second_field_read_exit.cx` — second-field read (PtrOffset + Load)
  - `t127_struct_field_write_exit.cx` — field write then read-back (Store + Load)
  - `t128_struct_compound_assign_exit.cx` — compound assign on field (Load + Binary + Store)

- All four registered in `feature_of()` under `Struct` / `CompoundAssign`.

## Files changed

- `src/backend/cranelift/host_boundary.rs` — void-main dispatch fix
- `src/diff_harness.rs` — register t125–t128 in feature_of()
- `src/tests/verification_matrix/t125_struct_field_read_exit.cx` (new)
- `src/tests/verification_matrix/t126_struct_second_field_read_exit.cx` (new)
- `src/tests/verification_matrix/t127_struct_field_write_exit.cx` (new)
- `src/tests/verification_matrix/t128_struct_compound_assign_exit.cx` (new)

## Parity table after this change

| Feature | PASS | SKIP | PARITY_FAIL |
|---|---|---|---|
| Struct | 5 (+3) | 6 | 0 |
| CompoundAssign | 1 (+1) | 2 | 0 |
| Arithmetic | 6 (+3) | 11 | 0 |
| VariableDecl | 5 (+2) | 3 | 0 |

The void-main fix also recovered previously-skipping Arithmetic and VariableDecl fixtures.

## Validation

```
cargo build --features jit && cargo test --features jit
280 passed, 0 failed; 0 PARITY_FAILs across all 15 feature categories
132 fixtures checked
```

## Linear ticket reference

CX-94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added four new verification tests covering struct field read, second-field read, field write, and compound-assignment scenarios (exit-code validation).
  * Updated test categorization to include the new struct-related fixtures.

* **Bug Fixes**
  * JIT execution now validates and dispatches based on a function's declared return signature, correctly handling void and int-return mains and rejecting unsupported signatures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/137)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->