### PR TITLE
CX-123: Add automatic IR dump on JIT compile/link failure

### DIFF
--- a/src/backend/cranelift/mod.rs
+++ b/src/backend/cranelift/mod.rs
@@ -241,6 +241,14 @@ fn lower_terminator(term: &IrTerminator) -> Result<(), CraneliftLoweringError> {
 
 // ── Backend impl ─────────────────────────────────────────────────────────────
 
+/// Returns `true` when `e` is a compile-or-link failure that warrants an IR
+/// dump.  `RuntimePanic` means the IR compiled successfully and the failure
+/// happened at execution time, so the dump would not add signal.
+#[cfg(feature = "jit")]
+fn should_dump_ir_on_jit_failure(e: &host_boundary::JitExecutionError) -> bool {
+    !matches!(e, host_boundary::JitExecutionError::RuntimePanic { .. })
+}
+
 impl Backend for CraneliftBackend {
     fn execute(&self, module: &IrModule) -> Result<(), BackendError> {
         #[cfg(feature = "jit")]
@@ -270,6 +278,11 @@ impl Backend for CraneliftBackend {
                         // 126 = JIT_RUNTIME_FAILURE: program compiled but crashed.
                         JitExecutionError::RuntimePanic { .. } => 126,
                     };
+                    if should_dump_ir_on_jit_failure(&e) {
+                        eprintln!("--- cx jit: compile/link failed — IR dump ---");
+                        eprint!("{}", crate::ir::printer::print_module(module));
+                        eprintln!("--- end IR dump ---");
+                    }
                     Err(BackendError {
                         message: e.to_string(),
                         exit_code,
@@ -385,6 +398,48 @@ mod tests {
         assert!(
             CraneliftBackend.execute(&module).is_ok(),
             "program exiting 0 must produce Ok(())"
+        );
+    }
+
+    // ── IR dump gating tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn ir_dump_suppressed_for_runtime_panic() {
+        use host_boundary::JitExecutionError;
+        let err = JitExecutionError::RuntimePanic { detail: "crash".to_string() };
+        assert!(
+            !should_dump_ir_on_jit_failure(&err),
+            "RuntimePanic must not trigger an IR dump"
+        );
+    }
+
+    #[test]
+    fn ir_dump_enabled_for_codegen_failure() {
+        use host_boundary::JitExecutionError;
+        let err = JitExecutionError::CodegenFailure { detail: "bad".to_string() };
+        assert!(
+            should_dump_ir_on_jit_failure(&err),
+            "CodegenFailure must trigger an IR dump"
+        );
+    }
+
+    #[test]
+    fn ir_dump_enabled_for_unsupported_construct() {
+        use host_boundary::JitExecutionError;
+        let err = JitExecutionError::UnsupportedConstruct { construct: "X".to_string() };
+        assert!(
+            should_dump_ir_on_jit_failure(&err),
+            "UnsupportedConstruct must trigger an IR dump"
+        );
+    }
+
+    #[test]
+    fn ir_dump_enabled_for_main_not_found() {
+        use host_boundary::JitExecutionError;
+        let err = JitExecutionError::MainNotFound;
+        assert!(
+            should_dump_ir_on_jit_failure(&err),
+            "MainNotFound must trigger an IR dump"
         );
     }
 


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-123/cx-123-add-automatic-ir-dump-on-jit-compilelink-failure

## Summary

- When the JIT pipeline fails with `CodegenFailure`, `UnsupportedConstruct`, or `MainNotFound`, the full IR module text is automatically written to stderr between `--- cx jit: compile/link failed — IR dump ---` markers.
- `RuntimePanic` is excluded: the IR compiled successfully in that case, so dumping adds no diagnostic signal.
- No new CLI flags — the dump is unconditional on compile/link failure.

## Files changed

- `src/backend/cranelift/mod.rs` — added `should_dump_ir_on_jit_failure()` helper and stderr dump in `CraneliftBackend::execute()`'s `Err(e)` branch.

## Tests run

```
cargo build --features jit
cargo test --features jit
```

## Validation results

```
test result: ok. 313 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

4 new unit tests added:
- `ir_dump_suppressed_for_runtime_panic`
- `ir_dump_enabled_for_codegen_failure`
- `ir_dump_enabled_for_unsupported_construct`
- `ir_dump_enabled_for_main_not_found`

## Linear ticket

CX-123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling by selectively controlling verbose debug output for specific runtime errors, while preserving complete diagnostic information for compilation and linking failures.

* **Tests**
  * Added unit tests to verify the improved debug output behavior across various error scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/166)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->