### PR TITLE
CX-121: Add exit-code array fixtures to unblock Array JIT parity

### DIFF
--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -217,6 +217,9 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── Array ─────────────────────────────────────────────────────────────
         "t33_arrays"
         | "t112_array_of_result"
+        | "t146_array_read_exit"
+        | "t147_array_write_exit"
+        | "t148_array_in_func_exit"
             => FeatureCategory::Array,
 
         // ── CompoundAssign ────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t146_array_read_exit.cx
+++ b/src/tests/verification_matrix/t146_array_read_exit.cx
@@ -1,0 +1,7 @@
+// CX-121: exit-code-based JIT parity — array literal construction and index reads.
+// Exercises Alloca + PtrOffset + Store (init) and PtrAdd + Load (read).
+// Correctness verified by exit code only (0 = all asserts held).
+arr: [5: t64] = [10, 20, 30, 40, 50]
+assert_eq(arr:[0], 10)
+assert_eq(arr:[2], 30)
+assert_eq(arr:[4], 50)

--- a/src/tests/verification_matrix/t147_array_write_exit.cx
+++ b/src/tests/verification_matrix/t147_array_write_exit.cx
@@ -1,0 +1,8 @@
+// CX-121: exit-code-based JIT parity — array element write then read-back.
+// Exercises Alloca + init, then PtrAdd + Store (write), then PtrAdd + Load (read-back).
+// Correctness verified by exit code only (0 = all asserts held).
+arr: [3: t64] = [10, 20, 30]
+arr:[1] = 99
+assert_eq(arr:[0], 10)
+assert_eq(arr:[1], 99)
+assert_eq(arr:[2], 30)

--- a/src/tests/verification_matrix/t148_array_in_func_exit.cx
+++ b/src/tests/verification_matrix/t148_array_in_func_exit.cx
@@ -1,0 +1,9 @@
+// CX-121: exit-code-based JIT parity — array alloca inside a user-defined function.
+// Exercises array allocation, init, and indexed read within a non-main function scope.
+// Correctness verified by exit code only (0 = all asserts held).
+fnc: t64 pick_middle() {
+    vals: [3: t64] = [7, 42, 99]
+    return vals:[1]
+}
+result: t64 = pick_middle()
+assert_eq(result, 42)


### PR DESCRIPTION
Closes CX-121

## Summary

- Added three JIT-compatible exit-code fixtures that exercise array alloca, init, indexed reads, and indexed writes through the Cranelift backend — bypassing the `print` blocker that keeps `t33_arrays` and `t112_array_of_result` in SKIP.
- Registered all three fixtures under `FeatureCategory::Array` in `diff_harness.rs` so `jit_parity_by_feature` counts them as PASS.

## Files changed

| File | Change |
|---|---|
| `src/tests/verification_matrix/t146_array_read_exit.cx` | New — array literal + index reads via `assert_eq` |
| `src/tests/verification_matrix/t147_array_write_exit.cx` | New — array element write then read-back |
| `src/tests/verification_matrix/t148_array_in_func_exit.cx` | New — array alloca inside a user-defined function |
| `src/diff_harness.rs` | `feature_of()` extended to classify t146/t147/t148 as `FeatureCategory::Array` |

## Why no JIT emit code changed

All required Cranelift emit paths for arrays were already present (`IrInst::Alloca`, `PtrOffset`, `PtrAdd`, `Load`, `Store`). The previous Array SKIP count came entirely from `t33_arrays` (uses `print`) and `t112_array_of_result` (uses `Result<t32>`). The new fixtures use only `assert_eq`, which is fully lowerable to IR, so they run to completion in the JIT.

## Tests run

```
cargo build --features jit
cargo test --features jit
```

## Validation result

```
test result: ok. 309 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`jit_parity_by_feature` passed with 0 PARITY_FAILs. The three new Array fixtures PASS in JIT (exit 0).

## Known limitations

- `t33_arrays` and `t112_array_of_result` remain SKIP (exit 127) — blocked by `print` (Phase 9 pending) and `Result<T>` respectively. Those are separate tickets.

## Linear ticket reference

CX-121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added three new verification tests validating array functionality: read operations, write operations, and arrays in functions.

* **Chores**
  * Enhanced categorization of array-related test fixtures for improved test organization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/164)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->