### PR TITLE
CX-98: Apply CodeRabbit main-signature fix on CX-94 void-main PR

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -388,36 +388,56 @@ impl HostBoundary {
         let main_id = main_id.ok_or(JitExecutionError::MainNotFound)?;
         let main_ptr = module.get_finalized_function(main_id);
 
-        // Dispatch based on whether `main` has an explicit return type.
+        // Validate `main`'s full signature before dispatching.
         //
-        // Real Cx programs always produce a synthetic `main` with no return type
-        // (`return_ty: None`).  The validator enforces this.  Calling a void
-        // function as `fn() -> i32` is UB — the register file is indeterminate
-        // after `ret`.  Instead, call as `fn()` and return exit code 0.
+        // Real Cx programs always produce a synthetic `main` with no parameters
+        // and no return type (`return_ty: None`).  The validator enforces this.
+        // Calling a void function as `fn() -> i32` is UB — the register file is
+        // indeterminate after `ret`.  Instead, call as `fn()` and return exit code 0.
         //
         // Manually-constructed IR (e.g. JIT unit tests) may declare `main` with
         // `return_ty: Some(IrType::I32)` to exercise non-zero exit codes.  In
         // that case the Cranelift signature has an I32 return, so calling as
         // `fn() -> i32` is correct and the return value becomes the exit code.
         //
+        // Any other signature (parameters present, or unsupported return type) is
+        // rejected as UnsupportedConstruct rather than transmuted unsafely.
+        //
         // SAFETY: `module` is still alive here, keeping the JIT code mapped.
-        let main_returns_value = ir
+        let main_func = ir
             .functions
             .iter()
             .find(|f| f.name == "main")
-            .map(|f| f.return_ty.is_some())
-            .unwrap_or(false);
+            .ok_or(JitExecutionError::MainNotFound)?;
 
-        if main_returns_value {
-            let main_fn: unsafe extern "C" fn() -> i32 =
-                unsafe { std::mem::transmute(main_ptr) };
-            let ret = unsafe { main_fn() };
-            Ok(JitOutcome::from_main_return(ret))
-        } else {
-            let main_fn: unsafe extern "C" fn() =
-                unsafe { std::mem::transmute(main_ptr) };
-            unsafe { main_fn() };
-            Ok(JitOutcome::success())
+        if !main_func.params.is_empty() {
+            return Err(JitExecutionError::UnsupportedConstruct {
+                construct: format!(
+                    "main has {} parameter(s); entry point must be parameter-free",
+                    main_func.params.len()
+                ),
+            });
+        }
+
+        match &main_func.return_ty {
+            None => {
+                let main_fn: unsafe extern "C" fn() =
+                    unsafe { std::mem::transmute(main_ptr) };
+                unsafe { main_fn() };
+                Ok(JitOutcome::success())
+            }
+            Some(crate::ir::types::IrType::I32) => {
+                let main_fn: unsafe extern "C" fn() -> i32 =
+                    unsafe { std::mem::transmute(main_ptr) };
+                let ret = unsafe { main_fn() };
+                Ok(JitOutcome::from_main_return(ret))
+            }
+            Some(other) => Err(JitExecutionError::UnsupportedConstruct {
+                construct: format!(
+                    "main has unsupported return type {:?}; only () and i32 are valid entry-point signatures",
+                    other
+                ),
+            }),
         }
     }
 

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -388,13 +388,37 @@ impl HostBoundary {
         let main_id = main_id.ok_or(JitExecutionError::MainNotFound)?;
         let main_ptr = module.get_finalized_function(main_id);
 
+        // Dispatch based on whether `main` has an explicit return type.
+        //
+        // Real Cx programs always produce a synthetic `main` with no return type
+        // (`return_ty: None`).  The validator enforces this.  Calling a void
+        // function as `fn() -> i32` is UB — the register file is indeterminate
+        // after `ret`.  Instead, call as `fn()` and return exit code 0.
+        //
+        // Manually-constructed IR (e.g. JIT unit tests) may declare `main` with
+        // `return_ty: Some(IrType::I32)` to exercise non-zero exit codes.  In
+        // that case the Cranelift signature has an I32 return, so calling as
+        // `fn() -> i32` is correct and the return value becomes the exit code.
+        //
         // SAFETY: `module` is still alive here, keeping the JIT code mapped.
-        // The function signature () -> i32 matches the IR declaration of `main`.
-        let main_fn: unsafe extern "C" fn() -> i32 =
-            unsafe { std::mem::transmute(main_ptr) };
-        let ret = unsafe { main_fn() };
+        let main_returns_value = ir
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .map(|f| f.return_ty.is_some())
+            .unwrap_or(false);
 
-        Ok(JitOutcome::from_main_return(ret))
+        if main_returns_value {
+            let main_fn: unsafe extern "C" fn() -> i32 =
+                unsafe { std::mem::transmute(main_ptr) };
+            let ret = unsafe { main_fn() };
+            Ok(JitOutcome::from_main_return(ret))
+        } else {
+            let main_fn: unsafe extern "C" fn() =
+                unsafe { std::mem::transmute(main_ptr) };
+            unsafe { main_fn() };
+            Ok(JitOutcome::success())
+        }
     }
 
     /// Stub used when the `jit` feature is not enabled.

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -200,6 +200,9 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t110_struct_field_assign_overflow"
         | "t114_field_type_mismatch_reject"
         | "t115_strref_in_struct_reject"
+        | "t125_struct_field_read_exit"
+        | "t126_struct_second_field_read_exit"
+        | "t127_struct_field_write_exit"
             => FeatureCategory::Struct,
 
         // ── Array ─────────────────────────────────────────────────────────────
@@ -210,6 +213,7 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── CompoundAssign ────────────────────────────────────────────────────
         "t26_compound_add_two"
         | "t41_compound_assign_dot"
+        | "t128_struct_compound_assign_exit"
             => FeatureCategory::CompoundAssign,
 
         // ── Unary ─────────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t125_struct_field_read_exit.cx
+++ b/src/tests/verification_matrix/t125_struct_field_read_exit.cx
@@ -1,0 +1,5 @@
+// CX-94: exit-code-based JIT parity — struct field read, first field (no PtrOffset).
+// Correctness verified by exit code only (0 = all asserts held).
+struct Point { x: t64, y: t64 }
+p: Point = Point { x: 10, y: 20 }
+assert_eq(p.x, 10)

--- a/src/tests/verification_matrix/t126_struct_second_field_read_exit.cx
+++ b/src/tests/verification_matrix/t126_struct_second_field_read_exit.cx
@@ -1,0 +1,5 @@
+// CX-94: exit-code-based JIT parity — struct field read, second field (PtrOffset + Load).
+// Correctness verified by exit code only (0 = all asserts held).
+struct Point { x: t64, y: t64 }
+p: Point = Point { x: 10, y: 20 }
+assert_eq(p.y, 20)

--- a/src/tests/verification_matrix/t127_struct_field_write_exit.cx
+++ b/src/tests/verification_matrix/t127_struct_field_write_exit.cx
@@ -1,0 +1,6 @@
+// CX-94: exit-code-based JIT parity — struct field write then read-back.
+// Correctness verified by exit code only (0 = all asserts held).
+struct Counter { value: t64 }
+c: Counter = Counter { value: 0 }
+c.value = 42
+assert_eq(c.value, 42)

--- a/src/tests/verification_matrix/t128_struct_compound_assign_exit.cx
+++ b/src/tests/verification_matrix/t128_struct_compound_assign_exit.cx
@@ -1,0 +1,7 @@
+// CX-94: exit-code-based JIT parity — compound assign on a struct field.
+// Verifies the Load + Binary + Store pattern emitted by DotAccess compound assign.
+// Correctness verified by exit code only (0 = all asserts held).
+struct Player { health: t64 }
+p: Player = Player { health: 100 }
+p.health -= 30
+assert_eq(p.health, 70)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-98/cx-97-apply-coderabbit-main-signature-fix-on-cx-94-void-main-pr

## Summary

Applies the CodeRabbit-requested main-signature validation fix to the void-main dispatch introduced in CX-94.

Previously, the dispatch only checked `main_returns_value` (a bool) to decide which transmute to use — never validating that `main` has no parameters or that its return type is one of the two supported forms.

This PR replaces the bool guard with full signature validation:
- Looks up `main` in `ir.functions` (already done for `main_id`, now used for validation)
- Rejects any non-empty `params` list with `Err(UnsupportedConstruct)`
- Dispatches `return_ty: None` as `unsafe extern "C" fn()` → `JitOutcome::success()`
- Dispatches `return_ty: Some(IrType::I32)` as `unsafe extern "C" fn() -> i32` → `JitOutcome::from_main_return(ret)`
- Rejects any other `return_ty` variant with `Err(UnsupportedConstruct)`

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — replaced `main_returns_value` bool check with match on `main_func.return_ty` plus `main_func.params` count guard

## Base

This branch is based on `stokowski/CX-94` and includes CX-94's void-main dispatch and struct-fixture changes as its base.

## Validation

```
cargo build --features jit   ✓ (warnings only, no errors)
cargo test --features jit    ✓ 280 passed; 0 failed
```

## Linear

CX-98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT execution to validate main function signatures before invocation, ensuring safe handling of functions with different return types.

* **Tests**
  * Expanded verification test suite with new tests covering struct field operations including field reads, field writes, and compound assignments on struct members.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/141)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->