### PR TITLE
CX-117: Add exit-code-based JIT parity fixtures for FloatOps and Cast

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -29,8 +29,8 @@ set:
 | Array          | Array literals and array-of-result           | t33, t112 |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128 |
 | Unary          | Unary operators (negation, etc.)             | t96 |
-| Cast           | Explicit type casts                          | t139, t140 |
-| FloatOps       | f64 operations                               | t55, t135–t138 |
+| Cast           | Explicit type casts                          | t139, t140, t145, t146 |
+| FloatOps       | f64 operations                               | t55, t135–t138, t143, t144 |
 | BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
 | LogicalOps     | Logical AND/OR short-circuit operators       | t141, t142 |
 | Other          | Enums, generics, when-blocks, handles, macros, imports, Result/try, string interp, semicolons, copy semantics, and any fixture not matching a named category | t09–t22, t24, t27–t32, t37–t38, t42, t47, t49, t51–t54, t58–t76, t81–t88, t97–t100, t111 |
@@ -102,9 +102,10 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-111` (submain as of CX-111 merge window, 2026-05-11).
+Run on branch `stokowski/CX-117` (submain as of CX-117 merge window, 2026-05-11).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), and the CX-111 bool-variable negation extension to t131.
+fixtures (t141–t142), the CX-111 bool-variable negation extension to t131, and the CX-117
+FloatOps/Cast expansion fixtures (t143–t146).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -120,13 +121,13 @@ Struct                    5      6            0
 Array                     0      2            0
 CompoundAssign            1      2            0
 Unary                     0      1            0
-Cast                      0      2            0
-FloatOps                  0      5            0
+Cast                      0      4            0
+FloatOps                  0      7            0
 BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    13     48            0
 ------------------------------------------------
-Total: 146 fixtures, 0 PARITY_FAILs
+Total: 150 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -232,6 +232,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── Cast ─────────────────────────────────────────────────────────────
         "t139_cast_t32_to_f64_exit"
         | "t140_cast_f64_truncate_exit"
+        | "t145_cast_neg_t32_to_f64_exit"
+        | "t146_cast_t64_to_f64_exit"
             => FeatureCategory::Cast,
 
         // ── FloatOps ──────────────────────────────────────────────────────────
@@ -240,6 +242,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t136_float_arith_sub_exit"
         | "t137_float_arith_mul_exit"
         | "t138_float_arith_div_exit"
+        | "t143_float_arith_mod_exit"
+        | "t144_float_neg_exit"
             => FeatureCategory::FloatOps,
 
         // ── BuiltinAssert ─────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t143_float_arith_mod_exit.cx
+++ b/src/tests/verification_matrix/t143_float_arith_mod_exit.cx
@@ -1,0 +1,13 @@
+// CX-117: exit-code-based JIT parity — f64 modulo (remainder).
+// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+a: f64 = 10.0
+b: f64 = 3.0
+rem: f64 = a % b
+n: t32 = rem
+assert_eq(n, 1)
+
+x: f64 = 7.5
+y: f64 = 2.5
+rem2: f64 = x % y
+m: t32 = rem2
+assert_eq(m, 0)

--- a/src/tests/verification_matrix/t144_float_neg_exit.cx
+++ b/src/tests/verification_matrix/t144_float_neg_exit.cx
@@ -1,0 +1,12 @@
+// CX-117: exit-code-based JIT parity — unary f64 negation.
+// Negation lowers to ConstFloat(0.0) + Binary(Sub, F64).
+// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+a: f64 = 5.0
+neg: f64 = -a
+n: t32 = neg
+assert_eq(n, -5)
+
+b: f64 = 3.0
+neg2: f64 = -b
+m: t32 = neg2
+assert_eq(m, -3)

--- a/src/tests/verification_matrix/t145_cast_neg_t32_to_f64_exit.cx
+++ b/src/tests/verification_matrix/t145_cast_neg_t32_to_f64_exit.cx
@@ -1,0 +1,11 @@
+// CX-117: exit-code-based JIT parity — negative t32→f64 widening cast.
+// Verifies that sign is preserved when a negative t32 widens to f64.
+a: t32 = -42
+b: f64 = a
+c: t32 = b
+assert_eq(c, -42)
+
+x: t32 = -100
+y: f64 = x
+z: t32 = y
+assert_eq(z, -100)

--- a/src/tests/verification_matrix/t146_cast_t64_to_f64_exit.cx
+++ b/src/tests/verification_matrix/t146_cast_t64_to_f64_exit.cx
@@ -1,0 +1,11 @@
+// CX-117: exit-code-based JIT parity — t64→f64 widening cast.
+// Exercises the I64→F64 conversion path (fcvt_from_sint on a 64-bit value).
+a: t64 = 42
+b: f64 = a
+c: t32 = b
+assert_eq(c, 42)
+
+x: t64 = -100
+y: f64 = x
+z: t32 = y
+assert_eq(z, -100)


### PR DESCRIPTION
Closes CX-117

## Summary

- Adds 4 new exit-code-based JIT parity fixtures: `t143`–`t146`
- Registers all 4 in `feature_of()` in `src/diff_harness.rs` under `FloatOps` (t143, t144) and `Cast` (t145, t146)
- Updates parity checklist baseline: 146→150 fixtures, Cast SKIP 2→4, FloatOps SKIP 5→7

## New Fixtures

| File | Category | What it tests |
|------|----------|---------------|
| `t143_float_arith_mod_exit.cx` | FloatOps | f64 modulo (`%`), exercises `BinaryOp::Rem` on F64 via fmod libcall |
| `t144_float_neg_exit.cx` | FloatOps | Unary f64 negation, exercises `ConstFloat(0.0) + Binary(Sub, F64)` lowering path |
| `t145_cast_neg_t32_to_f64_exit.cx` | Cast | Negative `t32→f64` widening, verifies sign preservation (complements t139's positive-only coverage) |
| `t146_cast_t64_to_f64_exit.cx` | Cast | `t64→f64` widening, exercises the `I64→F64` (`fcvt_from_sint`) path distinct from t139's `I32→F64` |

All fixtures follow the established pattern: integer-valued results are cast to `t32` and verified via `assert_eq`. They are SKIP under the current JIT (same as t135–t140) due to the assert_eq I32/I64 operand-type mismatch; zero PARITY_FAILs are maintained.

## Files Changed

- `src/tests/verification_matrix/t143_float_arith_mod_exit.cx` — new
- `src/tests/verification_matrix/t144_float_neg_exit.cx` — new
- `src/tests/verification_matrix/t145_cast_neg_t32_to_f64_exit.cx` — new
- `src/tests/verification_matrix/t146_cast_t64_to_f64_exit.cx` — new
- `src/diff_harness.rs` — `feature_of()` updated with 4 new fixture names
- `docs/backend/cx_jit_parity_checklist.md` — Section 1 table and Section 3 baseline updated

## Validation

```
cargo build --features jit   → ok (warnings pre-existing, no new)
cargo test --features jit    → 309 passed; 0 failed
```

jit_parity_by_feature result:
```
Cast       0   4   0
FloatOps   0   7   0
Total: 150 fixtures, 0 PARITY_FAILs
```

## Linear Ticket

CX-117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JIT parity checklist to document expanded test coverage, including new fixtures for floating-point operations and type-casting scenarios.

* **Tests**
  * Added four new verification tests covering floating-point modulo, negation, negative integer-to-float widening casts, and 64-bit integer-to-float casts to strengthen JIT parity assurance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/160)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->