### PR TITLE
CX-120: Add ForLoop, Array, Unary exit-code parity fixtures (t146–t149)

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -22,13 +22,13 @@ set:
 | VariableDecl   | Variable/const declarations, scope, type errors | t15, t56, t57, t101, t102, t122–t124 |
 | IfElse         | Conditional branches                         | t44, t45, t46 (output-verified); t129, t130, t131 (exit-code-verified, CX-102/CX-111) |
 | WhileLoop      | While loops and while-in construct           | t23, t34, t35, t105, t107, t108 (output-verified); t132, t133 (exit-code-verified, CX-102) |
-| ForLoop        | For-in loops                                 | t48, t104 |
+| ForLoop        | For-in loops                                 | t48, t104 (output-verified); t146, t147 (exit-code-verified, CX-120) |
 | InfiniteLoop   | `loop { ... break }` (infinite loop + break) | t25, t106, t134 |
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
-| Array          | Array literals and array-of-result           | t33, t112 |
+| Array          | Array literals and array-of-result           | t33, t112 (output-verified); t148 (exit-code-verified, CX-120) |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128 |
-| Unary          | Unary operators (negation, etc.)             | t96 |
+| Unary          | Unary operators (negation, etc.)             | t96 (output-verified); t149 (exit-code-verified, CX-120) |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |
 | BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
@@ -102,10 +102,11 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-113` (submain as of CX-113 merge window, 2026-05-11).
+Run on branch `stokowski/CX-120` (submain as of CX-120 merge window, 2026-05-11).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), the CX-111 bool-variable negation extension to t131, and
-CX-113 when-block exit-code fixtures (t143–t145).
+fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
+CX-113 when-block exit-code fixtures (t143–t145), and CX-120 ForLoop/Array/Unary
+exit-code fixtures (t146–t149).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -114,20 +115,20 @@ Arithmetic                6     11            0
 VariableDecl              5      3            0
 IfElse                    3      3            0
 WhileLoop                 2      6            0
-ForLoop                   0      2            0
+ForLoop                   0      4            0
 InfiniteLoop              1      2            0
 DirectCall                5      6            0
 Struct                    5      6            0
-Array                     0      2            0
+Array                     0      3            0
 CompoundAssign            1      2            0
-Unary                     0      1            0
+Unary                     0      2            0
 Cast                      0      2            0
 FloatOps                  0      5            0
 BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    13     51            0
 ------------------------------------------------
-Total: 149 fixtures, 0 PARITY_FAILs
+Total: 153 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -164,6 +165,20 @@ and while-in/while-in-then constructs (not yet JIT-lowerable).
 mirrors t20 (TBool three-way), t145 mirrors t21 (range pattern). All 3 are SKIP
 in JIT (when-block lowering not yet implemented; exits 127). Once when-block
 lowering lands, these fixtures will transition from SKIP to PASS without changes.
+
+**ForLoop parity coverage (CX-120):** t146 mirrors t48 (top-level for loop,
+accumulation), t147 mirrors t104 (for loop in a function). Both are SKIP in JIT
+(for-loop lowering not yet implemented; exits 127). The 4 SKIP total includes the
+2 original output-verified fixtures plus the 2 new exit-code-verified mirrors.
+
+**Array parity coverage (CX-120):** t148 mirrors t33 (array index read and
+write). SKIP in JIT (array lowering not yet implemented; exits 127). The 3 SKIP
+total includes the 2 original fixtures plus the new exit-code-verified mirror.
+
+**Unary parity coverage (CX-120):** t149 mirrors t96 (unary integer negation,
+using t64 to test the basic semantic without t8 overflow). SKIP in JIT (unary
+negation not yet lowered; exits 127). The 2 SKIP total includes the original
+output-verified fixture plus the new exit-code-verified mirror.
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -178,6 +178,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── ForLoop ───────────────────────────────────────────────────────────
         "t48_for_loop"
         | "t104_for_in_func"
+        | "t146_for_loop_exit"
+        | "t147_for_in_func_exit"
             => FeatureCategory::ForLoop,
 
         // ── InfiniteLoop ──────────────────────────────────────────────────────
@@ -217,6 +219,7 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── Array ─────────────────────────────────────────────────────────────
         "t33_arrays"
         | "t112_array_of_result"
+        | "t148_array_basic_exit"
             => FeatureCategory::Array,
 
         // ── CompoundAssign ────────────────────────────────────────────────────
@@ -227,6 +230,7 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
 
         // ── Unary ─────────────────────────────────────────────────────────────
         "t96_overflow_t8_unary_neg"
+        | "t149_unary_neg_exit"
             => FeatureCategory::Unary,
 
         // ── Cast ─────────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t146_for_loop_exit.cx
+++ b/src/tests/verification_matrix/t146_for_loop_exit.cx
@@ -1,0 +1,21 @@
+// CX-120: exit-code-based JIT parity — for-loop accumulation (mirrors t48).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// JIT SKIP: for-loop lowering not yet implemented; exits 127.
+
+sum: t64 = 0
+for i in 0..5 {
+    sum = sum + i
+}
+assert_eq(sum, 10)
+
+sum = 0
+for i in 0..3 {
+    sum = sum + i
+}
+assert_eq(sum, 3)
+
+sum = 0
+for i in 0..1 {
+    sum = sum + i
+}
+assert_eq(sum, 0)

--- a/src/tests/verification_matrix/t147_for_in_func_exit.cx
+++ b/src/tests/verification_matrix/t147_for_in_func_exit.cx
@@ -1,0 +1,15 @@
+// CX-120: exit-code-based JIT parity — for-loop in a function (mirrors t104).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// JIT SKIP: for-loop lowering not yet implemented; exits 127.
+
+fnc: t64 sum_range(n: t64) {
+    s: t64 = 0
+    for i in 0..n {
+        s = s + i
+    }
+    return s
+}
+
+assert_eq(sum_range(3), 3)
+assert_eq(sum_range(5), 10)
+assert_eq(sum_range(0), 0)

--- a/src/tests/verification_matrix/t148_array_basic_exit.cx
+++ b/src/tests/verification_matrix/t148_array_basic_exit.cx
@@ -1,0 +1,11 @@
+// CX-120: exit-code-based JIT parity — array index read and write (mirrors t33).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// JIT SKIP: array lowering not yet implemented; exits 127.
+
+arr: [5: t64] = [10, 20, 30, 40, 50]
+assert_eq(arr:[0], 10)
+assert_eq(arr:[2], 30)
+assert_eq(arr:[4], 50)
+
+arr:[1] = 99
+assert_eq(arr:[1], 99)

--- a/src/tests/verification_matrix/t149_unary_neg_exit.cx
+++ b/src/tests/verification_matrix/t149_unary_neg_exit.cx
@@ -1,0 +1,12 @@
+// CX-120: exit-code-based JIT parity — unary integer negation (mirrors t96).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// JIT SKIP: unary negation not yet lowered to JIT IR; exits 127.
+
+x: t64 = 5
+assert_eq(-x, -5)
+
+y: t64 = -3
+assert_eq(-y, 3)
+
+z: t64 = 0
+assert_eq(-z, 0)


### PR DESCRIPTION
Closes CX-120

## Summary

Adds four exit-code-verified JIT parity fixtures for the three feature categories
that had 0 PASS and no exit-code mirrors after the CX-113 merge:

- **t146_for_loop_exit** — top-level for-loop accumulation (mirrors t48)
- **t147_for_in_func_exit** — for-loop inside a function (mirrors t104)
- **t148_array_basic_exit** — array index read and write (mirrors t33)
- **t149_unary_neg_exit** — unary integer negation using t64 (mirrors t96)

All four fixtures follow the established exit-code fixture pattern: no `print`
output, correctness verified by exit code only (0 = all `assert_eq` assertions
held). Each fixture will SKIP in JIT (exits 127) until the corresponding
lowering is implemented; all four PASS in the interpreter baseline today.

## Files Changed

- `src/tests/verification_matrix/t146_for_loop_exit.cx` — new fixture
- `src/tests/verification_matrix/t147_for_in_func_exit.cx` — new fixture
- `src/tests/verification_matrix/t148_array_basic_exit.cx` — new fixture
- `src/tests/verification_matrix/t149_unary_neg_exit.cx` — new fixture
- `src/diff_harness.rs` — `feature_of()` mappings for t146–t149 added to ForLoop, Array, Unary arms
- `docs/backend/cx_jit_parity_checklist.md` — Section 1 table and Section 3 baseline updated (149 → 153 fixtures)

## Parity Baseline After This PR

```
Feature                PASS   SKIP  PARITY_FAIL
------------------------------------------------
ForLoop                   0      4            0   (was 0/2)
Array                     0      3            0   (was 0/2)
Unary                     0      2            0   (was 0/1)
(all other categories unchanged)
------------------------------------------------
Total: 153 fixtures, 0 PARITY_FAILs
```

## Validation

```
cargo build --features jit
cargo test --features jit
```

Results: **309 passed; 0 failed** — includes `interpreter_baseline_all` (all 153 fixtures pass the interpreter) and `jit_parity_by_feature` (0 PARITY_FAILs across all 16 feature categories).

## Linear Ticket

CX-120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CX JIT parity checklist baseline from CX-113 to CX-120. Expanded fixture set now includes exit-code-verified mirrors alongside output-verified fixtures. Fixture count increased from 149 to 153.

* **Tests**
  * Added four new exit-code verification tests for for-loop accumulation, for-loop within functions, array indexing, and unary negation operations. Tests verify correctness via process exit codes where full lowering is not yet implemented.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->