### PR TITLE
CX-129: Apply CodeRabbit fixes on CX-121 ArrayAlloca PR

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -722,6 +722,26 @@ fn compile_ir_function(
                     val_map.insert(*dst, ptr_val);
                 }
 
+                IrInst::ArrayAlloca { dst, element_type, count } => {
+                    use crate::ir::types::compute_array_layout;
+                    use cranelift_codegen::ir::stackslot::{StackSlotData, StackSlotKind};
+                    use cranelift_codegen::ir::types;
+
+                    let layout = compute_array_layout(element_type, *count);
+                    let align_shift = if layout.alignment == 0 {
+                        0u8
+                    } else {
+                        layout.alignment.trailing_zeros() as u8
+                    };
+                    let slot = builder.create_sized_stack_slot(StackSlotData::new(
+                        StackSlotKind::ExplicitSlot,
+                        layout.total_size as u32,
+                        align_shift,
+                    ));
+                    let ptr_val = builder.ins().stack_addr(types::I64, slot, 0);
+                    val_map.insert(*dst, ptr_val);
+                }
+
                 IrInst::Load { dst, ty, ptr } => {
                     use cranelift_codegen::ir::MemFlags;
 

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -728,6 +728,14 @@ fn compile_ir_function(
                     use cranelift_codegen::ir::types;
 
                     let layout = compute_array_layout(element_type, *count);
+                    let slot_size = u32::try_from(layout.total_size).map_err(|_| {
+                        JitExecutionError::UnsupportedConstruct {
+                            construct: format!(
+                                "ArrayAlloca total size {} exceeds Cranelift stack-slot limit",
+                                layout.total_size
+                            ),
+                        }
+                    })?;
                     let align_shift = if layout.alignment == 0 {
                         0u8
                     } else {
@@ -735,7 +743,7 @@ fn compile_ir_function(
                     };
                     let slot = builder.create_sized_stack_slot(StackSlotData::new(
                         StackSlotKind::ExplicitSlot,
-                        layout.total_size as u32,
+                        slot_size,
                         align_shift,
                     ));
                     let ptr_val = builder.ins().stack_addr(types::I64, slot, 0);

--- a/src/backend/cranelift/mod.rs
+++ b/src/backend/cranelift/mod.rs
@@ -176,6 +176,12 @@ fn lower_instruction(inst: &IrInst) -> Result<(), CraneliftLoweringError> {
                 context: format!("dst={dst:?} size={size} align={align}"),
             })
         }
+        IrInst::ArrayAlloca { dst, element_type, count } => {
+            Err(CraneliftLoweringError::UnsupportedInstruction {
+                inst: "ArrayAlloca".to_string(),
+                context: format!("dst={dst:?} element_type={element_type:?} count={count}"),
+            })
+        }
         IrInst::PtrOffset { dst, base, offset } => {
             Err(CraneliftLoweringError::UnsupportedInstruction {
                 inst: "PtrOffset".to_string(),

--- a/src/ir/instr.rs
+++ b/src/ir/instr.rs
@@ -65,6 +65,16 @@ pub enum IrInst {
         size: usize,
         align: usize,
     },
+    /// Allocate a fixed-size array on the stack.
+    ///
+    /// Equivalent to `Alloca { size: element_size(element_type) * count,
+    /// align: align_bytes(element_type) }` but carries explicit array
+    /// semantics so the JIT emitter can use typed layout helpers.
+    ArrayAlloca {
+        dst: ValueId,
+        element_type: IrType,
+        count: usize,
+    },
     /// Advance a pointer by a compile-time byte offset.
     ///
     /// `dst = ptr_offset base + offset`

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -2425,16 +2425,24 @@ fn lower_array_lit(
         });
     }
 
-    let elem_ir_ty = lower_type(elem_sem_ty)?;
-    let layout = compute_array_layout(&elem_ir_ty, count);
+    // Numeric is a placeholder type used by the semantic layer for untyped
+    // integer literals.  Map it to the target's default integer width (I64 on
+    // 64-bit) so arrays of untyped literals (e.g. [10, 20, 30]) lower cleanly.
+    let elem_ir_ty = if elem_sem_ty == &SemanticType::Numeric {
+        ctx.target.numeric_literal_ir_type()
+    } else {
+        lower_type(elem_sem_ty)?
+    };
 
-    // 1. Alloca: reserve stack space for the entire array.
+    // 1. ArrayAlloca: reserve stack space for the entire array.
     let ptr = ctx.fresh_value();
-    active.emit(IrInst::Alloca {
+    active.emit(IrInst::ArrayAlloca {
         dst: ptr,
-        size: layout.total_size,
-        align: layout.alignment,
+        element_type: elem_ir_ty.clone(),
+        count,
     })?;
+
+    let layout = compute_array_layout(&elem_ir_ty, count);
 
     // 2. Store each element at its stride-aligned byte offset.
     for (i, elem_expr) in elements.iter().enumerate() {
@@ -2504,18 +2512,30 @@ fn lower_index(
         }
     };
 
-    let elem_ir_ty = lower_type(declared_elem_sem_ty)?;
+    // Numeric and Unknown are placeholder types the semantic layer uses for
+    // unresolved or partially-resolved array element positions.  Map both to
+    // the target's default integer width (I64 on 64-bit) to allow array
+    // programs that mix declared and literal types to lower cleanly.
+    let elem_ir_ty = if matches!(declared_elem_sem_ty, SemanticType::Numeric | SemanticType::Unknown) {
+        ctx.target.numeric_literal_ir_type()
+    } else {
+        lower_type(declared_elem_sem_ty)?
+    };
     let layout = compute_array_layout(&elem_ir_ty, count);
 
     // Verify the outer expression type is consistent with the element type.
-    let outer_ir_ty = lower_type(elem_sem_ty)?;
-    if outer_ir_ty != elem_ir_ty {
-        return Err(LoweringError::InternalInvariantViolation {
-            detail: format!(
-                "Index expression type {:?} does not match array element type {:?}",
-                outer_ir_ty, elem_ir_ty
-            ),
-        });
+    // When the outer type is Unknown the semantic layer could not resolve it;
+    // skip the check and use the declared element type directly.
+    if !matches!(elem_sem_ty, SemanticType::Numeric | SemanticType::Unknown) {
+        let outer_ir_ty = lower_type(elem_sem_ty)?;
+        if outer_ir_ty != elem_ir_ty {
+            return Err(LoweringError::InternalInvariantViolation {
+                detail: format!(
+                    "Index expression type {:?} does not match array element type {:?}",
+                    outer_ir_ty, elem_ir_ty
+                ),
+            });
+        }
     }
 
     // 1. Lower the array target to get the base pointer.
@@ -5283,7 +5303,7 @@ mod tests {
         }
     }
 
-    // ArrayLit lowering: a three-element i64 array must emit exactly one Alloca
+    // ArrayLit lowering: a three-element i64 array must emit exactly one ArrayAlloca
     // (for the whole array), two PtrOffset instructions (elements 1 and 2 —
     // element 0 is at offset 0 so no PtrOffset), and three Stores.
     #[test]
@@ -5306,12 +5326,12 @@ mod tests {
             .flat_map(|b| b.insts.iter())
             .collect();
 
-        // One Alloca for the array storage (3 * 8 = 24 bytes, align 8).
+        // One ArrayAlloca for the array storage (3 x I64).
         let alloca_count = insts
             .iter()
-            .filter(|i| matches!(i, IrInst::Alloca { size: 24, align: 8, .. }))
+            .filter(|i| matches!(i, IrInst::ArrayAlloca { element_type: IrType::I64, count: 3, .. }))
             .count();
-        assert_eq!(alloca_count, 1, "expected exactly one Alloca(24, 8)");
+        assert_eq!(alloca_count, 1, "expected exactly one ArrayAlloca(I64, 3)");
 
         // Three Store instructions — one per element.
         let store_count = insts.iter().filter(|i| matches!(i, IrInst::Store { .. })).count();

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -2425,10 +2425,11 @@ fn lower_array_lit(
         });
     }
 
-    // Numeric is a placeholder type used by the semantic layer for untyped
-    // integer literals.  Map it to the target's default integer width (I64 on
-    // 64-bit) so arrays of untyped literals (e.g. [10, 20, 30]) lower cleanly.
-    let elem_ir_ty = if elem_sem_ty == &SemanticType::Numeric {
+    // Numeric and Unknown are placeholder types used by the semantic layer for
+    // untyped integer literals.  Map both to the target's default integer width
+    // (I64 on 64-bit) so arrays of untyped literals (e.g. [10, 20, 30]) lower
+    // cleanly regardless of which placeholder the semantic pass emitted.
+    let elem_ir_ty = if matches!(elem_sem_ty, SemanticType::Numeric | SemanticType::Unknown) {
         ctx.target.numeric_literal_ir_type()
     } else {
         lower_type(elem_sem_ty)?
@@ -5287,6 +5288,21 @@ mod tests {
         }
     }
 
+    // Helper: build an ArrayLit SemanticExpr with N Numeric-typed elements,
+    // matching what the semantic layer emits for untyped integer literals.
+    fn array_lit_numeric(elements: Vec<i128>) -> SemanticExpr {
+        let count = elements.len();
+        SemanticExpr {
+            ty: SemanticType::Array(count, Box::new(SemanticType::Numeric)),
+            kind: SemanticExprKind::ArrayLit {
+                elements: elements
+                    .into_iter()
+                    .map(|v| int_expr(v, SemanticType::Numeric))
+                    .collect(),
+            },
+        }
+    }
+
     // Helper: build an Index SemanticExpr.
     fn index_expr(
         target: SemanticExpr,
@@ -5352,6 +5368,37 @@ mod tests {
             .iter()
             .any(|i| matches!(i, IrInst::PtrOffset { offset: 0, .. }));
         assert!(!has_ptr_offset_0, "unexpected PtrOffset(0) for first element");
+    }
+
+    // ArrayLit with Numeric placeholder element type must still emit one
+    // ArrayAlloca (using the target's default integer width), locking in the
+    // SemanticType::Numeric fallback introduced in lower_array_lit.
+    #[test]
+    fn lowers_array_lit_numeric_elem_uses_default_int() {
+        let arr = array_lit_numeric(vec![10, 20, 30]);
+        let program = SemanticProgram {
+            stmts: vec![typed_assign(
+                BindingId(0),
+                "arr",
+                SemanticType::Array(3, Box::new(SemanticType::Numeric)),
+                arr,
+            )],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let insts: Vec<&IrInst> = module.functions[0]
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .collect();
+
+        // The fallback maps Numeric → I64 on a 64-bit target; count stays 3.
+        let alloca_count = insts
+            .iter()
+            .filter(|i| matches!(i, IrInst::ArrayAlloca { element_type: IrType::I64, count: 3, .. }))
+            .count();
+        assert_eq!(alloca_count, 1, "expected exactly one ArrayAlloca(I64, 3) for Numeric element type");
     }
 
     // lower_type must map SemanticType::Array(_) to IrType::Ptr.

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -111,6 +111,14 @@ pub fn print_inst(inst: &IrInst) -> String {
         IrInst::Alloca { dst, size, align } => {
             format!("{} = alloca size {} align {}", print_value_id(*dst), size, align)
         }
+        IrInst::ArrayAlloca { dst, element_type, count } => {
+            format!(
+                "{} = array_alloca {} * {}",
+                print_value_id(*dst),
+                print_type(element_type),
+                count
+            )
+        }
         IrInst::PtrOffset { dst, base, offset } => {
             format!(
                 "{} = ptr_offset {} + {}",

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -510,6 +510,16 @@ fn validate_inst(
             }
             define_value(function, block, *dst, IrType::Ptr, "Alloca destination", defined_values, errors);
         }
+        IrInst::ArrayAlloca { dst, element_type: _, count } => {
+            if *count == 0 {
+                errors.push(IrValidationError::InvalidTypeUsage {
+                    function: function.name.clone(),
+                    block,
+                    detail: "ArrayAlloca count must be > 0".to_string(),
+                });
+            }
+            define_value(function, block, *dst, IrType::Ptr, "ArrayAlloca destination", defined_values, errors);
+        }
         IrInst::PtrOffset { dst, base, .. } => {
             require_value(function, block, *base, "PtrOffset base", defined_values, errors);
             if let Some(base_ty) = defined_values.get(base) {

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -510,12 +510,19 @@ fn validate_inst(
             }
             define_value(function, block, *dst, IrType::Ptr, "Alloca destination", defined_values, errors);
         }
-        IrInst::ArrayAlloca { dst, element_type: _, count } => {
+        IrInst::ArrayAlloca { dst, element_type, count } => {
             if *count == 0 {
                 errors.push(IrValidationError::InvalidTypeUsage {
                     function: function.name.clone(),
                     block,
                     detail: "ArrayAlloca count must be > 0".to_string(),
+                });
+            }
+            if matches!(element_type, IrType::Void) {
+                errors.push(IrValidationError::InvalidTypeUsage {
+                    function: function.name.clone(),
+                    block,
+                    detail: "ArrayAlloca element_type must be storable, got Void".to_string(),
                 });
             }
             define_value(function, block, *dst, IrType::Ptr, "ArrayAlloca destination", defined_values, errors);


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-129

## Summary

Rebases `IrInst::ArrayAlloca` (from the open CX-121 branch, PR #170) onto current `submain` and applies the three actionable CodeRabbit review fixes.

## Changes

### Cherry-picked from CX-121 (commit acd8806)
- `src/ir/instr.rs` — `IrInst::ArrayAlloca { dst, element_type, count }` variant
- `src/ir/lower.rs` — `lower_array_lit` emits `ArrayAlloca`; placeholder-type mapping
- `src/ir/validate.rs` — validator arm for `ArrayAlloca`
- `src/ir/printer.rs` — printer arm for `ArrayAlloca`
- `src/backend/cranelift/host_boundary.rs` — Cranelift JIT emit for `ArrayAlloca`
- `src/backend/cranelift/mod.rs` — AOT stub for `ArrayAlloca`

### CodeRabbit fixes (this PR — commit fe315ce)

**Fix 1 — `src/ir/lower.rs`**: `lower_array_lit` only guarded `SemanticType::Numeric`; `SemanticType::Unknown` fell through to `lower_type` and errored. Changed to `matches!(elem_sem_ty, SemanticType::Numeric | SemanticType::Unknown)` so both placeholders map to the target's default integer width.

**Fix 2 — `src/backend/cranelift/host_boundary.rs`**: Replaced `layout.total_size as u32` with `u32::try_from(...).map_err(|_| JitExecutionError::UnsupportedConstruct {...})?` to surface an explicit error instead of silently truncating the stack-slot size for large arrays.

**Fix 3 — `src/ir/validate.rs`**: The `ArrayAlloca` validator arm was ignoring `element_type`. Added a `IrType::Void` check that pushes an `InvalidTypeUsage` error, catching invalid typed arrays before they reach lowering.

**Test — `src/ir/lower.rs`**: Added `lowers_array_lit_numeric_elem_uses_default_int` regression test that constructs an `ArrayLit` with `SemanticType::Numeric` element placeholders and asserts the fallback produces `ArrayAlloca { element_type: IrType::I64, count: 3 }`.

## Files changed
- `src/backend/cranelift/host_boundary.rs`
- `src/ir/lower.rs`
- `src/ir/validate.rs`

## Validation

```
cargo build --features jit   — ok (20 pre-existing warnings, no new warnings)
cargo test --features jit    — 314/314 passed, 0 failed
```

Array parity: 3 PASS / 2 SKIP / 0 PARITY_FAIL (unchanged from CX-121 baseline).

## Linear
CX-129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fixed-size array stack allocation with explicit element types and counts

* **Improvements**
  * Enhanced array literal handling to better resolve semantic placeholder element types
  * Improved array indexing to use dedicated array semantics in IR lowering

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/173)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->