### PR TITLE
CX-133: Add differential harness PARITY_FAIL gate to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,30 @@ jobs:
       - name: Run tests (with jit feature)
         run: cargo test --features jit
 
+  parity-gate:
+    name: Differential Harness — PARITY_FAIL Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-jit-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build (with jit feature)
+        run: cargo build --features jit
+
+      - name: Differential harness — PARITY_FAIL gate
+        run: cargo test --features jit jit_parity_by_feature -- --nocapture
+
   stale-base:
     name: Stale Base Check
     runs-on: ubuntu-latest

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-05-10
+Last updated: 2026-05-12
 
 This file is a concise synthesis of the project's roadmap state. Detailed roadmaps live at:
 - Frontend: `docs/frontend/ROADMAP.md` (v5.0)
@@ -79,7 +79,7 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
   - [x] 120 fixtures, 0 PARITY_FAILs
   - [x] Determinism tests (CX-55)
   - [ ] Full construct set coverage expansion (CX-34 on feature branch)
-  - [ ] CI gate on every PR
+  - [x] CI gate on every PR (CX-133)
 - [ ] Phase 15 — Cranelift JIT 0.1 target
   - [x] No-panic guarantee on valid IR (CX-50)
   - [x] Float comparison + ConstFloat (CX-52)
@@ -91,7 +91,7 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
   - [ ] Cast instruction JIT coverage (CX-91 on feature branch)
   - [ ] DotAccess JIT parity fixtures (CX-94 on feature branch)
   - [ ] Full parity fixture coverage (CX-34 on feature branch)
-  - [ ] Differential harness in CI
+  - [x] Differential harness in CI (CX-133)
 
 ### Post-0.1
 - [ ] Cranelift AOT (Phase 16)


### PR DESCRIPTION
Closes CX-133

## Summary

Adds a dedicated `parity-gate` CI job to `.github/workflows/ci.yml` that runs the `jit_parity_by_feature` test with `--nocapture`, making the per-feature PASS/SKIP/PARITY_FAIL table visible in every PR check run. Previously the parity test ran as part of the generic `cargo test --features jit` step and its output was suppressed.

## Changes

- `.github/workflows/ci.yml` — New `parity-gate` job with explicit `cargo test --features jit jit_parity_by_feature -- --nocapture` step; named separately so it can be required as a branch protection check
- `docment/ROADMAP.md` — Checked off Phase 12 "CI gate on every PR (CX-133)" and Phase 15 "Differential harness in CI (CX-133)"; updated `Last updated` date

## Why a separate job

A separate named job appears in the GitHub Actions PR status panel as an independent check and can be required in branch protection rules. A step buried inside the `backend` job cannot be independently required. The cargo cache key is shared, so the rebuild is fast (cache hit on `target/`).

## Validation

```
cargo build --features jit   → Finished `dev` profile in ~1m49s (0 errors)
cargo test --features jit    → test result: ok. 317 passed; 0 failed; 0 ignored
  incl. diff_harness::tests::jit_parity_by_feature ... ok
```

## Linear ticket

CX-133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing infrastructure with an additional verification check to ensure code quality and consistency.

* **Documentation**
  * Updated project roadmap to reflect completed development milestones.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/176)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->