### PR TITLE
CX-113: Add when-block SKIP parity fixtures to JIT differential harness

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -33,7 +33,7 @@ set:
 | FloatOps       | f64 operations                               | t55, t135–t138 |
 | BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
 | LogicalOps     | Logical AND/OR short-circuit operators       | t141, t142 |
-| Other          | Enums, generics, when-blocks, handles, macros, imports, Result/try, string interp, semicolons, copy semantics, and any fixture not matching a named category | t09–t22, t24, t27–t32, t37–t38, t42, t47, t49, t51–t54, t58–t76, t81–t88, t97–t100, t111 |
+| Other          | Enums, generics, when-blocks, handles, macros, imports, Result/try, string interp, semicolons, copy semantics, and any fixture not matching a named category | t09–t22, t24, t27–t32, t37–t38, t42, t47, t49, t51–t54, t58–t76, t81–t88, t97–t100, t111; exit-code-verified: t143–t145 (CX-113) |
 
 Fixtures not explicitly listed in `feature_of()` fall into `Other`.
 
@@ -102,9 +102,10 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-111` (submain as of CX-111 merge window, 2026-05-11).
+Run on branch `stokowski/CX-113` (submain as of CX-113 merge window, 2026-05-11).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), and the CX-111 bool-variable negation extension to t131.
+fixtures (t141–t142), the CX-111 bool-variable negation extension to t131, and
+CX-113 when-block exit-code fixtures (t143–t145).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -124,9 +125,9 @@ Cast                      0      2            0
 FloatOps                  0      5            0
 BuiltinAssert             2      2            0
 LogicalOps                2      0            0
-Other                    13     48            0
+Other                    13     51            0
 ------------------------------------------------
-Total: 146 fixtures, 0 PARITY_FAILs
+Total: 149 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -158,6 +159,11 @@ exit-code-verified set; the 3 SKIP are the print-based originals.
 top-level while at file scope; t133 covers while in a function. The 2 PASS
 reflect the exit-code-verified set; the 6 SKIP include print-based originals
 and while-in/while-in-then constructs (not yet JIT-lowerable).
+
+**WhenBlock parity coverage (CX-113):** t143 mirrors t19 (numeric pattern), t144
+mirrors t20 (TBool three-way), t145 mirrors t21 (range pattern). All 3 are SKIP
+in JIT (when-block lowering not yet implemented; exits 127). Once when-block
+lowering lands, these fixtures will transition from SKIP to PASS without changes.
 
 ---
 

--- a/src/tests/verification_matrix/t143_when_num_exit.cx
+++ b/src/tests/verification_matrix/t143_when_num_exit.cx
@@ -1,0 +1,30 @@
+// CX-113: exit-code-based JIT parity — when-block numeric pattern matching.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// JIT SKIP: when-block lowering not yet implemented; exits 127.
+
+x: t64 = 3
+result: t64 = 0
+when x {
+    1 => { result = 10 },
+    2 => { result = 20 },
+    _ => { result = 99 },
+}
+assert_eq(result, 99)
+
+x = 1
+result = 0
+when x {
+    1 => { result = 10 },
+    2 => { result = 20 },
+    _ => { result = 99 },
+}
+assert_eq(result, 10)
+
+x = 2
+result = 0
+when x {
+    1 => { result = 10 },
+    2 => { result = 20 },
+    _ => { result = 99 },
+}
+assert_eq(result, 20)

--- a/src/tests/verification_matrix/t144_when_tbool_exit.cx
+++ b/src/tests/verification_matrix/t144_when_tbool_exit.cx
@@ -1,0 +1,24 @@
+// CX-113: exit-code-based JIT parity — when-block TBool pattern matching.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// JIT SKIP: when-block lowering not yet implemented; exits 127.
+// Uses untyped let+assign (same as t20) because bool literals cannot be
+// directly assigned to an explicit tbool-annotated variable.
+
+let x
+x = false
+result: t64 = 0
+when x {
+    true    => { result = 1 },
+    false   => { result = 190 },
+    unknown => { result = 2 },
+}
+assert_eq(result, 190)
+
+x = true
+result = 0
+when x {
+    true    => { result = 1 },
+    false   => { result = 190 },
+    unknown => { result = 2 },
+}
+assert_eq(result, 1)

--- a/src/tests/verification_matrix/t145_when_range_exit.cx
+++ b/src/tests/verification_matrix/t145_when_range_exit.cx
@@ -1,0 +1,30 @@
+// CX-113: exit-code-based JIT parity — when-block range pattern matching.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// JIT SKIP: when-block lowering not yet implemented; exits 127.
+
+x: t64 = 15
+result: t64 = 0
+when x {
+    1..=10  => { result = 1 },
+    11..=20 => { result = 2 },
+    _       => { result = 3 },
+}
+assert_eq(result, 2)
+
+x = 5
+result = 0
+when x {
+    1..=10  => { result = 1 },
+    11..=20 => { result = 2 },
+    _       => { result = 3 },
+}
+assert_eq(result, 1)
+
+x = 99
+result = 0
+when x {
+    1..=10  => { result = 1 },
+    11..=20 => { result = 2 },
+    _       => { result = 3 },
+}
+assert_eq(result, 3)


### PR DESCRIPTION
Closes CX-113

## Summary

- Adds three exit-code-verified when-block fixtures (t143–t145) to the JIT differential harness
- t143 mirrors t19: numeric pattern matching (`1`, `2`, `_`)
- t144 mirrors t20: TBool pattern matching (`true`, `false`, `unknown`) — tests true and false arms; uses untyped `let`+assign as in t20 since bool literals cannot be assigned to `tbool`-annotated vars
- t145 mirrors t21: range pattern matching (`1..=10`, `11..=20`, `_`)
- All three fixtures use `assert_eq` arm bodies (block form `{ result = N }`) instead of `print`, enabling exit-code-only correctness verification
- All three SKIP in JIT (exit 127: `UnsupportedSemanticConstruct` from when-block lowering) and PASS in the interpreter (exit 0)
- Updates `docs/backend/cx_jit_parity_checklist.md` Section 1 (key fixtures list) and Section 3 baseline (146→149 fixtures, Other SKIP 48→51, 0 PARITY_FAILs)
- No changes to `diff_harness.rs` — fixtures fall through to `Other` via the `_` catch-all

## Files changed

- `src/tests/verification_matrix/t143_when_num_exit.cx` (new)
- `src/tests/verification_matrix/t144_when_tbool_exit.cx` (new)
- `src/tests/verification_matrix/t145_when_range_exit.cx` (new)
- `docs/backend/cx_jit_parity_checklist.md` (baseline updated)

## Tests run

```
cargo build --features jit
cargo test --features jit
```

## Validation result

```
test diff_harness::tests::interpreter_baseline_all ... ok   (149/149)
test diff_harness::tests::jit_parity_by_feature ... ok
  Other: 13 PASS / 51 SKIP / 0 PARITY_FAIL
  Total: 149 fixtures, 0 PARITY_FAILs

test result: ok. 309 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Known limitations

- The `unknown` arm in t144 is present in the pattern but not exercised at runtime. The `unknown` keyword is not a valid rvalue expression in Cx; only `?` introduces a TBool unknown value, and `bool` literals (`true`/`false`) cannot be assigned to an explicit `tbool`-annotated variable. This matches the behavior of the source fixture t20, which also never exercises the unknown arm.
- When when-block lowering lands in a future phase, t143–t145 will transition from SKIP to PASS automatically with no fixture changes needed.

## Linear ticket

CX-113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added three new verification tests for pattern matching scenarios (numeric patterns, boolean conditions, and range-based matching).

* **Documentation**
  * Updated test parity checklist with new fixture references and pattern matching coverage notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/156)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->