### PR TITLE
CX-119: Add CompoundAssign Var-target JIT lowering (Load+BinOp+Store on plain variables)

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -27,7 +27,7 @@ set:
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 |
-| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128 |
+| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t146 |
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |
@@ -102,10 +102,11 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-113` (submain as of CX-113 merge window, 2026-05-11).
+Run on branch `stokowski/CX-119` (submain as of CX-119 merge window, 2026-05-11).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), the CX-111 bool-variable negation extension to t131, and
-CX-113 when-block exit-code fixtures (t143–t145).
+fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
+CX-113 when-block exit-code fixtures (t143–t145), and CX-119 var compound assign
+exit-code fixture (t146).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -119,7 +120,7 @@ InfiniteLoop              1      2            0
 DirectCall                5      6            0
 Struct                    5      6            0
 Array                     0      2            0
-CompoundAssign            1      2            0
+CompoundAssign            2      2            0
 Unary                     0      1            0
 Cast                      0      2            0
 FloatOps                  0      5            0
@@ -127,7 +128,7 @@ BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    13     51            0
 ------------------------------------------------
-Total: 149 fixtures, 0 PARITY_FAILs
+Total: 150 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -164,6 +165,14 @@ and while-in/while-in-then constructs (not yet JIT-lowerable).
 mirrors t20 (TBool three-way), t145 mirrors t21 (range pattern). All 3 are SKIP
 in JIT (when-block lowering not yet implemented; exits 127). Once when-block
 lowering lands, these fixtures will transition from SKIP to PASS without changes.
+
+**CompoundAssign Var-target parity (CX-119):** t146 tests all five compound-assign
+operators (+=, -=, *=, /=, %=) on a typed t64 plain variable, verified by exit
+code. Fixed a semantic-analysis bug where the Var-target branch used
+`info.inferred` only (defaulting to `Unknown` for typed variables declared with an
+explicit type annotation) instead of `binding_type()` which checks `declared`
+first. The 2 PASS reflect t128 (struct field) and t146 (plain variable); the 2
+SKIP are t26 and t41 (print-based, JIT not yet lowerable for `print`).
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -223,6 +223,7 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         "t26_compound_add_two"
         | "t41_compound_assign_dot"
         | "t128_struct_compound_assign_exit"
+        | "t146_var_compound_assign_exit"
             => FeatureCategory::CompoundAssign,
 
         // ── Unary ─────────────────────────────────────────────────────────────

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -803,10 +803,12 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 operand,
                 pos,
             } => {
+                let tp = self.current_type_params.clone();
                 let sem_target = match target {
                     AssignTarget::Var(name) => {
-                        let binding = self.lookup_var(name).map(|info| info.binding).unwrap_or(BindingId(u32::MAX));
-                        let ty = self.lookup_var(name).and_then(|info| info.inferred.clone()).unwrap_or(SemanticType::Unknown);
+                        let (binding, ty) = self.lookup_var(name)
+                            .map(|info| (info.binding, binding_type(info, &tp)))
+                            .unwrap_or((BindingId(u32::MAX), SemanticType::Unknown));
                         SemanticLValue::Binding { binding, name: name.clone(), ty }
                     }
                     AssignTarget::Field(container, field) => {

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -806,10 +806,16 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 let tp = self.current_type_params.clone();
                 let sem_target = match target {
                     AssignTarget::Var(name) => {
-                        let (binding, ty) = self.lookup_var(name)
-                            .map(|info| (info.binding, binding_type(info, &tp)))
-                            .unwrap_or((BindingId(u32::MAX), SemanticType::Unknown));
-                        SemanticLValue::Binding { binding, name: name.clone(), ty }
+                        let info = self.lookup_var(name)
+                            .ok_or_else(|| sem_err!(*pos, "use of undeclared variable '{}'", name))?;
+                        if !info.initialized {
+                            return Err(sem_err!(*pos, "use of uninitialized variable '{}'", name));
+                        }
+                        SemanticLValue::Binding {
+                            binding: info.binding,
+                            name: name.clone(),
+                            ty: binding_type(info, &tp),
+                        }
                     }
                     AssignTarget::Field(container, field) => {
                         let binding = self.lookup_var(container).map(|info| info.binding);

--- a/src/tests/verification_matrix/t146_var_compound_assign_exit.cx
+++ b/src/tests/verification_matrix/t146_var_compound_assign_exit.cx
@@ -1,0 +1,23 @@
+// CX-119: exit-code-based JIT parity — compound assign on plain variables.
+// Exercises all five compound-assign operators (+=, -=, *=, /=, %=) on a
+// typed t64 variable.  Correctness verified by exit code only (0 = all
+// asserts held).
+x: t64 = 10
+x += 5
+assert_eq(x, 15)
+
+x = 20
+x -= 8
+assert_eq(x, 12)
+
+x = 6
+x *= 7
+assert_eq(x, 42)
+
+x = 100
+x /= 4
+assert_eq(x, 25)
+
+x = 17
+x %= 5
+assert_eq(x, 2)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-119/add-compoundassign-var-target-jit-lowering-loadbinopstore-on-plain

## Summary

- **Bug fix** (`src/frontend/semantic.rs`): CompoundAssign Var-target semantic analysis was computing the binding type as `info.inferred.clone().unwrap_or(SemanticType::Unknown)`, which returns `Unknown` for variables declared with an explicit type annotation (e.g. `x: t64 = 10`). Changed to use `binding_type(info, &tp)` — which checks `declared` first, then `inferred`, and never defaults to `Unknown` — matching the same logic used in plain `Assign`.
- **New fixture** (`src/tests/verification_matrix/t146_var_compound_assign_exit.cx`): Exit-code-verified test covering all five compound-assign operators (`+=`, `-=`, `*=`, `/=`, `%=`) on a `t64` plain variable. No `print` dependency; correctness verified by exit code 0.
- **Harness registration** (`src/diff_harness.rs`): Added `t146_var_compound_assign_exit` to `FeatureCategory::CompoundAssign`.
- **Checklist update** (`docs/backend/cx_jit_parity_checklist.md`): Updated baseline — CompoundAssign PASS 1 → 2, total fixtures 149 → 150.

## Root Cause

For `x: t64 = 10` (a `TypedAssign`), the semantic resolver sets `VarInfo::declared = Some(t64)` but `VarInfo::inferred = None`. The `CompoundAssign` semantic pass for `Var` targets was only looking at `inferred`, so typed variables always resolved to `Unknown`. That `Unknown` propagated into the IR as the binding type, causing `lower_type(Unknown)` to fail with an unsupported-type error, making the JIT exit 127 (SKIP).

The fix is one line: use `binding_type(info, &tp)` which mirrors what the `Assign` path already does correctly.

## Files Changed

- `src/frontend/semantic.rs` — Var-target type resolution in `CompoundAssign`
- `src/tests/verification_matrix/t146_var_compound_assign_exit.cx` — new fixture
- `src/diff_harness.rs` — `feature_of()` mapping for t146
- `docs/backend/cx_jit_parity_checklist.md` — updated baseline table

## Validation

```
cargo build --features jit
cargo test --features jit
```

Result: **309 passed; 0 failed**. CompoundAssign parity: PASS=2, SKIP=2, PARITY_FAIL=0.

## Linear Reference

CX-119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compound-assignment operators (+=, -=, *=, /=, %=) now correctly resolve and validate types for typed variables, improving semantic accuracy and parity.

* **Tests**
  * Added a new exit-code-based parity test that exercises all five compound-assign operators on a typed variable.

* **Documentation**
  * Updated the parity checklist and baseline counts to reflect the new test and adjusted feature classification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/162)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->