### PR TITLE
CX-125: Apply CodeRabbit hardening on CX-124 ForLoop parity fixtures

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -22,11 +22,11 @@ set:
 | VariableDecl   | Variable/const declarations, scope, type errors | t15, t56, t57, t101, t102, t122–t124 |
 | IfElse         | Conditional branches                         | t44, t45, t46 (output-verified); t129, t130, t131 (exit-code-verified, CX-102/CX-111) |
 | WhileLoop      | While loops and while-in construct           | t23, t34, t35, t105, t107, t108 (output-verified); t132, t133 (exit-code-verified, CX-102) |
-| ForLoop        | For-in loops                                 | t48, t104 |
+| ForLoop        | For-in loops                                 | t48, t104 (output-verified); t149, t150 (exit-code-verified, CX-124) |
 | InfiniteLoop   | `loop { ... break }` (infinite loop + break) | t25, t106, t134 |
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
-| Array          | Array literals and array-of-result           | t33, t112 |
+| Array          | Array literals and array-of-result           | t33, t112 (output-verified); t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit (exit-code-verified, CX-121) |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t146 |
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
@@ -102,11 +102,13 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-119` (submain as of CX-119 merge window, 2026-05-11).
+Run on branch `stokowski/CX-124` (submain as of CX-124 merge window, 2026-05-11).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
-CX-113 when-block exit-code fixtures (t143–t145), and CX-119 var compound assign
-exit-code fixture (t146).
+CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
+exit-code fixture (t146_var_compound_assign_exit), CX-121 Array exit-code fixtures
+(t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit), and
+CX-124 ForLoop exit-code fixtures (t149–t150).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -115,11 +117,11 @@ Arithmetic                6     11            0
 VariableDecl              5      3            0
 IfElse                    3      3            0
 WhileLoop                 2      6            0
-ForLoop                   0      2            0
+ForLoop                   2      2            0
 InfiniteLoop              1      2            0
 DirectCall                5      6            0
 Struct                    5      6            0
-Array                     0      2            0
+Array                     0      5            0
 CompoundAssign            2      2            0
 Unary                     0      1            0
 Cast                      0      2            0
@@ -128,7 +130,7 @@ BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    13     51            0
 ------------------------------------------------
-Total: 150 fixtures, 0 PARITY_FAILs
+Total: 155 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -173,6 +175,12 @@ code. Fixed a semantic-analysis bug where the Var-target branch used
 explicit type annotation) instead of `binding_type()` which checks `declared`
 first. The 2 PASS reflect t128 (struct field) and t146 (plain variable); the 2
 SKIP are t26 and t41 (print-based, JIT not yet lowerable for `print`).
+
+**ForLoop parity coverage (CX-124):** t149 mirrors t48 (top-level for loop at file scope),
+covering exclusive range (`0..5`), empty range (`3..3`, 0 iterations), and inclusive range
+(`1..=4`). t150 mirrors t104 (for loop inside a function), covering a sum-accumulator pattern
+with a mutable variable carried through the loop. The 2 PASS reflect the exit-code-verified
+set; the 2 SKIP are the print-based originals (t48, t104).
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -178,6 +178,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── ForLoop ───────────────────────────────────────────────────────────
         "t48_for_loop"
         | "t104_for_in_func"
+        | "t149_for_loop_exit"
+        | "t150_for_in_func_exit"
             => FeatureCategory::ForLoop,
 
         // ── InfiniteLoop ──────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t149_for_loop_exit.cx
+++ b/src/tests/verification_matrix/t149_for_loop_exit.cx
@@ -8,6 +8,13 @@ for i in 0..5 {
 }
 assert_eq(total, 10)
 
+// Non-zero lower bound: 2+3+4 = 9; catches start-bound off-by-one.
+offset_total: t64 = 0
+for i in 2..5 {
+    offset_total = offset_total + i
+}
+assert_eq(offset_total, 9)
+
 // Empty range: start == end yields 0 iterations.
 count: t64 = 0
 for i in 3..3 {

--- a/src/tests/verification_matrix/t149_for_loop_exit.cx
+++ b/src/tests/verification_matrix/t149_for_loop_exit.cx
@@ -1,0 +1,23 @@
+// CX-124: exit-code-based JIT parity — for-in range loop at file scope.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+
+// Exclusive range: 0+1+2+3+4 = 10.
+total: t64 = 0
+for i in 0..5 {
+    total = total + i
+}
+assert_eq(total, 10)
+
+// Empty range: start == end yields 0 iterations.
+count: t64 = 0
+for i in 3..3 {
+    count = count + 1
+}
+assert_eq(count, 0)
+
+// Inclusive range: 1+2+3+4 = 10.
+sum: t64 = 0
+for i in 1..=4 {
+    sum = sum + i
+}
+assert_eq(sum, 10)

--- a/src/tests/verification_matrix/t150_for_in_func_exit.cx
+++ b/src/tests/verification_matrix/t150_for_in_func_exit.cx
@@ -1,0 +1,13 @@
+// CX-124: exit-code-based JIT parity — for-in loop inside a user-defined function.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 sum_range(n: t64) {
+    total: t64 = 0
+    for i in 0..n {
+        total = total + i
+    }
+    return total
+}
+
+assert_eq(sum_range(5), 10)
+assert_eq(sum_range(0), 0)
+assert_eq(sum_range(1), 0)

--- a/src/tests/verification_matrix/t150_for_in_func_exit.cx
+++ b/src/tests/verification_matrix/t150_for_in_func_exit.cx
@@ -8,6 +8,17 @@ fnc: t64 sum_range(n: t64) {
     return total
 }
 
+// Explicit iteration counter: proves the loop executed exactly n times.
+// sum-only checks can mask a bug that skips the first iteration.
+fnc: t64 iter_count(n: t64) {
+    count: t64 = 0
+    for i in 0..n {
+        count = count + 1
+    }
+    return count
+}
+
 assert_eq(sum_range(5), 10)
 assert_eq(sum_range(0), 0)
 assert_eq(sum_range(1), 0)
+assert_eq(iter_count(5), 5)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-125

## Summary

Applies both CodeRabbit review comments from PR #167 (CX-124) to the ForLoop
exit-code parity fixtures added in that PR.

- **t149**: adds a non-zero lower-bound exclusive-range probe (`2..5 → 9`) that
  would fail if the loop start-bound is computed with an off-by-one error; the
  previous zero-based sums could still pass in that case.
- **t150**: adds `iter_count(n)` alongside the existing `sum_range(n)`, using
  an explicit counter incremented each iteration so `iter_count(5)==5` verifies
  the loop executed exactly 5 times — a sum-based check alone cannot distinguish
  a first-iteration skip from a correct run.

## Files changed

| File | Change |
|------|--------|
| `src/tests/verification_matrix/t149_for_loop_exit.cx` | +7 lines: non-zero lower-bound probe block |
| `src/tests/verification_matrix/t150_for_in_func_exit.cx` | +11 lines: `iter_count()` function + assertion |

## Tests run

```
cargo build --features jit   → clean (pre-existing warnings only)
cargo test  --features jit   → 309 passed, 0 failed
```

## Linear ticket reference

CX-125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated baseline documentation with expanded ForLoop test coverage and increased fixture count to 155.

* **Tests**
  * Added new verification tests for ForLoop scenarios, including exclusive ranges, non-zero bounds, and loops within user-defined functions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->