### PR TITLE
CX-108: Add observable short-circuit side-effect proof to LogicalOps tests

### DIFF
--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -6357,4 +6357,120 @@ mod tests {
             "logical OR with non-Bool result type must be rejected by lower_logical"
         );
     }
+
+    // Observable side-effect proof: the Call instruction (representing an
+    // observable RHS side effect) must appear only in the RHS block, never in
+    // the SC block.  This is the IR-level equivalent of the rhs_trap() fixture
+    // in t141_logical_and_or_exit.cx — it proves that short-circuit lowering
+    // truly isolates RHS evaluation to the path where it is needed.
+
+    #[test]
+    fn and_short_circuit_rhs_call_is_in_rhs_block_only() {
+        // x: bool = false && side_effect_fn()
+        // AND: then=rhs (LHS true → evaluate RHS), else=sc (LHS false → false constant).
+        // The Call must land in the rhs block and must be absent from the sc block.
+        let call_rhs = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "side_effect_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let program = SemanticProgram {
+            stmts: vec![
+                semantic_function(
+                    "side_effect_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(true)),
+                ),
+                typed_assign(
+                    BindingId(0),
+                    "x",
+                    SemanticType::Bool,
+                    logical_and_expr(bool_expr(false), call_rhs),
+                ),
+            ],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+
+        let branch_block = main_fn.blocks.iter()
+            .find(|b| matches!(b.term, IrTerminator::Branch { .. }))
+            .expect("AND must emit a Branch terminator");
+        let (rhs_id, sc_id) = match &branch_block.term {
+            IrTerminator::Branch { then_block, else_block, .. } => (*then_block, *else_block),
+            _ => unreachable!(),
+        };
+
+        let rhs_block = main_fn.blocks.iter().find(|b| b.id == rhs_id).unwrap();
+        let sc_block  = main_fn.blocks.iter().find(|b| b.id == sc_id).unwrap();
+
+        assert!(
+            rhs_block.insts.iter().any(|i| matches!(i, IrInst::Call { .. })),
+            "Call must be present in the RHS block"
+        );
+        assert!(
+            !sc_block.insts.iter().any(|i| matches!(i, IrInst::Call { .. })),
+            "Call must NOT be present in the SC block — AND short-circuit must suppress RHS evaluation"
+        );
+    }
+
+    #[test]
+    fn or_short_circuit_rhs_call_is_in_rhs_block_only() {
+        // x: bool = true || side_effect_fn()
+        // OR: then=sc (LHS true → true constant), else=rhs (LHS false → evaluate RHS).
+        // The Call must land in the rhs block and must be absent from the sc block.
+        let call_rhs = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "side_effect_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let program = SemanticProgram {
+            stmts: vec![
+                semantic_function(
+                    "side_effect_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(false)),
+                ),
+                typed_assign(
+                    BindingId(0),
+                    "x",
+                    SemanticType::Bool,
+                    logical_or_expr(bool_expr(true), call_rhs),
+                ),
+            ],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+
+        let branch_block = main_fn.blocks.iter()
+            .find(|b| matches!(b.term, IrTerminator::Branch { .. }))
+            .expect("OR must emit a Branch terminator");
+        let (sc_id, rhs_id) = match &branch_block.term {
+            IrTerminator::Branch { then_block, else_block, .. } => (*then_block, *else_block),
+            _ => unreachable!(),
+        };
+
+        let rhs_block = main_fn.blocks.iter().find(|b| b.id == rhs_id).unwrap();
+        let sc_block  = main_fn.blocks.iter().find(|b| b.id == sc_id).unwrap();
+
+        assert!(
+            rhs_block.insts.iter().any(|i| matches!(i, IrInst::Call { .. })),
+            "Call must be present in the RHS block"
+        );
+        assert!(
+            !sc_block.insts.iter().any(|i| matches!(i, IrInst::Call { .. })),
+            "Call must NOT be present in the SC block — OR short-circuit must suppress RHS evaluation"
+        );
+    }
 }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-108/cx-108-add-observable-short-circuit-side-effect-proof-to-cx-107

## Summary

Adds two IR-level unit tests that prove short-circuit evaluation truly isolates RHS evaluation to the correct CFG block. This is the IR-level counterpart to the `rhs_trap()` runtime proof already present in `t141_logical_and_or_exit.cx`.

- `and_short_circuit_rhs_call_is_in_rhs_block_only`: lowers `false && side_effect_fn()`, locates the Branch terminator, and asserts the `IrInst::Call` is present in the `then_block` (rhs path, reached when LHS is true) and **absent** from the `else_block` (sc path, reached when LHS is false).

- `or_short_circuit_rhs_call_is_in_rhs_block_only`: lowers `true || side_effect_fn()`, locates the Branch terminator, and asserts the `IrInst::Call` is present in the `else_block` (rhs path, reached when LHS is false) and **absent** from the `then_block` (sc path, reached when LHS is true).

## Files changed

- `src/ir/lower.rs` — 116 lines added (two new `#[test]` functions + explanatory block comment)

## Tests run

```
cargo build --features jit   ✓
cargo test --features jit    ✓  305 passed; 0 failed
```

New tests pass:
```
test ir::lower::tests::and_short_circuit_rhs_call_is_in_rhs_block_only ... ok
test ir::lower::tests::or_short_circuit_rhs_call_is_in_rhs_block_only ... ok
```

## Validation result

All 305 tests pass. No regressions. No warnings introduced.

## Context

The existing LogicalOps unit tests (`lowers_logical_and_to_short_circuit_cfg`, `lowers_logical_or_to_short_circuit_cfg`) verify CFG structure (block count ≥ 4, Branch terminator present, short-circuit ConstInt present somewhere). CX-108 extends this with block-containment assertions: the observable side effect (a `Call` instruction representing RHS evaluation) must appear **only** in the RHS block, never in the SC block.

## Linear ticket

https://linear.app/cx-lang/issue/CX-108/cx-108-add-observable-short-circuit-side-effect-proof-to-cx-107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to verify correct handling of logical operators in conditional expressions across different execution paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/151)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->