### PR TITLE
CX-114: Add exit-code-based JIT parity fixtures for array constructs

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -26,7 +26,7 @@ set:
 | InfiniteLoop   | `loop { ... break }` (infinite loop + break) | t25, t106, t134 |
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
-| Array          | Array literals and array-of-result           | t33, t112 |
+| Array          | Array literals and array-of-result           | t33, t112; t143–t145 (exit-code-verified, CX-114) |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128 |
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
@@ -102,9 +102,10 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-111` (submain as of CX-111 merge window, 2026-05-11).
+Run on branch `stokowski/CX-114` (submain as of CX-114 merge window, 2026-05-11).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), and the CX-111 bool-variable negation extension to t131.
+fixtures (t141–t142), the CX-111 bool-variable negation extension to t131, and the CX-114
+Array exit-code fixtures (t143–t145).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -117,7 +118,7 @@ ForLoop                   0      2            0
 InfiniteLoop              1      2            0
 DirectCall                5      6            0
 Struct                    5      6            0
-Array                     0      2            0
+Array                     0      5            0
 CompoundAssign            1      2            0
 Unary                     0      1            0
 Cast                      0      2            0
@@ -126,7 +127,7 @@ BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    13     48            0
 ------------------------------------------------
-Total: 146 fixtures, 0 PARITY_FAILs
+Total: 149 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -158,6 +159,13 @@ exit-code-verified set; the 3 SKIP are the print-based originals.
 top-level while at file scope; t133 covers while in a function. The 2 PASS
 reflect the exit-code-verified set; the 6 SKIP include print-based originals
 and while-in/while-in-then constructs (not yet JIT-lowerable).
+
+**Array parity coverage (CX-114):** t143 covers array literal creation and
+indexed reads; t144 covers array element write and read-back; t145 covers array
+creation and access inside a function body. All 5 Array fixtures currently SKIP
+in JIT because Alloca/PtrOffset/Load/Store are not yet JIT-lowerable. The 2
+print-based originals (t33, t112) also SKIP. When JIT array support lands, all
+5 exit-code fixtures are expected to transition to PASS.
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -217,6 +217,9 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── Array ─────────────────────────────────────────────────────────────
         "t33_arrays"
         | "t112_array_of_result"
+        | "t143_array_read_exit"
+        | "t144_array_write_exit"
+        | "t145_array_in_func_exit"
             => FeatureCategory::Array,
 
         // ── CompoundAssign ────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t143_array_read_exit.cx
+++ b/src/tests/verification_matrix/t143_array_read_exit.cx
@@ -1,0 +1,6 @@
+// CX-114: exit-code-based JIT parity — array literal and indexed read.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+arr: [5: t64] = [10, 20, 30, 40, 50]
+assert_eq(arr:[0], 10)
+assert_eq(arr:[2], 30)
+assert_eq(arr:[4], 50)

--- a/src/tests/verification_matrix/t144_array_write_exit.cx
+++ b/src/tests/verification_matrix/t144_array_write_exit.cx
@@ -1,0 +1,7 @@
+// CX-114: exit-code-based JIT parity — array element write and read-back.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+arr: [5: t64] = [10, 20, 30, 40, 50]
+arr:[1] = 99
+assert_eq(arr:[1], 99)
+assert_eq(arr:[0], 10)
+assert_eq(arr:[4], 50)

--- a/src/tests/verification_matrix/t145_array_in_func_exit.cx
+++ b/src/tests/verification_matrix/t145_array_in_func_exit.cx
@@ -1,0 +1,7 @@
+// CX-114: exit-code-based JIT parity — array creation and indexed read inside a function.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 get_mid() {
+    vals: [3: t64] = [100, 200, 300]
+    return vals:[1]
+}
+assert_eq(get_mid(), 200)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-114/add-exit-code-based-jit-parity-fixtures-for-array-constructs

## Summary

- Adds three exit-code-verified JIT parity fixtures (t143–t145) for the Array feature category
- Updates `feature_of()` in `src/diff_harness.rs` to classify all three under `FeatureCategory::Array`
- Updates `docs/backend/cx_jit_parity_checklist.md` with the new baseline (149 fixtures, Array SKIP 2→5)

## Fixtures Added

| Fixture | Construct Covered |
|---------|------------------|
| `t143_array_read_exit.cx` | Array literal creation and indexed reads (`arr:[0]`, `arr:[2]`, `arr:[4]`) |
| `t144_array_write_exit.cx` | Array element write and read-back (`arr:[1] = 99`) |
| `t145_array_in_func_exit.cx` | Array creation and indexed access inside a function body |

All three fixtures use `assert_eq` for correctness verification — no `print` dependency — following the same pattern as t117–t142.

## JIT Behavior

All three exit 127 (SKIP / `UNSUPPORTED_CONSTRUCT`) under `--backend=cranelift` because `Alloca`, `PtrOffset`, `Load`, and `Store` are not yet JIT-lowerable. This is expected. When JIT array support lands, all five Array exit-code fixtures (t143–t145 plus the two print-based originals t33, t112) are positioned to transition to PASS.

## Files Changed

- `src/tests/verification_matrix/t143_array_read_exit.cx` (new)
- `src/tests/verification_matrix/t144_array_write_exit.cx` (new)
- `src/tests/verification_matrix/t145_array_in_func_exit.cx` (new)
- `src/diff_harness.rs` — Array arm in `feature_of()` extended with t143–t145
- `docs/backend/cx_jit_parity_checklist.md` — baseline updated to 149 fixtures

## Validation

```
cargo build --features jit   ✓
cargo test --features jit    ✓  309 passed; 0 failed
```

Parity table (Array row):
```
Array    0    5    0   (was 0 PASS / 2 SKIP / 0 PARITY_FAIL)
```

Gate holds: 0 PARITY_FAILs across all 16 categories.

## Linear Ticket

CX-114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Phase 12 JIT parity baseline checklist with new array fixture classifications and exit-code verification metrics.

* **Tests**
  * Added three new array verification tests covering indexed reads, element writes, and array operations within functions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->