### PR TITLE
CX-110: Apply final CodeRabbit hardening on CX-109 LogicalOps tests

### DIFF
--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -251,6 +251,7 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
 
         // ── LogicalOps ────────────────────────────────────────────────────────
         "t141_logical_and_or_exit"
+        | "t142_logical_while_and_nested_exit"
             => FeatureCategory::LogicalOps,
 
         // ── Other (everything not assigned to a named category) ───────────────

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -6357,4 +6357,470 @@ mod tests {
             "logical OR with non-Bool result type must be rejected by lower_logical"
         );
     }
+
+    // CX-108: Observable side-effect proof.
+    //
+    // The Call instruction (representing an observable RHS side effect) must
+    // appear only in the RHS block, never in the SC block.  This is the
+    // IR-level equivalent of the rhs_trap() fixture in t141_logical_and_or_exit.cx
+    // — it proves that short-circuit lowering truly isolates RHS evaluation to
+    // the path where it is needed.
+    //
+    // CX-110 hardens these tests: instead of matching any IrInst::Call,
+    // we match by callee name ("side_effect_fn") and assert that exactly one
+    // such call exists across all blocks in main, and that block is rhs_id.
+
+    #[test]
+    fn and_short_circuit_rhs_call_is_in_rhs_block_only() {
+        // x: bool = false && side_effect_fn()
+        // AND: then=rhs (LHS true → evaluate RHS), else=sc (LHS false → false constant).
+        // The Call must land in the rhs block and must be absent from the sc block.
+        let call_rhs = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "side_effect_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let program = SemanticProgram {
+            stmts: vec![
+                semantic_function(
+                    "side_effect_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(true)),
+                ),
+                typed_assign(
+                    BindingId(0),
+                    "x",
+                    SemanticType::Bool,
+                    logical_and_expr(bool_expr(false), call_rhs),
+                ),
+            ],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+
+        let branch_block = main_fn.blocks.iter()
+            .find(|b| matches!(b.term, IrTerminator::Branch { .. }))
+            .expect("AND must emit a Branch terminator");
+        let (rhs_id, sc_id) = match &branch_block.term {
+            IrTerminator::Branch { then_block, else_block, .. } => (*then_block, *else_block),
+            _ => unreachable!(),
+        };
+
+        let sc_block = main_fn.blocks.iter().find(|b| b.id == sc_id).unwrap();
+
+        let call_blocks: Vec<_> = main_fn.blocks.iter()
+            .filter(|b| b.insts.iter().any(|i| {
+                matches!(i, IrInst::Call { callee, .. } if callee == "side_effect_fn")
+            }))
+            .map(|b| b.id)
+            .collect();
+        assert_eq!(call_blocks.len(), 1, "expected exactly one side_effect_fn call in main");
+        assert_eq!(call_blocks[0], rhs_id, "side_effect_fn call must be emitted only in RHS block");
+        assert!(
+            !sc_block.insts.iter().any(|i| {
+                matches!(i, IrInst::Call { callee, .. } if callee == "side_effect_fn")
+            }),
+            "side_effect_fn call must NOT be present in SC block — AND short-circuit must suppress RHS evaluation"
+        );
+    }
+
+    #[test]
+    fn or_short_circuit_rhs_call_is_in_rhs_block_only() {
+        // x: bool = true || side_effect_fn()
+        // OR: then=sc (LHS true → true constant), else=rhs (LHS false → evaluate RHS).
+        // The Call must land in the rhs block and must be absent from the sc block.
+        let call_rhs = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "side_effect_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let program = SemanticProgram {
+            stmts: vec![
+                semantic_function(
+                    "side_effect_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(false)),
+                ),
+                typed_assign(
+                    BindingId(0),
+                    "x",
+                    SemanticType::Bool,
+                    logical_or_expr(bool_expr(true), call_rhs),
+                ),
+            ],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+
+        let branch_block = main_fn.blocks.iter()
+            .find(|b| matches!(b.term, IrTerminator::Branch { .. }))
+            .expect("OR must emit a Branch terminator");
+        let (sc_id, rhs_id) = match &branch_block.term {
+            IrTerminator::Branch { then_block, else_block, .. } => (*then_block, *else_block),
+            _ => unreachable!(),
+        };
+
+        let sc_block = main_fn.blocks.iter().find(|b| b.id == sc_id).unwrap();
+
+        let call_blocks: Vec<_> = main_fn.blocks.iter()
+            .filter(|b| b.insts.iter().any(|i| {
+                matches!(i, IrInst::Call { callee, .. } if callee == "side_effect_fn")
+            }))
+            .map(|b| b.id)
+            .collect();
+        assert_eq!(call_blocks.len(), 1, "expected exactly one side_effect_fn call in main");
+        assert_eq!(call_blocks[0], rhs_id, "side_effect_fn call must be emitted only in RHS block");
+        assert!(
+            !sc_block.insts.iter().any(|i| {
+                matches!(i, IrInst::Call { callee, .. } if callee == "side_effect_fn")
+            }),
+            "side_effect_fn call must NOT be present in SC block — OR short-circuit must suppress RHS evaluation"
+        );
+    }
+
+    // CX-109: Hardened RHS-block-only proof.
+    //
+    // CX-108 proved that a Call appearing as the RHS of a short-circuit
+    // expression lands in the RHS block and not in the SC block.  These tests
+    // strengthen that proof to cover all blocks: we scan every block in the
+    // lowered function and assert that the Call appears in exactly one of them,
+    // and that block is the RHS block.  This rules out leakage into the decision
+    // block, the merge block, or any synthetic block the lowering might
+    // introduce in the future.
+    //
+    // We additionally prove that the short-circuit constant (false for AND,
+    // true for OR) is confined to the SC block and does not appear in any other
+    // block, completing the dual-isolation guarantee.
+    //
+    // CX-110 hardens both groups:
+    // — "confined" tests: match Call by callee ("side_effect_fn") instead of any Call.
+    // — SC-constant tests: replace literal bool LHS with a non-literal call so
+    //   the same ConstInt cannot leak into the decision block, then assert the
+    //   constant appears in exactly one block (the SC block).
+
+    #[test]
+    fn and_rhs_call_confined_to_rhs_block_across_all_blocks() {
+        // false && side_effect_fn()
+        // Scans every block in main; the side_effect_fn Call must appear in
+        // exactly one block and that block must be the RHS block (then-branch
+        // of the AND Branch).
+        let call_rhs = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "side_effect_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let program = SemanticProgram {
+            stmts: vec![
+                semantic_function(
+                    "side_effect_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(true)),
+                ),
+                typed_assign(
+                    BindingId(0),
+                    "x",
+                    SemanticType::Bool,
+                    logical_and_expr(bool_expr(false), call_rhs),
+                ),
+            ],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+
+        let branch_block = main_fn.blocks.iter()
+            .find(|b| matches!(b.term, IrTerminator::Branch { .. }))
+            .expect("AND must emit a Branch terminator");
+        // AND: then_block = rhs, else_block = sc.
+        let rhs_id = match &branch_block.term {
+            IrTerminator::Branch { then_block, .. } => *then_block,
+            _ => unreachable!(),
+        };
+
+        let blocks_with_call: Vec<_> = main_fn.blocks.iter()
+            .filter(|b| b.insts.iter().any(|i| {
+                matches!(i, IrInst::Call { callee, .. } if callee == "side_effect_fn")
+            }))
+            .collect();
+
+        assert_eq!(
+            blocks_with_call.len(),
+            1,
+            "side_effect_fn Call must appear in exactly one block; got {} — decision/sc/merge block isolation violated",
+            blocks_with_call.len()
+        );
+        assert_eq!(
+            blocks_with_call[0].id,
+            rhs_id,
+            "The sole block containing a side_effect_fn Call must be the RHS block"
+        );
+    }
+
+    #[test]
+    fn or_rhs_call_confined_to_rhs_block_across_all_blocks() {
+        // true || side_effect_fn()
+        // Scans every block in main; the side_effect_fn Call must appear in
+        // exactly one block and that block must be the RHS block (else-branch
+        // of the OR Branch).
+        let call_rhs = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "side_effect_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let program = SemanticProgram {
+            stmts: vec![
+                semantic_function(
+                    "side_effect_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(false)),
+                ),
+                typed_assign(
+                    BindingId(0),
+                    "x",
+                    SemanticType::Bool,
+                    logical_or_expr(bool_expr(true), call_rhs),
+                ),
+            ],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+
+        let branch_block = main_fn.blocks.iter()
+            .find(|b| matches!(b.term, IrTerminator::Branch { .. }))
+            .expect("OR must emit a Branch terminator");
+        // OR: then_block = sc, else_block = rhs.
+        let rhs_id = match &branch_block.term {
+            IrTerminator::Branch { else_block, .. } => *else_block,
+            _ => unreachable!(),
+        };
+
+        let blocks_with_call: Vec<_> = main_fn.blocks.iter()
+            .filter(|b| b.insts.iter().any(|i| {
+                matches!(i, IrInst::Call { callee, .. } if callee == "side_effect_fn")
+            }))
+            .collect();
+
+        assert_eq!(
+            blocks_with_call.len(),
+            1,
+            "side_effect_fn Call must appear in exactly one block; got {} — decision/sc/merge block isolation violated",
+            blocks_with_call.len()
+        );
+        assert_eq!(
+            blocks_with_call[0].id,
+            rhs_id,
+            "The sole block containing a side_effect_fn Call must be the RHS block"
+        );
+    }
+
+    #[test]
+    fn and_sc_block_contains_exactly_false_constant() {
+        // lhs_cond_fn() && side_effect_fn()
+        // Uses a non-literal (call) LHS so ConstInt(Bool, 0) can only appear
+        // in the SC block, never in the decision block.  Proves the false
+        // short-circuit constant is exclusive to the SC block.
+        let lhs_call = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "lhs_cond_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let call_rhs = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "side_effect_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let program = SemanticProgram {
+            stmts: vec![
+                semantic_function(
+                    "lhs_cond_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(false)),
+                ),
+                semantic_function(
+                    "side_effect_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(true)),
+                ),
+                typed_assign(
+                    BindingId(0),
+                    "x",
+                    SemanticType::Bool,
+                    logical_and_expr(lhs_call, call_rhs),
+                ),
+            ],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+
+        let branch_block = main_fn.blocks.iter()
+            .find(|b| matches!(b.term, IrTerminator::Branch { .. }))
+            .expect("AND must emit a Branch terminator");
+        // AND: then_block = rhs, else_block = sc.
+        let (rhs_id, sc_id) = match &branch_block.term {
+            IrTerminator::Branch { then_block, else_block, .. } => (*then_block, *else_block),
+            _ => unreachable!(),
+        };
+        let sc_block  = main_fn.blocks.iter().find(|b| b.id == sc_id).unwrap();
+        let rhs_block = main_fn.blocks.iter().find(|b| b.id == rhs_id).unwrap();
+
+        assert_eq!(
+            sc_block.insts.len(),
+            1,
+            "AND SC block must contain exactly one instruction (the short-circuit constant), got {}",
+            sc_block.insts.len()
+        );
+        assert!(
+            matches!(sc_block.insts[0], IrInst::ConstInt { ty: IrType::Bool, value: 0, .. }),
+            "AND SC block's sole instruction must be ConstInt(Bool, 0)"
+        );
+        assert!(
+            !rhs_block.insts.iter().any(|i| matches!(i, IrInst::ConstInt { ty: IrType::Bool, value: 0, .. })),
+            "ConstInt(Bool, 0) must not appear in the RHS block — false constant belongs only in SC block"
+        );
+        // Cross-block uniqueness: ConstInt(Bool, 0) must appear in exactly one
+        // block (the SC block).  With a non-literal LHS call, the decision block
+        // emits no ConstInt, so leakage would be caught here.
+        let false_const_blocks: Vec<_> = main_fn.blocks.iter()
+            .filter(|b| b.insts.iter().any(|i| matches!(i, IrInst::ConstInt { ty: IrType::Bool, value: 0, .. })))
+            .collect();
+        assert_eq!(
+            false_const_blocks.len(),
+            1,
+            "ConstInt(Bool, 0) must appear in exactly one block (the SC block); got {}",
+            false_const_blocks.len()
+        );
+        assert_eq!(
+            false_const_blocks[0].id,
+            sc_id,
+            "The sole ConstInt(Bool, 0) must reside in the SC block"
+        );
+    }
+
+    #[test]
+    fn or_sc_block_contains_exactly_true_constant() {
+        // lhs_cond_fn() || side_effect_fn()
+        // Uses a non-literal (call) LHS so ConstInt(Bool, 1) can only appear
+        // in the SC block, never in the decision block.  Proves the true
+        // short-circuit constant is exclusive to the SC block.
+        let lhs_call = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "lhs_cond_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let call_rhs = SemanticExpr {
+            ty: SemanticType::Bool,
+            kind: SemanticExprKind::Call {
+                callee: "side_effect_fn".to_string(),
+                function: FunctionId(0),
+                args: vec![],
+            },
+        };
+        let program = SemanticProgram {
+            stmts: vec![
+                semantic_function(
+                    "lhs_cond_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(true)),
+                ),
+                semantic_function(
+                    "side_effect_fn",
+                    vec![],
+                    Some(SemanticType::Bool),
+                    vec![],
+                    Some(bool_expr(false)),
+                ),
+                typed_assign(
+                    BindingId(0),
+                    "x",
+                    SemanticType::Bool,
+                    logical_or_expr(lhs_call, call_rhs),
+                ),
+            ],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+
+        let branch_block = main_fn.blocks.iter()
+            .find(|b| matches!(b.term, IrTerminator::Branch { .. }))
+            .expect("OR must emit a Branch terminator");
+        // OR: then_block = sc, else_block = rhs.
+        let (sc_id, rhs_id) = match &branch_block.term {
+            IrTerminator::Branch { then_block, else_block, .. } => (*then_block, *else_block),
+            _ => unreachable!(),
+        };
+        let sc_block  = main_fn.blocks.iter().find(|b| b.id == sc_id).unwrap();
+        let rhs_block = main_fn.blocks.iter().find(|b| b.id == rhs_id).unwrap();
+
+        assert_eq!(
+            sc_block.insts.len(),
+            1,
+            "OR SC block must contain exactly one instruction (the short-circuit constant), got {}",
+            sc_block.insts.len()
+        );
+        assert!(
+            matches!(sc_block.insts[0], IrInst::ConstInt { ty: IrType::Bool, value: 1, .. }),
+            "OR SC block's sole instruction must be ConstInt(Bool, 1)"
+        );
+        assert!(
+            !rhs_block.insts.iter().any(|i| matches!(i, IrInst::ConstInt { ty: IrType::Bool, value: 1, .. })),
+            "ConstInt(Bool, 1) must not appear in the RHS block — true constant belongs only in SC block"
+        );
+        // Cross-block uniqueness: ConstInt(Bool, 1) must appear in exactly one
+        // block (the SC block).  With a non-literal LHS call, the decision block
+        // emits no ConstInt, so leakage would be caught here.
+        let true_const_blocks: Vec<_> = main_fn.blocks.iter()
+            .filter(|b| b.insts.iter().any(|i| matches!(i, IrInst::ConstInt { ty: IrType::Bool, value: 1, .. })))
+            .collect();
+        assert_eq!(
+            true_const_blocks.len(),
+            1,
+            "ConstInt(Bool, 1) must appear in exactly one block (the SC block); got {}",
+            true_const_blocks.len()
+        );
+        assert_eq!(
+            true_const_blocks[0].id,
+            sc_id,
+            "The sole ConstInt(Bool, 1) must reside in the SC block"
+        );
+    }
 }

--- a/src/tests/verification_matrix/t142_logical_while_and_nested_exit.cx
+++ b/src/tests/verification_matrix/t142_logical_while_and_nested_exit.cx
@@ -1,0 +1,77 @@
+// CX-107: exit-code-based JIT parity — LogicalOps in while conditions
+// and nested/chained expressions.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+
+// ─── While with && condition ─────────────────────────────────────────────────
+// Loop while both i < 5 and j > 0 hold simultaneously.
+// i starts at 0 and j starts at 10; both advance each iteration.
+// AND short-circuits: once i reaches 5 the first operand is false and the
+// loop exits without evaluating j > 0.  Expect 5 iterations.
+wand_i: t64 = 0
+wand_j: t64 = 10
+wand_count: t64 = 0
+while (wand_i < 5 && wand_j > 0) {
+    wand_count = wand_count + 1
+    wand_i = wand_i + 1
+    wand_j = wand_j - 1
+}
+assert_eq(wand_count, 5)
+
+// AND while short-circuit: first operand immediately false → body never runs.
+wsc_i: t64 = 10
+wsc_count: t64 = 0
+while (wsc_i < 5 && wsc_count < 100) {
+    wsc_count = wsc_count + 1
+}
+assert_eq(wsc_count, 0)
+
+// ─── While with || condition ─────────────────────────────────────────────────
+// Loop while either a < 3 or b < 3.
+// Both start at 0 and tick together; loop exits when both reach 3 (3 iters).
+wor_a: t64 = 0
+wor_b: t64 = 0
+wor_count: t64 = 0
+while (wor_a < 3 || wor_b < 3) {
+    wor_count = wor_count + 1
+    wor_a = wor_a + 1
+    wor_b = wor_b + 1
+}
+assert_eq(wor_count, 3)
+
+// ─── Nested: AND with OR as right operand ────────────────────────────────────
+// true && (false || true) → inner OR produces true; outer AND: true && true → true.
+nest1: bool = true && (false || true)
+assert_eq(nest1, true)
+
+// false && (true || true) → outer AND short-circuits on false LHS → false.
+// The inner OR must NOT be evaluated (short-circuit proof).
+nest2: bool = false && (true || true)
+assert_eq(nest2, false)
+
+// ─── Nested: OR with AND as right operand ────────────────────────────────────
+// false || (true && false) → inner AND produces false; outer OR: false || false → false.
+nest3: bool = false || (true && false)
+assert_eq(nest3, false)
+
+// true || (false && true) → outer OR short-circuits on true LHS → true.
+// The inner AND must NOT be evaluated.
+nest4: bool = true || (false && true)
+assert_eq(nest4, true)
+
+// ─── Chained && (left-associative: (a && b) && c) ───────────────────────────
+// (true && true) && true → true
+chain1: bool = true && true && true
+assert_eq(chain1, true)
+
+// (true && false) && true → inner false; outer: false && true → false.
+chain2: bool = true && false && true
+assert_eq(chain2, false)
+
+// ─── Chained || (left-associative: (a || b) || c) ───────────────────────────
+// (false || false) || true → inner false; outer: false || true → true.
+chain3: bool = false || false || true
+assert_eq(chain3, true)
+
+// (true || false) || false → inner OR short-circuits to true; outer: true || false → true.
+chain4: bool = true || false || false
+assert_eq(chain4, true)

--- a/src/tests/verification_matrix/t142_logical_while_and_nested_exit.cx
+++ b/src/tests/verification_matrix/t142_logical_while_and_nested_exit.cx
@@ -1,6 +1,13 @@
-// CX-107: exit-code-based JIT parity — LogicalOps in while conditions
+// CX-107/CX-110: exit-code-based JIT parity — LogicalOps in while conditions
 // and nested/chained expressions.
 // No stdout; correctness verified by exit code only (0 = all asserts held).
+
+// rhs_trap() calls assert(false); if ever invoked it causes a non-zero exit.
+// Used below to prove that short-circuit evaluation truly suppresses RHS calls.
+fnc: bool rhs_trap() {
+    assert(false)
+    return false
+}
 
 // ─── While with && condition ─────────────────────────────────────────────────
 // Loop while both i < 5 and j > 0 hold simultaneously.
@@ -75,3 +82,15 @@ assert_eq(chain3, true)
 // (true || false) || false → inner OR short-circuits to true; outer: true || false → true.
 chain4: bool = true || false || false
 assert_eq(chain4, true)
+
+// ─── Observable short-circuit proof ──────────────────────────────────────────
+// rhs_trap() would assert(false) if called, proving the RHS is never evaluated
+// when the LHS already settles the result.
+
+// AND: lhs false → short-circuit (rhs_trap must NOT be called)
+sc_and_proof: bool = false && rhs_trap()
+assert_eq(sc_and_proof, false)
+
+// OR: lhs true → short-circuit (rhs_trap must NOT be called)
+sc_or_proof: bool = true || rhs_trap()
+assert_eq(sc_or_proof, true)


### PR DESCRIPTION
Closes CX-110

## Summary

Applies all CodeRabbit hardening feedback from PR #150 (CX-107), PR #151 (CX-108), and PR #152 (CX-109) in a single coherent commit on top of CX-107's cherry-picked fixture changes.

## Changes

### `src/ir/lower.rs` — IR-level test hardening (CX-108 + CX-109)

**CX-108 tests** (`and/or_short_circuit_rhs_call_is_in_rhs_block_only`):
- Replaced broad `IrInst::Call { .. }` predicate with callee-specific `callee == "side_effect_fn"` match to prevent false positives from unrelated calls.
- Added exclusivity assertion: exactly one `side_effect_fn` Call exists across all blocks in `main`, and that block is `rhs_id`.

**CX-109 "confined" tests** (`and/or_rhs_call_confined_to_rhs_block_across_all_blocks`):
- Same callee-specific predicate fix applied to the `blocks_with_call` filter.

**CX-109 SC-constant tests** (`and/or_sc_block_contains_exactly_false/true_constant`):
- Replaced literal bool LHS (`bool_expr(false/true)`) with a non-literal call (`lhs_cond_fn()`) — a separate helper function that returns the appropriate constant — so the SC `ConstInt` cannot also materialize in the decision block.
- Added cross-block uniqueness assertion: `ConstInt(Bool, 0/1)` must appear in exactly one block across all of `main`, and that block must be `sc_id`.

### `src/tests/verification_matrix/t142_logical_while_and_nested_exit.cx` — Observable SC proof (CX-107)

- Added `rhs_trap()` function (calls `assert(false)`; causes non-zero exit if invoked).
- Added `sc_and_proof` and `sc_or_proof` cases using `rhs_trap()` as the RHS, providing observable short-circuit evidence at the JIT parity level (mirroring the pattern from t141).

## Validation

```
cargo build --features jit   → clean (pre-existing warnings only)
cargo test  --features jit   → 309 passed, 0 failed
```

## Linear ticket reference

CX-110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression tests for logical operator short-circuit behavior in `while` loop conditions, including nested and chained boolean expressions, ensuring proper evaluation semantics and loop iteration correctness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/153)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->