### PR TITLE
CX-101: Add JIT parity fixtures for float arithmetic and explicit cast operations

### DIFF
--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -220,11 +220,17 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         "t96_overflow_t8_unary_neg"
             => FeatureCategory::Unary,
 
-        // Cast — no fixtures in the current matrix explicitly target casts.
-        // The variant exists for completeness when new cast fixtures are added.
+        // ── Cast ─────────────────────────────────────────────────────────────
+        "t133_cast_t32_to_f64_exit"
+        | "t134_cast_f64_truncate_exit"
+            => FeatureCategory::Cast,
 
         // ── FloatOps ──────────────────────────────────────────────────────────
         "t55_f64_basic"
+        | "t129_float_arith_add_exit"
+        | "t130_float_arith_sub_exit"
+        | "t131_float_arith_mul_exit"
+        | "t132_float_arith_div_exit"
             => FeatureCategory::FloatOps,
 
         // ── BuiltinAssert ─────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t129_float_arith_add_exit.cx
+++ b/src/tests/verification_matrix/t129_float_arith_add_exit.cx
@@ -1,0 +1,13 @@
+// CX-101: exit-code-based JIT parity — f64 addition.
+// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+a: f64 = 3.0
+b: f64 = 4.0
+sum: f64 = a + b
+n: t32 = sum
+assert_eq(n, 7)
+
+x: f64 = 0.5
+y: f64 = 1.5
+sum2: f64 = x + y
+m: t32 = sum2
+assert_eq(m, 2)

--- a/src/tests/verification_matrix/t130_float_arith_sub_exit.cx
+++ b/src/tests/verification_matrix/t130_float_arith_sub_exit.cx
@@ -1,0 +1,13 @@
+// CX-101: exit-code-based JIT parity — f64 subtraction.
+// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+a: f64 = 10.0
+b: f64 = 3.0
+diff: f64 = a - b
+n: t32 = diff
+assert_eq(n, 7)
+
+x: f64 = 5.5
+y: f64 = 0.5
+diff2: f64 = x - y
+m: t32 = diff2
+assert_eq(m, 5)

--- a/src/tests/verification_matrix/t131_float_arith_mul_exit.cx
+++ b/src/tests/verification_matrix/t131_float_arith_mul_exit.cx
@@ -1,0 +1,13 @@
+// CX-101: exit-code-based JIT parity — f64 multiplication.
+// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+a: f64 = 2.0
+b: f64 = 4.0
+product: f64 = a * b
+n: t32 = product
+assert_eq(n, 8)
+
+x: f64 = 3.0
+y: f64 = 3.0
+product2: f64 = x * y
+m: t32 = product2
+assert_eq(m, 9)

--- a/src/tests/verification_matrix/t132_float_arith_div_exit.cx
+++ b/src/tests/verification_matrix/t132_float_arith_div_exit.cx
@@ -1,0 +1,13 @@
+// CX-101: exit-code-based JIT parity — f64 division.
+// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+a: f64 = 21.0
+b: f64 = 3.0
+quotient: f64 = a / b
+n: t32 = quotient
+assert_eq(n, 7)
+
+x: f64 = 10.0
+y: f64 = 2.0
+quotient2: f64 = x / y
+m: t32 = quotient2
+assert_eq(m, 5)

--- a/src/tests/verification_matrix/t133_cast_t32_to_f64_exit.cx
+++ b/src/tests/verification_matrix/t133_cast_t32_to_f64_exit.cx
@@ -1,0 +1,12 @@
+// CX-101: exit-code-based JIT parity — implicit t32→f64 cast and round-trip.
+// Assigns a t32 value to an f64 variable (implicit widening cast), then
+// reads it back into t32 (implicit truncating cast) and asserts equality.
+a: t32 = 42
+b: f64 = a
+c: t32 = b
+assert_eq(c, 42)
+
+x: t32 = 100
+y: f64 = x
+z: t32 = y
+assert_eq(z, 100)

--- a/src/tests/verification_matrix/t134_cast_f64_truncate_exit.cx
+++ b/src/tests/verification_matrix/t134_cast_f64_truncate_exit.cx
@@ -1,0 +1,13 @@
+// CX-101: exit-code-based JIT parity — implicit f64→t32 truncation cast.
+// Truncates toward zero: 7.9 → 7, 9.9 → 9, 2.1 → 2.
+x: f64 = 7.9
+n: t32 = x
+assert_eq(n, 7)
+
+y: f64 = 9.9
+m: t32 = y
+assert_eq(m, 9)
+
+z: f64 = 2.1
+k: t32 = z
+assert_eq(k, 2)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-101/cx-101-add-jit-parity-fixtures-for-float-arithmetic-and-explicit-cast

## Summary

- Added 4 exit-code-based fixtures for f64 arithmetic parity (t129–t132)
- Added 2 exit-code-based fixtures for implicit cast parity (t133–t134)
- Registered all 6 fixtures in `diff_harness::feature_of()` under `FloatOps` and `Cast`

## Files changed

- `src/tests/verification_matrix/t129_float_arith_add_exit.cx` — f64 addition (+)
- `src/tests/verification_matrix/t130_float_arith_sub_exit.cx` — f64 subtraction (-)
- `src/tests/verification_matrix/t131_float_arith_mul_exit.cx` — f64 multiplication (*)
- `src/tests/verification_matrix/t132_float_arith_div_exit.cx` — f64 division (/)
- `src/tests/verification_matrix/t133_cast_t32_to_f64_exit.cx` — implicit t32→f64 widening cast + round-trip
- `src/tests/verification_matrix/t134_cast_f64_truncate_exit.cx` — implicit f64→t32 truncation cast
- `src/diff_harness.rs` — `feature_of()` mapping for the 6 new fixtures

## Design notes

`assert_eq` does not support `F64` operands (rejected in IR lowering) and `print()` is blocked in the JIT backend (requires string ABI, not yet implemented). The fixtures therefore cast f64 results to `t32` before asserting, which exercises the full path — float arithmetic in the JIT, then `fcvt_to_sint_sat` for the narrowing cast — while keeping the assertion expressible in both backends.

## Validation

```
cargo build --features jit   ✓ (warnings pre-existing, no new ones)
cargo test --features jit    ✓ 290 passed; 0 failed
  interpreter_baseline_all   ok
  jit_parity_by_feature      ok
```

## Linear ticket

CX-101 — https://linear.app/cx-lang/issue/CX-101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification tests for floating-point arithmetic operations (addition, subtraction, multiplication, and division).
  * Added verification tests for numeric type casting between integer and floating-point types.
  * Updated test matrix configuration to reflect new test coverage for Phase 12.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/144)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->