### PR TITLE
CX-130: Apply CodeRabbit roadmap version fix on CX-127 TBool ABI PR

### DIFF
--- a/docs/backend/cx_abi_v0.1.md
+++ b/docs/backend/cx_abi_v0.1.md
@@ -63,17 +63,20 @@ When copy param support lands in the compiled backend:
 
 ## Open Design Questions
 
-### TBool Representation — PARTIALLY LOCKED
+### TBool Representation — LOCKED (0.1)
 Three-state value: true (1), false (0), unknown (2).
 - Wire format and storage size: LOCKED. 1 byte, values 0/1/2, stored as I8 at Cranelift level.
-- IrType::TBool exists in the IR type system. Not yet produced by lower_type (awaiting SemanticType::TBool in frontend).
+- IrType::TBool exists in the IR type system. Maps to Cranelift `types::I8`.
 - Valid operations: comparison (0/1/2), three-way branching. Invalid: arithmetic, bitwise.
-- Wire format 0/1/2 is locked from the language spec.
-- Runtime representation: u8? enum? tagged union?
-- Does IrType need a TBool variant or is it lowered as I8 with 0/1/2 convention?
-- Unknown propagation: IR-level checks or runtime intrinsic calls?
-- TBool function parameters: calling convention implications.
-- Arithmetic on unknown-infected values: propagation cost and mechanism.
+- Runtime representation: u8 stored in a 1-byte slot. No enum wrapping. Values 0/1/2 are the only valid states.
+- IrType::TBool is a first-class IR type — not lowered as I8 with a comment. The type carries semantic intent.
+- TBool function parameters: LOCKED. Follows C ABI treating TBool as I8. Passed in the same integer registers as Bool (RDI/RSI/RDX/RCX/R8/R9 on Linux x64; RCX/RDX/R8/R9 on Windows x64). Values 0/1/2 are preserved across the call boundary without padding or encoding. Zero-extended when widened to a larger integer type (Cast TBool → I32 uses `uextend`, not `sextend`).
+- JIT validation: all three TBool wire values (0 = false, 1 = true, 2 = unknown) round-trip correctly through JIT-compiled function calls (confirmed by CX-127 tests in `host_boundary.rs`).
+
+**Post-0.1 deferred items:**
+- Unknown propagation strategy — does unknown checking happen in IR instructions or as runtime intrinsic calls? This decision gates when-block lowering and unknown-infected arithmetic.
+- Arithmetic on unknown-infected values: propagation cost and mechanism. Blocked on unknown propagation strategy.
+- When-block lowering: TBool three-way branching requires two nested Branch instructions since IR Branch is two-way only. Design work needed before implementation.
 
 ### String Layout — OPEN
 - `str` at C boundary is `(*const u8, u32)` — pointer + length, no null termination. LOCKED per frontend dev.

--- a/docs/backend/cx_backend_roadmap_v3_1.md
+++ b/docs/backend/cx_backend_roadmap_v3_1.md
@@ -1,5 +1,5 @@
 # Cx Compiler Backend Roadmap
-v4.2 — 2026-05-10
+v4.3 — 2026-05-11
 
 ---
 

--- a/docs/backend/cx_backend_roadmap_v3_1.md
+++ b/docs/backend/cx_backend_roadmap_v3_1.md
@@ -249,9 +249,11 @@ Without this phase, parity testing is incomplete — the backend could produce o
 - str and strref layout at backend boundary
   - Arena ownership question: the tree-walk interpreter's arena is a Vec<u8> in RunTime. In JIT mode, does the JIT call into the same RunTime arena via intrinsic calls, maintain its own separate arena, or treat strings as heap-allocated (arena as interpreter-only optimization)? This decision affects strref escape rules since strref is an arena view that cannot outlive the arena. Must be answered before any string layout is defined.
 - Handle<T> runtime representation
-- TBool calling convention — a TBool param is not a bool param; function parameter passing convention for TBool needs explicit decision
-- Unknown propagation strategy — does unknown checking happen in IR instructions or as runtime intrinsic calls? Arithmetic on unknown-infected values: propagation cost and mechanism must be defined
+- Unknown propagation strategy — does unknown checking happen in IR instructions or as runtime intrinsic calls? Arithmetic on unknown-infected values: propagation cost and mechanism. This decision gates when-block lowering.
 - Return value rules for large values and void — IrType::Void still pending
+
+**Locked in Round 2 (2026-05-11, CX-127):**
+- TBool calling convention — LOCKED. TBool function parameters follow C ABI treating TBool as I8, passed in the standard integer registers (RDI/RSI/RDX/RCX/R8/R9 on Linux; RCX/RDX/R8/R9 on Windows). Values 0/1/2 preserved across the call boundary. Zero-extended on widening (Cast TBool → I32 uses `uextend`). JIT validation tests confirm all three wire values round-trip correctly.
 
 Done when:
 - Every core Cx type has a documented backend representation
@@ -645,7 +647,7 @@ Nothing in the post-0.1 compiler targets should start until Phase 15 closes.
 
 **Active**
 - Surface area reduction (Phase 11) — all original open items closed; remaining: `when` block lowering/rejection, method call actual lowering
-- ABI and data layout Round 2 (Phase 8) — str/strref layout, Handle<T>, TBool calling convention, unknown propagation still open
+- ABI and data layout Round 2 (Phase 8) — TBool calling convention LOCKED (CX-127); str/strref layout, Handle<T>, unknown propagation still open
 - Differential backend harness (Phase 12) — harness running, 120 fixtures, 0 PARITY_FAILs; full construct set coverage expansion in progress (CX-34)
 - Cranelift JIT — 0.1 target (Phase 15) — no-panic, float ops, exit-code, PtrOffset, intrinsic validation, numeric casts all landed; cast JIT, DotAccess JIT parity, full fixture coverage still in flight
 
@@ -666,6 +668,14 @@ Nothing in the post-0.1 compiler targets should start until Phase 15 closes.
 **Separate Roadmap**
 - GPU layer — Cx Platform and GPU Roadmap
 - Window and screen system — Cx Platform and GPU Roadmap
+
+---
+
+## Key Changes — v4.3 (2026-05-11)
+
+- Phase 8 Round 2 partial progress: TBool calling convention LOCKED — TBool params follow C ABI as I8, values 0/1/2 preserved across call boundary, zero-extended on widening; JIT validation tests confirm (CX-127)
+- `docs/backend/cx_abi_v0.1.md` TBool section updated from PARTIALLY LOCKED to LOCKED; post-0.1 deferred items explicitly listed (unknown propagation, when-block lowering strategy)
+- Roadmap Progress Board updated to reflect TBool calling convention locked; str/strref layout, Handle<T>, unknown propagation remain open Phase 8 items
 
 ---
 

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -1158,7 +1158,7 @@ mod tests {
 mod jit_tests {
     use super::*;
     use crate::ir::instr::{BinaryOp, IrInst, IrTerminator};
-    use crate::ir::types::{BlockId, IrBlock, IrFunction, IrModule, IrType, ValueId};
+    use crate::ir::types::{BlockId, BlockParam, IrBlock, IrFunction, IrModule, IrParam, IrType, ValueId};
 
     /// Build a minimal `main() -> i32` module that returns a single constant.
     fn const_return_module(value: i128) -> IrModule {
@@ -2776,6 +2776,105 @@ mod jit_tests {
         let result = HostBoundary::new().execute(&module);
         assert!(result.is_ok(), "JIT ptr_add failed: {:?}", result.unwrap_err());
         assert_eq!(result.unwrap().exit_code.raw(), 55);
+    }
+
+    // ── TBool calling convention validation (CX-127, Phase 8 Round 2) ─────────
+    //
+    // These tests verify the TBool calling convention at the JIT level:
+    // - TBool function parameters are accepted by Cranelift (TBool maps to I8)
+    // - All three TBool values (0 = false, 1 = true, 2 = unknown) round-trip
+    //   through a function call without corruption
+    // - Cast TBool → I32 uses zero-extension (uextend), preserving 0/1/2
+    //
+    // Each test materialises a TBool value via Alloca+Store+Load (because
+    // ConstInt rejects IrType::TBool — the validator limits ConstInt to integer
+    // and Bool types), then passes it to a helper that casts TBool → I32 and
+    // returns it, using the I32 value as the process exit code.
+    //
+    // Helper shape for all three tests:
+    //   pass_tbool_as_i32(t: TBool) -> I32:
+    //     B0(v0: TBool): v1 = Cast(TBool → I32, v0); return v1
+    //   main() -> I32:
+    //     B0: v10=ConstInt(I8,<n>); v11=Alloca(1,1); Store(v11,v10);
+    //         v12=Load(TBool,v11); v13=Call(pass_tbool_as_i32,[v12])->I32; return v13
+
+    fn tbool_param_module(raw_value: i128) -> IrModule {
+        IrModule {
+            debug_name: format!("tbool_param_{}", raw_value),
+            functions: vec![
+                IrFunction {
+                    name: "pass_tbool_as_i32".to_string(),
+                    params: vec![IrParam { name: "t".to_string(), ty: IrType::TBool }],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![BlockParam {
+                            value: ValueId(0),
+                            ty: IrType::TBool,
+                            read_only: true,
+                        }],
+                        insts: vec![IrInst::Cast {
+                            dst: ValueId(1),
+                            from: IrType::TBool,
+                            to: IrType::I32,
+                            value: ValueId(0),
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(1)) },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstInt { dst: ValueId(10), ty: IrType::I8, value: raw_value },
+                            IrInst::Alloca { dst: ValueId(11), size: 1, align: 1 },
+                            IrInst::Store { ptr: ValueId(11), value: ValueId(10) },
+                            IrInst::Load { dst: ValueId(12), ty: IrType::TBool, ptr: ValueId(11) },
+                            IrInst::Call {
+                                dst: Some(ValueId(13)),
+                                callee: "pass_tbool_as_i32".to_string(),
+                                args: vec![ValueId(12)],
+                                return_ty: Some(IrType::I32),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(13)) },
+                    }],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn jit_tbool_param_false_passes_correctly() {
+        // TBool value 0 (false) survives the call boundary and returns as I32(0).
+        let module = tbool_param_module(0);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 0);
+    }
+
+    #[test]
+    fn jit_tbool_param_true_passes_correctly() {
+        // TBool value 1 (true) survives the call boundary and returns as I32(1).
+        let module = tbool_param_module(1);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 1);
+    }
+
+    #[test]
+    fn jit_tbool_param_unknown_passes_correctly() {
+        // TBool value 2 (unknown) survives the call boundary and returns as I32(2).
+        // This is the critical case: "unknown" is the third state that has no Bool
+        // equivalent, so it exercises the 0/1/2 wire format explicitly.
+        let module = tbool_param_module(2);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 2);
     }
 }
 


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-130

## Summary

Applies the actionable CodeRabbit fix from the CX-127 TBool ABI PR review: the top-of-file roadmap version header was out of sync with the v4.3 changelog section added in CX-127.

## Changes

**`docs/backend/cx_backend_roadmap_v3_1.md`**
- Line 2 bumped from `v4.2 — 2026-05-10` to `v4.3 — 2026-05-11`
- The header now matches the `## Key Changes — v4.3 (2026-05-11)` section, giving the document a single canonical version/date

This branch is based on `stokowski/CX-127` and includes CX-127's TBool calling convention commit (`71bd420`) so the full change set lands in submain together.

## Tests Run

```
cargo build --features jit
cargo test --features jit
```

## Validation Results

```
test result: ok. 316 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Known Limitations

None — the C-ABI interop test suggestion from CodeRabbit was a nitpick and is outside the scope of this fix ticket.

## Linear Ticket Reference

CX-130 — Apply CodeRabbit roadmap version fix on CX-127 TBool ABI PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * TBool specification finalized and locked to v0.1 with calling convention and runtime behavior details.
  * Backend roadmap updated to v4.3 reflecting the TBool specification lock.

* **Tests**
  * Added test coverage validating TBool parameter passing and round-trip correctness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/174)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->