### PR TITLE
CX-102: Rebase CX-99 Branch/Jump parity fixtures onto current submain

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -1379,6 +1379,60 @@ mod jit_tests {
     }
 
     #[test]
+    fn jit_void_main_returns_success() {
+        // A void-returning main (return_ty: None) must be called as fn() and
+        // produce JitOutcome::success() — not as fn()->i32 which would read
+        // garbage from rax and produce an indeterminate exit code.
+        //
+        // The helper function returns 99 (non-zero); main calls it and discards
+        // the result.  Under the old wrong calling convention (fn()->i32), rax
+        // holds 99 after the call and the exit code would be non-zero, making
+        // this test reliably surface the regression.
+        let module = IrModule {
+            debug_name: "test_void_main".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "helper".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 99 },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(0)) },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: None,
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::Call {
+                                dst: None,
+                                callee: "helper".to_string(),
+                                args: vec![],
+                                return_ty: Some(IrType::I32),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: None },
+                    }],
+                },
+            ],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert!(
+            result.unwrap().exit_code.is_success(),
+            "void main must produce exit code 0"
+        );
+    }
+
+    #[test]
     fn jit_unsupported_inst_returns_error() {
         // Cast from Ptr is explicitly unsupported and must return UnsupportedConstruct.
         // Ptr casts have no scalar equivalent in Cx and are rejected at the JIT boundary.

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -156,6 +156,9 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         "t44_if_else_basic"
         | "t45_if_else_in_func"
         | "t46_if_not"
+        | "t129_if_else_exit"
+        | "t130_if_else_in_func_exit"
+        | "t131_if_not_exit"
             => FeatureCategory::IfElse,
 
         // ── WhileLoop ─────────────────────────────────────────────────────────
@@ -165,6 +168,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t105_while_in_func"
         | "t107_continue_in_func"
         | "t108_nested_loops_in_func"
+        | "t132_while_loop_exit"
+        | "t133_while_in_func_exit"
             => FeatureCategory::WhileLoop,
 
         // ── ForLoop ───────────────────────────────────────────────────────────
@@ -175,6 +180,7 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── InfiniteLoop ──────────────────────────────────────────────────────
         "t25_loop_break"
         | "t106_loop_break_in_func"
+        | "t134_loop_break_exit"
             => FeatureCategory::InfiniteLoop,
 
         // ── DirectCall ────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t129_if_else_exit.cx
+++ b/src/tests/verification_matrix/t129_if_else_exit.cx
@@ -1,0 +1,27 @@
+// CX-97: exit-code-based JIT parity — Branch terminator (if/else).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+x: t64 = 10
+
+result: t64 = 0
+if x > 5 {
+    result = 1
+} else {
+    result = 0
+}
+assert_eq(result, 1)
+
+result = 0
+if x > 20 {
+    result = 99
+} else {
+    result = 2
+}
+assert_eq(result, 2)
+
+result = 0
+if x == 10 {
+    result = 3
+} else {
+    result = 0
+}
+assert_eq(result, 3)

--- a/src/tests/verification_matrix/t130_if_else_in_func_exit.cx
+++ b/src/tests/verification_matrix/t130_if_else_in_func_exit.cx
@@ -1,0 +1,21 @@
+// CX-97: exit-code-based JIT parity — Branch terminator in function (if/else chain).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 classify(n: t64) {
+    if n > 100 {
+        return 3;
+    } else if n > 50 {
+        return 2;
+    } else if n > 10 {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+assert_eq(classify(200), 3)
+assert_eq(classify(75), 2)
+assert_eq(classify(25), 1)
+assert_eq(classify(5), 0)
+assert_eq(classify(100), 2)
+assert_eq(classify(50), 1)
+assert_eq(classify(10), 0)

--- a/src/tests/verification_matrix/t131_if_not_exit.cx
+++ b/src/tests/verification_matrix/t131_if_not_exit.cx
@@ -1,0 +1,19 @@
+// CX-97: exit-code-based JIT parity — Branch terminator with negated condition.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+y: t64 = 5
+
+result: t64 = 0
+if !(y == 5) {
+    result = 99
+} else {
+    result = 1
+}
+assert_eq(result, 1)
+
+result = 0
+if !(y > 10) {
+    result = 2
+} else {
+    result = 0
+}
+assert_eq(result, 2)

--- a/src/tests/verification_matrix/t132_while_loop_exit.cx
+++ b/src/tests/verification_matrix/t132_while_loop_exit.cx
@@ -1,0 +1,32 @@
+// CX-97: exit-code-based JIT parity — Jump+Branch terminators (while loop).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// Uses plain assignment (i = i + 1) to avoid compound-assign type inference.
+fnc: t64 count_loop(limit: t64) {
+    i: t64 = 0
+    while (i < limit) {
+        i = i + 1
+    }
+    return i
+}
+
+fnc: t64 sum_loop(n: t64) {
+    total: t64 = 0
+    i: t64 = 0
+    while (i < n) {
+        total = total + i
+        i = i + 1
+    }
+    return total
+}
+
+assert_eq(count_loop(5), 5)
+assert_eq(count_loop(0), 0)
+assert_eq(sum_loop(5), 10)
+assert_eq(sum_loop(0), 0)
+
+// Top-level while at file scope — exercises the void-main Jump+Branch lowering path.
+top: t64 = 0
+while (top < 4) {
+    top = top + 1
+}
+assert_eq(top, 4)

--- a/src/tests/verification_matrix/t133_while_in_func_exit.cx
+++ b/src/tests/verification_matrix/t133_while_in_func_exit.cx
@@ -1,0 +1,16 @@
+// CX-97: exit-code-based JIT parity — Jump+Branch terminators in function (while loop).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// Uses plain assignment (i = i + 1) to avoid compound-assign type inference.
+fnc: t64 sum_to(n: t64) {
+    total: t64 = 0
+    i: t64 = 0
+    while (i < n) {
+        total = total + i
+        i = i + 1
+    }
+    return total
+}
+
+assert_eq(sum_to(5), 10)
+assert_eq(sum_to(10), 45)
+assert_eq(sum_to(0), 0)

--- a/src/tests/verification_matrix/t134_loop_break_exit.cx
+++ b/src/tests/verification_matrix/t134_loop_break_exit.cx
@@ -1,0 +1,17 @@
+// CX-97: exit-code-based JIT parity — Jump terminator (loop + break).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// Uses plain assignment (i = i + 1) to avoid compound-assign type inference.
+fnc: t64 find_first_even(start: t64) {
+    i: t64 = start
+    loop {
+        if (i % 2) == 0 {
+            break
+        }
+        i = i + 1
+    }
+    return i
+}
+
+assert_eq(find_first_even(7), 8)
+assert_eq(find_first_even(0), 0)
+assert_eq(find_first_even(3), 4)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-102/cx-101-rebase-cx-99-branchjump-parity-cleanup-pr-onto-current-submain

## Summary

- CX-99's Branch/Jump terminator parity fixtures (originally t125-t130) conflicted with CX-94's struct field parity fixtures which occupied t125-t128 in submain. This PR rebases the CX-99 work by renumbering the Branch/Jump fixtures to t129-t134.
- Ports `jit_void_main_returns_success` unit test from CX-99 into `host_boundary.rs`; this test validates the void-main dispatch path added by CX-98 and was absent from submain.

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — added `jit_void_main_returns_success` test
- `src/diff_harness.rs` — updated `feature_of()` entries for renamed fixtures (t129–t134)
- `src/tests/verification_matrix/t129_if_else_exit.cx` — Branch terminator (if/else) parity fixture
- `src/tests/verification_matrix/t130_if_else_in_func_exit.cx` — Branch in function parity fixture
- `src/tests/verification_matrix/t131_if_not_exit.cx` — Branch with negated condition fixture
- `src/tests/verification_matrix/t132_while_loop_exit.cx` — Jump+Branch while-loop fixture
- `src/tests/verification_matrix/t133_while_in_func_exit.cx` — Jump+Branch while-in-func fixture
- `src/tests/verification_matrix/t134_loop_break_exit.cx` — Jump loop+break fixture

## Validation

```
cargo build --features jit  →  ok (warnings only, pre-existing)
cargo test --features jit   →  291 passed; 0 failed
```

## Linear Ticket

CX-102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added JIT integration test validating void entry function execution and calling conventions.
  * Added five new verification tests for control-flow features: if/else branching, while loops, and loop break statements.
  * Updated test fixture classification to include additional verification test coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/145)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->