### PR TITLE
CX-116: Add JIT parity PASS coverage for Unary feature category

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -28,7 +28,7 @@ set:
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128 |
-| Unary          | Unary operators (negation, etc.)             | t96 |
+| Unary          | Unary operators (negation, etc.)             | t96, t143, t144 |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |
 | BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
@@ -102,9 +102,10 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-111` (submain as of CX-111 merge window, 2026-05-11).
+Run on branch `stokowski/CX-116` (submain as of CX-116 merge window, 2026-05-11).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), and the CX-111 bool-variable negation extension to t131.
+fixtures (t141–t142), the CX-111 bool-variable negation extension to t131, and CX-116
+Unary parity fixtures (t143–t144).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -119,14 +120,14 @@ DirectCall                5      6            0
 Struct                    5      6            0
 Array                     0      2            0
 CompoundAssign            1      2            0
-Unary                     0      1            0
+Unary                     2      1            0
 Cast                      0      2            0
 FloatOps                  0      5            0
 BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    13     48            0
 ------------------------------------------------
-Total: 146 fixtures, 0 PARITY_FAILs
+Total: 148 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -135,7 +136,7 @@ Total: 146 fixtures, 0 PARITY_FAILs
 
 - **Expected-fail fixtures** in any category exit non-zero (semantic error),
   matching the expectation. Both interpreter and JIT correctly reject them.
-- **Exit-code-verified fixtures** (t117–t142) use `assert_eq` instead of
+- **Exit-code-verified fixtures** (t117–t144) use `assert_eq` instead of
   `print`, so their correctness is verified by exit code 0. These pass
   even though the `print` builtin is not yet JIT-lowerable (Phase 9 pending).
 - A small number of **pass-any fixtures** where the JIT happened to compile
@@ -158,6 +159,11 @@ exit-code-verified set; the 3 SKIP are the print-based originals.
 top-level while at file scope; t133 covers while in a function. The 2 PASS
 reflect the exit-code-verified set; the 6 SKIP include print-based originals
 and while-in/while-in-then constructs (not yet JIT-lowerable).
+
+**Unary parity coverage (CX-116):** t143 covers integer arithmetic negation
+(`-x`) verified by summing `−x + x = 0`; t144 covers boolean NOT (`!x`)
+storing the result in a bool variable. The 2 PASS reflect exit-code-verified
+fixtures; the 1 SKIP is t96 (print-based, awaiting Phase 9).
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -227,6 +227,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
 
         // ── Unary ─────────────────────────────────────────────────────────────
         "t96_overflow_t8_unary_neg"
+        | "t143_unary_neg_int_exit"
+        | "t144_unary_not_bool_exit"
             => FeatureCategory::Unary,
 
         // ── Cast ─────────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t143_unary_neg_int_exit.cx
+++ b/src/tests/verification_matrix/t143_unary_neg_int_exit.cx
@@ -1,0 +1,11 @@
+// CX-116: exit-code-based JIT parity — unary arithmetic negation on integers.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+x: t64 = 5
+assert_eq(-x + x, 0)
+
+y: t64 = 100
+neg_y: t64 = -y
+assert_eq(neg_y + y, 0)
+
+z: t64 = 0
+assert_eq(-z, 0)

--- a/src/tests/verification_matrix/t144_unary_not_bool_exit.cx
+++ b/src/tests/verification_matrix/t144_unary_not_bool_exit.cx
@@ -1,0 +1,12 @@
+// CX-116: exit-code-based JIT parity — unary boolean NOT operator.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+t: bool = true
+f: bool = false
+assert_eq(!t, false)
+assert_eq(!f, true)
+
+b: bool = !t
+assert_eq(b, false)
+
+c: bool = !f
+assert_eq(c, true)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-116/add-jit-parity-pass-coverage-for-unary-feature-category

## Summary

- Added two exit-code-verified JIT parity fixtures for the Unary feature category
- Registered both fixtures in the `feature_of()` Unary arm in `diff_harness.rs`
- Updated the parity checklist baseline doc to reflect the new counts

## Files Changed

- `src/tests/verification_matrix/t143_unary_neg_int_exit.cx` — new fixture: integer arithmetic negation (`-x`), verified by `−x + x = 0`
- `src/tests/verification_matrix/t144_unary_not_bool_exit.cx` — new fixture: boolean NOT (`!x`), storing result in bool variable
- `src/diff_harness.rs` — registered t143 and t144 in the Unary match arm
- `docs/backend/cx_jit_parity_checklist.md` — updated baseline table (148 total fixtures) and added Unary interpretation paragraph

## Parity Baseline Change

| Category | Before (PASS/SKIP/FAIL) | After (PASS/SKIP/FAIL) |
|----------|------------------------|------------------------|
| Unary    | 0 / 1 / 0              | 2 / 1 / 0              |
| Total    | 146 fixtures           | 148 fixtures           |

## Validation

```
cargo build --features jit
cargo test --features jit jit_parity_by_feature -- --nocapture
```

**Result:**
```
Unary      2      1            0
jit_parity_by_feature: 148 fixtures checked across 16 feature categories, 0 PARITY_FAILs
test result: ok. 1 passed; 0 failed
```

PARITY_FAIL = 0 across all 16 categories. Gate holds.

## Notes

- t96 (print-based, original Unary fixture) remains SKIP pending Phase 9 (print JIT lowering)
- t143 uses `−x + x = 0` idiom to avoid negative literals in assert_eq
- t144 follows the bool-assertion pattern established in t141 (LogicalOps)

## Linear Ticket

CX-116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new verification tests for unary arithmetic negation on 64-bit integers with exit-code validation
  * Added new verification tests for unary boolean NOT operator to verify JIT parity

* **Documentation**
  * Updated Phase 12 JIT parity checklist with extended unary operation coverage
  * Refreshed baseline reference and per-category pass/skip counts to latest version

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->