### PR TITLE
CX-112: Apply CodeRabbit doc fixes on CX-111 parity checklist PR

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -13,7 +13,7 @@ current baseline from a real run, and the gate semantics used by the
 
 Every fixture in `src/tests/verification_matrix/` maps to exactly one
 `FeatureCategory` variant. The mapping is defined by `feature_of()` in
-`src/diff_harness.rs`. The 15 categories cover the full 0.1 supported construct
+`src/diff_harness.rs`. The 16 categories cover the full 0.1 supported construct
 set:
 
 | Category       | Description                                  | Key fixtures |
@@ -25,7 +25,7 @@ set:
 | ForLoop        | For-in loops                                 | t48, t104 |
 | InfiniteLoop   | `loop { ... break }` (infinite loop + break) | t25, t106, t134 |
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
-| Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t128 |
+| Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128 |
 | Unary          | Unary operators (negation, etc.)             | t96 |


### PR DESCRIPTION
Closes CX-112

Stacked on `stokowski/CX-111` (CX-111 not yet merged to submain). The diff against the base branch shows only the two CX-112 doc fixes.

## Summary

Applies two CodeRabbit findings from PR #154 (CX-111: Reconcile if/else and while JIT parity coverage after CX-102).

### 1. `docs/backend/cx_jit_parity_checklist.md` — Fix category count in Section 1 intro

The introductory sentence in Section 1 still read "The **15** categories cover the full 0.1 supported construct set:" after CX-111 added LogicalOps as the 16th category. Updated to **16**.

### 2. `docs/backend/cx_jit_parity_checklist.md` — Fix t128 dual-listing in Section 1 table

The Struct row listed `t125–t128`, but `t128_struct_compound_assign_exit` maps to `CompoundAssign` in `feature_of()` (line 225 of `src/diff_harness.rs`). This violated the document's own invariant that every fixture appears in exactly one category. Fixed the range to `t125–t127`. The CompoundAssign row already correctly listed `t128`.

## Files Changed

- `docs/backend/cx_jit_parity_checklist.md` — two line edits, no other changes

## Tests Run

```
cargo build --features jit
cargo test --features jit
```

## Validation Result

```
test diff_harness::tests::jit_parity_by_feature ... ok
test result: ok. 309 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Known Limitations

None. Both fixes are doc-only corrections to match existing runtime behaviour.

## Linear Ticket

CX-112