### PR TITLE
CX-131: Reconcile stale parity fixture PRs — add t152–t166

### DIFF
--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -186,6 +186,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         "t25_loop_break"
         | "t106_loop_break_in_func"
         | "t134_loop_break_exit"
+        | "t164_infinite_loop_counter_exit"
+        | "t165_infinite_loop_countdown_exit"
             => FeatureCategory::InfiniteLoop,
 
         // ── DirectCall ────────────────────────────────────────────────────────
@@ -200,6 +202,12 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t29_forward_decl"
         | "t50_nested_func_no_leak"
         | "t113_recursive_fib"
+        | "t152_direct_call_implicit_return_exit"
+        | "t153_direct_call_explicit_return_exit"
+        | "t154_direct_call_no_args_exit"
+        | "t155_direct_call_chained_exit"
+        | "t156_direct_call_forward_decl_exit"
+        | "t157_direct_call_recursive_exit"
             => FeatureCategory::DirectCall,
 
         // ── Struct ────────────────────────────────────────────────────────────
@@ -229,15 +237,20 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t41_compound_assign_dot"
         | "t128_struct_compound_assign_exit"
         | "t151_var_compound_assign_exit"
+        | "t166_compound_assign_func_exit"
             => FeatureCategory::CompoundAssign,
 
         // ── Unary ─────────────────────────────────────────────────────────────
         "t96_overflow_t8_unary_neg"
+        | "t158_unary_neg_int_exit"
+        | "t159_unary_not_bool_exit"
             => FeatureCategory::Unary,
 
         // ── Cast ─────────────────────────────────────────────────────────────
         "t139_cast_t32_to_f64_exit"
         | "t140_cast_f64_truncate_exit"
+        | "t162_cast_neg_t32_to_f64_exit"
+        | "t163_cast_t64_to_f64_exit"
             => FeatureCategory::Cast,
 
         // ── FloatOps ──────────────────────────────────────────────────────────
@@ -246,6 +259,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t136_float_arith_sub_exit"
         | "t137_float_arith_mul_exit"
         | "t138_float_arith_div_exit"
+        | "t160_float_arith_mod_exit"
+        | "t161_float_neg_exit"
             => FeatureCategory::FloatOps,
 
         // ── BuiltinAssert ─────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t152_direct_call_implicit_return_exit.cx
+++ b/src/tests/verification_matrix/t152_direct_call_implicit_return_exit.cx
@@ -1,0 +1,8 @@
+// CX-131: exit-code-based JIT parity — function with implicit return.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 add(a: t64, b: t64) {
+    a + b
+}
+assert_eq(add(1, 2), 3)
+assert_eq(add(10, 20), 30)
+assert_eq(add(0, 0), 0)

--- a/src/tests/verification_matrix/t153_direct_call_explicit_return_exit.cx
+++ b/src/tests/verification_matrix/t153_direct_call_explicit_return_exit.cx
@@ -1,0 +1,8 @@
+// CX-131: exit-code-based JIT parity — function with explicit return.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 pick_first(a: t64, b: t64) {
+    return a;
+    b
+}
+assert_eq(pick_first(10, 20), 10)
+assert_eq(pick_first(99, 1), 99)

--- a/src/tests/verification_matrix/t154_direct_call_no_args_exit.cx
+++ b/src/tests/verification_matrix/t154_direct_call_no_args_exit.cx
@@ -1,0 +1,6 @@
+// CX-131: exit-code-based JIT parity — zero-argument function call.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 answer() {
+    42
+}
+assert_eq(answer(), 42)

--- a/src/tests/verification_matrix/t155_direct_call_chained_exit.cx
+++ b/src/tests/verification_matrix/t155_direct_call_chained_exit.cx
@@ -1,0 +1,10 @@
+// CX-131: exit-code-based JIT parity — function calling another function (chained calls).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 square(x: t64) {
+    x * x
+}
+fnc: t64 sum_of_squares(a: t64, b: t64) {
+    square(a) + square(b)
+}
+assert_eq(sum_of_squares(3, 4), 25)
+assert_eq(sum_of_squares(1, 1), 2)

--- a/src/tests/verification_matrix/t156_direct_call_forward_decl_exit.cx
+++ b/src/tests/verification_matrix/t156_direct_call_forward_decl_exit.cx
@@ -1,0 +1,8 @@
+// CX-131: exit-code-based JIT parity — forward declaration (call before definition).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+assert_eq(double(5), 10)
+assert_eq(double(0), 0)
+
+fnc: t64 double(x: t64) {
+    x * 2
+}

--- a/src/tests/verification_matrix/t157_direct_call_recursive_exit.cx
+++ b/src/tests/verification_matrix/t157_direct_call_recursive_exit.cx
@@ -1,0 +1,11 @@
+// CX-131: exit-code-based JIT parity — recursive function call (factorial).
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 fact(n: t64) {
+    if n < 2 {
+        return 1
+    }
+    return n * fact(n - 1)
+}
+assert_eq(fact(1), 1)
+assert_eq(fact(5), 120)
+assert_eq(fact(10), 3628800)

--- a/src/tests/verification_matrix/t158_unary_neg_int_exit.cx
+++ b/src/tests/verification_matrix/t158_unary_neg_int_exit.cx
@@ -1,0 +1,11 @@
+// CX-131: exit-code-based JIT parity — unary arithmetic negation on integers.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+x: t64 = 5
+assert_eq(-x + x, 0)
+
+y: t64 = 100
+neg_y: t64 = -y
+assert_eq(neg_y + y, 0)
+
+z: t64 = 0
+assert_eq(-z, 0)

--- a/src/tests/verification_matrix/t159_unary_not_bool_exit.cx
+++ b/src/tests/verification_matrix/t159_unary_not_bool_exit.cx
@@ -1,0 +1,12 @@
+// CX-131: exit-code-based JIT parity — unary boolean NOT operator.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+t: bool = true
+f: bool = false
+assert_eq(!t, false)
+assert_eq(!f, true)
+
+b: bool = !t
+assert_eq(b, false)
+
+c: bool = !f
+assert_eq(c, true)

--- a/src/tests/verification_matrix/t160_float_arith_mod_exit.cx
+++ b/src/tests/verification_matrix/t160_float_arith_mod_exit.cx
@@ -1,0 +1,13 @@
+// CX-131: exit-code-based JIT parity — f64 modulo (remainder).
+// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+a: f64 = 10.0
+b: f64 = 3.0
+rem: f64 = a % b
+n: t32 = rem
+assert_eq(n, 1)
+
+x: f64 = 7.5
+y: f64 = 2.5
+rem2: f64 = x % y
+m: t32 = rem2
+assert_eq(m, 0)

--- a/src/tests/verification_matrix/t160_float_arith_mod_exit.cx
+++ b/src/tests/verification_matrix/t160_float_arith_mod_exit.cx
@@ -1,13 +1,17 @@
 // CX-131: exit-code-based JIT parity — f64 modulo (remainder).
-// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+// Scaled exact check: multiply remainder by 10 before casting to t32.
+// This catches backend drift hidden by direct truncation (e.g. 1.9 → 1).
 a: f64 = 10.0
 b: f64 = 3.0
 rem: f64 = a % b
-n: t32 = rem
-assert_eq(n, 1)
+scale: f64 = 10.0
+product: f64 = rem * scale
+n: t32 = product
+assert_eq(n, 10)
 
-x: f64 = 7.5
-y: f64 = 2.5
+x: f64 = 5.5
+y: f64 = 2.0
 rem2: f64 = x % y
-m: t32 = rem2
-assert_eq(m, 0)
+product2: f64 = rem2 * scale
+m: t32 = product2
+assert_eq(m, 15)

--- a/src/tests/verification_matrix/t161_float_neg_exit.cx
+++ b/src/tests/verification_matrix/t161_float_neg_exit.cx
@@ -1,0 +1,12 @@
+// CX-131: exit-code-based JIT parity — unary f64 negation.
+// Negation lowers to ConstFloat(0.0) + Binary(Sub, F64).
+// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+a: f64 = 5.0
+neg: f64 = -a
+n: t32 = neg
+assert_eq(n, -5)
+
+b: f64 = 3.0
+neg2: f64 = -b
+m: t32 = neg2
+assert_eq(m, -3)

--- a/src/tests/verification_matrix/t162_cast_neg_t32_to_f64_exit.cx
+++ b/src/tests/verification_matrix/t162_cast_neg_t32_to_f64_exit.cx
@@ -1,0 +1,11 @@
+// CX-131: exit-code-based JIT parity — negative t32->f64 widening cast.
+// Verifies that sign is preserved when a negative t32 widens to f64.
+a: t32 = -42
+b: f64 = a
+c: t32 = b
+assert_eq(c, -42)
+
+x: t32 = -100
+y: f64 = x
+z: t32 = y
+assert_eq(z, -100)

--- a/src/tests/verification_matrix/t163_cast_t64_to_f64_exit.cx
+++ b/src/tests/verification_matrix/t163_cast_t64_to_f64_exit.cx
@@ -1,0 +1,11 @@
+// CX-131: exit-code-based JIT parity — t64->f64 widening cast.
+// Exercises the I64->F64 conversion path (fcvt_from_sint on a 64-bit value).
+a: t64 = 42
+b: f64 = a
+c: t32 = b
+assert_eq(c, 42)
+
+x: t64 = -100
+y: f64 = x
+z: t32 = y
+assert_eq(z, -100)

--- a/src/tests/verification_matrix/t164_infinite_loop_counter_exit.cx
+++ b/src/tests/verification_matrix/t164_infinite_loop_counter_exit.cx
@@ -1,0 +1,12 @@
+// CX-131: exit-code-based JIT parity — InfiniteLoop file-scope accumulator.
+// Verifies the back-edge jump fires correctly across multiple iterations at file scope.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+sum: t64 = 0
+i: t64 = 1
+loop {
+    if i > 5 { break }
+    sum = sum + i
+    i = i + 1
+}
+assert_eq(sum, 15)
+assert_eq(i, 6)

--- a/src/tests/verification_matrix/t165_infinite_loop_countdown_exit.cx
+++ b/src/tests/verification_matrix/t165_infinite_loop_countdown_exit.cx
@@ -1,0 +1,17 @@
+// CX-131: exit-code-based JIT parity — InfiniteLoop inside a function (countdown).
+// Complements t134 (loop+break in a function) with a different accumulation pattern.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 sum_down(n: t64) {
+    i: t64 = n
+    result: t64 = 0
+    loop {
+        if i == 0 { break }
+        result = result + i
+        i = i - 1
+    }
+    return result
+}
+
+assert_eq(sum_down(4), 10)
+assert_eq(sum_down(1), 1)
+assert_eq(sum_down(0), 0)

--- a/src/tests/verification_matrix/t166_compound_assign_func_exit.cx
+++ b/src/tests/verification_matrix/t166_compound_assign_func_exit.cx
@@ -1,0 +1,12 @@
+// CX-131: exit-code-based JIT parity — compound assign operators inside a function.
+// Verifies that compound assign lowering works on function-local variables.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+fnc: t64 apply_ops(v: t64) {
+    v += 10
+    v -= 3
+    v *= 2
+    return v
+}
+
+assert_eq(apply_ops(5), 24)
+assert_eq(apply_ops(0), 14)


### PR DESCRIPTION
Closes CX-131

## Summary

Extracts the genuinely new fixture content from six stale open PRs (CX-114 through CX-118, CX-120) that had gone CONFLICTING after ArrayAlloca (CX-121) and ForLoop (CX-124/CX-125) landed on submain with renumbered test slots.

Adds 15 new exit-code-verified JIT parity fixtures renumbered to follow the current submain sequence (t152–t166):

| Range | Category | Source PR |
|-------|----------|-----------|
| t152–t157 | DirectCall (implicit return, explicit return, no-args, chained, forward-decl, recursive) | CX-115 |
| t158–t159 | Unary (int neg, bool NOT) | CX-116 |
| t160–t161 | FloatOps (f64 mod, f64 neg) | CX-117 |
| t162–t163 | Cast (neg t32→f64, t64→f64) | CX-117 |
| t164–t165 | InfiniteLoop (file-scope counter, in-func countdown) | CX-118 |
| t166 | CompoundAssign (in-function variant) | CX-118 |

**Stale PRs with no net-new content (safe to close):**
- PR #157 (CX-114): array fixtures already in submain as t146–t148
- PR #163 (CX-120): for-loop fixtures already as t149–t150; unary covered by t158; array covered by t146–t148
- CX-118's `t145_compound_assign_vars_exit` omitted — functionally identical to the already-landed `t151_var_compound_assign_exit`

**Stale PRs superseded by this PR (safe to close):**
- PR #158 (CX-115), PR #159 (CX-116), PR #160 (CX-117), PR #161 (CX-118)

## Files changed

- `src/tests/verification_matrix/t152_direct_call_implicit_return_exit.cx` — new
- `src/tests/verification_matrix/t153_direct_call_explicit_return_exit.cx` — new
- `src/tests/verification_matrix/t154_direct_call_no_args_exit.cx` — new
- `src/tests/verification_matrix/t155_direct_call_chained_exit.cx` — new
- `src/tests/verification_matrix/t156_direct_call_forward_decl_exit.cx` — new
- `src/tests/verification_matrix/t157_direct_call_recursive_exit.cx` — new
- `src/tests/verification_matrix/t158_unary_neg_int_exit.cx` — new
- `src/tests/verification_matrix/t159_unary_not_bool_exit.cx` — new
- `src/tests/verification_matrix/t160_float_arith_mod_exit.cx` — new
- `src/tests/verification_matrix/t161_float_neg_exit.cx` — new
- `src/tests/verification_matrix/t162_cast_neg_t32_to_f64_exit.cx` — new
- `src/tests/verification_matrix/t163_cast_t64_to_f64_exit.cx` — new
- `src/tests/verification_matrix/t164_infinite_loop_counter_exit.cx` — new
- `src/tests/verification_matrix/t165_infinite_loop_countdown_exit.cx` — new
- `src/tests/verification_matrix/t166_compound_assign_func_exit.cx` — new
- `src/diff_harness.rs` — updated `feature_of()` to register all 15 new fixture names

## Validation

```
cargo build --features jit   → Finished (warnings only, no errors)
cargo test --features jit    → 317 passed; 0 failed
```

Linear: CX-131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added 16 verification tests covering direct/forward/chained/recursive calls, implicit/explicit/no-arg returns, unary ops, boolean/float arithmetic and modulo, casts between integer/float widths, infinite-loop patterns, and compound-assignment behavior (all validated via exit-code assertions).

* **Chores**
  * Improved test-harness classification to recognize additional fixture categories for more accurate test grouping.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/175)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->