### PR TITLE
CX-118: Add exit-code-based JIT parity fixtures for InfiniteLoop and CompoundAssign

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -23,11 +23,11 @@ set:
 | IfElse         | Conditional branches                         | t44, t45, t46 (output-verified); t129, t130, t131 (exit-code-verified, CX-102/CX-111) |
 | WhileLoop      | While loops and while-in construct           | t23, t34, t35, t105, t107, t108 (output-verified); t132, t133 (exit-code-verified, CX-102) |
 | ForLoop        | For-in loops                                 | t48, t104 |
-| InfiniteLoop   | `loop { ... break }` (infinite loop + break) | t25, t106, t134 |
+| InfiniteLoop   | `loop { ... break }` (infinite loop + break) | t25, t106, t134 (output-verified); t143, t144 (exit-code-verified, CX-118) |
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 |
-| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128 |
+| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128 (output-verified); t145, t146 (exit-code-verified, CX-118) |
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |
@@ -102,9 +102,10 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-111` (submain as of CX-111 merge window, 2026-05-11).
+Run on branch `stokowski/CX-118` (submain as of CX-118 merge window, 2026-05-11).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), and the CX-111 bool-variable negation extension to t131.
+fixtures (t141–t142), the CX-111 bool-variable negation extension to t131, and the CX-118
+InfiniteLoop/CompoundAssign fixtures (t143–t146).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -114,11 +115,11 @@ VariableDecl              5      3            0
 IfElse                    3      3            0
 WhileLoop                 2      6            0
 ForLoop                   0      2            0
-InfiniteLoop              1      2            0
+InfiniteLoop              3      2            0
 DirectCall                5      6            0
 Struct                    5      6            0
 Array                     0      2            0
-CompoundAssign            1      2            0
+CompoundAssign            1      4            0
 Unary                     0      1            0
 Cast                      0      2            0
 FloatOps                  0      5            0
@@ -126,7 +127,7 @@ BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    13     48            0
 ------------------------------------------------
-Total: 146 fixtures, 0 PARITY_FAILs
+Total: 150 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -158,6 +159,19 @@ exit-code-verified set; the 3 SKIP are the print-based originals.
 top-level while at file scope; t133 covers while in a function. The 2 PASS
 reflect the exit-code-verified set; the 6 SKIP include print-based originals
 and while-in/while-in-then constructs (not yet JIT-lowerable).
+
+**InfiniteLoop parity coverage (CX-118):** t143 covers a file-scope loop
+accumulator (back-edge fires correctly across multiple iterations without a
+function wrapper); t144 covers a countdown pattern in a function (complements
+t134's first-even search). The 3 PASS reflect t134 + t143 + t144; the 2 SKIP
+are the print-based originals (t25, t106).
+
+**CompoundAssign parity coverage (CX-118):** t145 covers all five compound
+assign operators (+=, -=, *=, /=, %=) on plain variables; t146 covers compound
+assign on function-local variables. Both are SKIP because the JIT does not yet
+lower the Var-target Load + Binop + Store pattern (exit 0, stderr). The 1 PASS
+is the existing t128 (struct field compound assign, which uses a different
+Field-target codepath). SKIP is expected; 0 PARITY_FAILs maintained.
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -184,6 +184,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         "t25_loop_break"
         | "t106_loop_break_in_func"
         | "t134_loop_break_exit"
+        | "t143_infinite_loop_counter_exit"
+        | "t144_infinite_loop_countdown_exit"
             => FeatureCategory::InfiniteLoop,
 
         // ── DirectCall ────────────────────────────────────────────────────────
@@ -223,6 +225,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         "t26_compound_add_two"
         | "t41_compound_assign_dot"
         | "t128_struct_compound_assign_exit"
+        | "t145_compound_assign_vars_exit"
+        | "t146_compound_assign_func_exit"
             => FeatureCategory::CompoundAssign,
 
         // ── Unary ─────────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t143_infinite_loop_counter_exit.cx
+++ b/src/tests/verification_matrix/t143_infinite_loop_counter_exit.cx
@@ -1,0 +1,12 @@
+// CX-118: exit-code-based JIT parity — InfiniteLoop file-scope accumulator.
+// Verifies the back-edge jump fires correctly across multiple iterations at file scope.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+sum: t64 = 0
+i: t64 = 1
+loop {
+    if i > 5 { break }
+    sum = sum + i
+    i = i + 1
+}
+assert_eq(sum, 15)
+assert_eq(i, 6)

--- a/src/tests/verification_matrix/t144_infinite_loop_countdown_exit.cx
+++ b/src/tests/verification_matrix/t144_infinite_loop_countdown_exit.cx
@@ -1,0 +1,17 @@
+// CX-118: exit-code-based JIT parity — InfiniteLoop inside a function (countdown).
+// Complements t134 (loop+break in a function) with a different accumulation pattern.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 sum_down(n: t64) {
+    i: t64 = n
+    result: t64 = 0
+    loop {
+        if i == 0 { break }
+        result = result + i
+        i = i - 1
+    }
+    return result
+}
+
+assert_eq(sum_down(4), 10)
+assert_eq(sum_down(1), 1)
+assert_eq(sum_down(0), 0)

--- a/src/tests/verification_matrix/t145_compound_assign_vars_exit.cx
+++ b/src/tests/verification_matrix/t145_compound_assign_vars_exit.cx
@@ -1,0 +1,22 @@
+// CX-118: exit-code-based JIT parity — compound assign on plain variables.
+// Verifies the Var-target Load + Binop + Store pattern for all five operators.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+a: t64 = 10
+a += 5
+assert_eq(a, 15)
+
+b: t64 = 20
+b -= 8
+assert_eq(b, 12)
+
+c: t64 = 6
+c *= 7
+assert_eq(c, 42)
+
+d: t64 = 30
+d /= 5
+assert_eq(d, 6)
+
+e: t64 = 17
+e %= 5
+assert_eq(e, 2)

--- a/src/tests/verification_matrix/t146_compound_assign_func_exit.cx
+++ b/src/tests/verification_matrix/t146_compound_assign_func_exit.cx
@@ -1,0 +1,12 @@
+// CX-118: exit-code-based JIT parity — compound assign operators inside a function.
+// Verifies that compound assign lowering works on function-local variables.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 apply_ops(v: t64) {
+    v += 10
+    v -= 3
+    v *= 2
+    return v
+}
+
+assert_eq(apply_ops(5), 24)
+assert_eq(apply_ops(0), 14)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-118/add-exit-code-based-jit-parity-fixtures-for-infiniteloop-and

## Summary

- Adds 4 exit-code-based JIT parity fixtures (t143–t146) to the verification matrix
- Registers all 4 in `feature_of()` in `src/diff_harness.rs`
- Updates `docs/backend/cx_jit_parity_checklist.md` Section 1 (classification table), Section 3 (baseline counts and interpretation notes)

## New fixtures

| Fixture | Category | JIT outcome | What it tests |
|---------|----------|-------------|---------------|
| t143_infinite_loop_counter_exit | InfiniteLoop | **PASS** | File-scope loop accumulator — back-edge across multiple iterations without a function wrapper |
| t144_infinite_loop_countdown_exit | InfiniteLoop | **PASS** | Countdown function using loop + break — complements t134's first-even search |
| t145_compound_assign_vars_exit | CompoundAssign | SKIP | All five operators (+=, -=, *=, /=, %=) on plain variables — JIT doesn't yet lower the Var-target Load+Binop+Store path |
| t146_compound_assign_func_exit | CompoundAssign | SKIP | Compound assign on function-local variables — same Var-target SKIP as t145 |

## Files changed

- `src/tests/verification_matrix/t143_infinite_loop_counter_exit.cx` (new)
- `src/tests/verification_matrix/t144_infinite_loop_countdown_exit.cx` (new)
- `src/tests/verification_matrix/t145_compound_assign_vars_exit.cx` (new)
- `src/tests/verification_matrix/t146_compound_assign_func_exit.cx` (new)
- `src/diff_harness.rs` — InfiniteLoop and CompoundAssign arms of `feature_of()`
- `docs/backend/cx_jit_parity_checklist.md` — Section 1 table and Section 3 baseline

## Validation

```
cargo build --features jit   ✓ (warnings only, no errors)
cargo test --features jit    ✓ 309 passed, 0 failed
```

Parity baseline (150 fixtures, 0 PARITY_FAILs):

```
InfiniteLoop      3 PASS  2 SKIP  0 PARITY_FAIL   (was 1 PASS 2 SKIP)
CompoundAssign    1 PASS  4 SKIP  0 PARITY_FAIL   (was 1 PASS 2 SKIP)
```

## Known limitations

CompoundAssign t145/t146 are SKIP because the JIT does not yet lower the Var-target compound assign path (plain variable `+=` etc.). The Field-target path used by t128 (struct field compound assign) already PASSES. Var-target lowering is out of scope for this ticket.

## Linear ticket

CX-118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added four new JIT parity verification tests for infinite loop exit behavior and compound assignment operations across different scenarios.

* **Documentation**
  * Updated CX JIT parity checklist with new baseline measurements, expanding feature verification coverage and per-category test metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->