### PR TITLE
CX-115: Add exit-code-based JIT parity fixtures for DirectCall constructs

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -24,7 +24,7 @@ set:
 | WhileLoop      | While loops and while-in construct           | t23, t34, t35, t105, t107, t108 (output-verified); t132, t133 (exit-code-verified, CX-102) |
 | ForLoop        | For-in loops                                 | t48, t104 |
 | InfiniteLoop   | `loop { ... break }` (infinite loop + break) | t25, t106, t134 |
-| DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
+| DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 (output-verified); t143–t148 (exit-code-verified, CX-115) |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128 |
@@ -102,9 +102,10 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-111` (submain as of CX-111 merge window, 2026-05-11).
+Run on branch `stokowski/CX-115` (submain as of CX-115 merge window, 2026-05-11).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), and the CX-111 bool-variable negation extension to t131.
+fixtures (t141–t142), the CX-111 bool-variable negation extension to t131, and the CX-115
+DirectCall exit-code fixtures (t143–t148).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -115,7 +116,7 @@ IfElse                    3      3            0
 WhileLoop                 2      6            0
 ForLoop                   0      2            0
 InfiniteLoop              1      2            0
-DirectCall                5      6            0
+DirectCall               10      7            0
 Struct                    5      6            0
 Array                     0      2            0
 CompoundAssign            1      2            0
@@ -126,7 +127,7 @@ BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    13     48            0
 ------------------------------------------------
-Total: 146 fixtures, 0 PARITY_FAILs
+Total: 152 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -158,6 +159,13 @@ exit-code-verified set; the 3 SKIP are the print-based originals.
 top-level while at file scope; t133 covers while in a function. The 2 PASS
 reflect the exit-code-verified set; the 6 SKIP include print-based originals
 and while-in/while-in-then constructs (not yet JIT-lowerable).
+
+**DirectCall parity coverage (CX-115):** t143 (implicit return), t144 (explicit return),
+t145 (zero-argument function), t146 (chained calls), t147 (forward declaration), t148
+(recursive factorial) mirror the print-based originals t02, t03, t14, t29, and t113.
+Five of the six fixtures PASS immediately (JIT already lowers direct calls for these
+patterns); one remains SKIP alongside the 6 print-based originals. The 10 PASS reflects
+5 expected-fail fixtures plus 5 new exit-code-verified fixtures.
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -198,6 +198,12 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t29_forward_decl"
         | "t50_nested_func_no_leak"
         | "t113_recursive_fib"
+        | "t143_direct_call_implicit_return_exit"
+        | "t144_direct_call_explicit_return_exit"
+        | "t145_direct_call_no_args_exit"
+        | "t146_direct_call_chained_exit"
+        | "t147_direct_call_forward_decl_exit"
+        | "t148_direct_call_recursive_exit"
             => FeatureCategory::DirectCall,
 
         // ── Struct ────────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t143_direct_call_implicit_return_exit.cx
+++ b/src/tests/verification_matrix/t143_direct_call_implicit_return_exit.cx
@@ -1,0 +1,8 @@
+// CX-115: exit-code-based JIT parity — function with implicit return.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 add(a: t64, b: t64) {
+    a + b
+}
+assert_eq(add(1, 2), 3)
+assert_eq(add(10, 20), 30)
+assert_eq(add(0, 0), 0)

--- a/src/tests/verification_matrix/t144_direct_call_explicit_return_exit.cx
+++ b/src/tests/verification_matrix/t144_direct_call_explicit_return_exit.cx
@@ -1,0 +1,8 @@
+// CX-115: exit-code-based JIT parity — function with explicit return.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 pick_first(a: t64, b: t64) {
+    return a;
+    b
+}
+assert_eq(pick_first(10, 20), 10)
+assert_eq(pick_first(99, 1), 99)

--- a/src/tests/verification_matrix/t145_direct_call_no_args_exit.cx
+++ b/src/tests/verification_matrix/t145_direct_call_no_args_exit.cx
@@ -1,0 +1,6 @@
+// CX-115: exit-code-based JIT parity — zero-argument function call.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 answer() {
+    42
+}
+assert_eq(answer(), 42)

--- a/src/tests/verification_matrix/t146_direct_call_chained_exit.cx
+++ b/src/tests/verification_matrix/t146_direct_call_chained_exit.cx
@@ -1,0 +1,10 @@
+// CX-115: exit-code-based JIT parity — function calling another function (chained calls).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 square(x: t64) {
+    x * x
+}
+fnc: t64 sum_of_squares(a: t64, b: t64) {
+    square(a) + square(b)
+}
+assert_eq(sum_of_squares(3, 4), 25)
+assert_eq(sum_of_squares(1, 1), 2)

--- a/src/tests/verification_matrix/t147_direct_call_forward_decl_exit.cx
+++ b/src/tests/verification_matrix/t147_direct_call_forward_decl_exit.cx
@@ -1,0 +1,8 @@
+// CX-115: exit-code-based JIT parity — forward declaration (call before definition).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+assert_eq(double(5), 10)
+assert_eq(double(0), 0)
+
+fnc: t64 double(x: t64) {
+    x * 2
+}

--- a/src/tests/verification_matrix/t148_direct_call_recursive_exit.cx
+++ b/src/tests/verification_matrix/t148_direct_call_recursive_exit.cx
@@ -1,0 +1,11 @@
+// CX-115: exit-code-based JIT parity — recursive function call (factorial).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 fact(n: t64) {
+    if n < 2 {
+        return 1
+    }
+    return n * fact(n - 1)
+}
+assert_eq(fact(1), 1)
+assert_eq(fact(5), 120)
+assert_eq(fact(10), 3628800)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-115/add-exit-code-based-jit-parity-fixtures-for-directcall-constructs

## Summary

- Adds 6 exit-code-based JIT parity fixtures for DirectCall constructs (t143–t148), mirroring the existing print-based originals (t02, t03, t14, t29, t50, t113).
- Registers all 6 new fixtures in the `DirectCall` branch of `feature_of()` in `src/diff_harness.rs`.
- Updates `docs/backend/cx_jit_parity_checklist.md` with the new baseline (152 fixtures) and a DirectCall coverage note.

## Files Changed

- `src/tests/verification_matrix/t143_direct_call_implicit_return_exit.cx` — implicit return
- `src/tests/verification_matrix/t144_direct_call_explicit_return_exit.cx` — explicit return (early return)
- `src/tests/verification_matrix/t145_direct_call_no_args_exit.cx` — zero-argument function
- `src/tests/verification_matrix/t146_direct_call_chained_exit.cx` — function calling another function
- `src/tests/verification_matrix/t147_direct_call_forward_decl_exit.cx` — forward declaration (call before definition)
- `src/tests/verification_matrix/t148_direct_call_recursive_exit.cx` — recursive function (factorial)
- `src/diff_harness.rs` — t143–t148 added to `DirectCall` arm of `feature_of()`
- `docs/backend/cx_jit_parity_checklist.md` — updated baseline table and interpretation notes

## Parity Outcome

DirectCall category changed from `5 PASS / 6 SKIP / 0 PARITY_FAIL` to `10 PASS / 7 SKIP / 0 PARITY_FAIL`.
Five of the six new fixtures PASS immediately (JIT already lowers these direct-call patterns); one remains SKIP alongside the print-based originals.

## Validation

```
cargo build --features jit   ✓ (Finished dev profile)
cargo test --features jit    ✓ (309 passed; 0 failed)
```

```text
Feature                PASS   SKIP  PARITY_FAIL
------------------------------------------------
DirectCall               10      7            0
...
Total: 152 fixtures, 0 PARITY_FAILs
```

## Linear Ticket

CX-115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added six new verification tests for DirectCall functionality, covering implicit returns, explicit returns, no-argument functions, chained calls, forward declarations, and recursive functions.

* **Documentation**
  * Updated parity checklist to reflect Phase 12 CX JIT parity baseline with extended fixture coverage and updated pass/skip counts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/158)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->