### PR TITLE
CX-134: Add automatic IR dump to differential harness PARITY_FAIL output

### DIFF
--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -508,6 +508,60 @@ pub fn run_jit_subprocess(binary: &Path, fixture: &TestFixture) -> InterpOutcome
     }
 }
 
+/// Print a diagnostic for a single PARITY_FAIL and attempt to dump the IR.
+///
+/// Invokes the Cx binary with `--backend=validate` to obtain a textual IR dump
+/// without executing the program.  The dump is written to stderr so it appears
+/// inline with `cargo test --nocapture` output.
+#[cfg(feature = "jit")]
+fn emit_parity_fail_diagnostic(
+    binary: &Path,
+    fixture: &TestFixture,
+    outcome: &InterpOutcome,
+) {
+    eprintln!("PARITY_FAIL: {}", fixture.name);
+    eprintln!("  expected : {:?}", fixture.expectation);
+    eprintln!("  exit_code: {}", outcome.exit_code);
+    if !outcome.stdout.is_empty() {
+        eprintln!("  stdout   : {:?}", normalise(&outcome.stdout));
+    }
+    if !outcome.stderr.is_empty() {
+        let first = outcome.stderr.lines().next().unwrap_or("").trim();
+        if !first.is_empty() {
+            eprintln!("  stderr   : {}", first);
+        }
+    }
+
+    match Command::new(binary)
+        .arg("--backend=validate")
+        .arg(&fixture.path)
+        .env("NO_COLOR", "1")
+        .output()
+    {
+        Ok(out) => {
+            // validate prints IR to stdout on success, stderr on validation error
+            let ir_text = if !out.stdout.is_empty() {
+                String::from_utf8_lossy(&out.stdout).into_owned()
+            } else {
+                String::from_utf8_lossy(&out.stderr).into_owned()
+            };
+            if !ir_text.trim().is_empty() {
+                eprintln!("--- IR dump: {} ---", fixture.name);
+                eprint!("{}", ir_text);
+                if !ir_text.ends_with('\n') {
+                    eprintln!();
+                }
+                eprintln!("--- end IR dump ---");
+            } else {
+                eprintln!("  (IR dump unavailable)");
+            }
+        }
+        Err(e) => {
+            eprintln!("  (IR dump failed: {})", e);
+        }
+    }
+}
+
 /// Run all matrix fixtures through the Cranelift JIT subprocess and aggregate
 /// results by [`FeatureCategory`].
 ///
@@ -562,6 +616,7 @@ pub fn parity_by_feature(
             };
             if is_parity_fail {
                 entry.2 += 1; // PARITY_FAIL
+                emit_parity_fail_diagnostic(binary, fixture, &outcome);
             } else {
                 entry.0 += 1; // pass
             }


### PR DESCRIPTION
Closes CX-134

## Summary

- Added `emit_parity_fail_diagnostic()` to `src/diff_harness.rs`
- When `parity_by_feature()` detects a PARITY_FAIL, the new function automatically prints:
  - Fixture name and feature category
  - Expected outcome vs actual exit code, stdout, stderr (first line)
  - Full IR dump via a second subprocess invocation with `--backend=validate`
- IR dump uses the existing `--backend=validate` backend path (already in `main.rs`) — no changes to the binary itself were required

## Files Changed

- `src/diff_harness.rs` — added `emit_parity_fail_diagnostic()` helper (54 lines) and one call-site in `parity_by_feature()`

## Implementation Notes

The `--backend=validate` flag already causes the Cx binary to lower the source to IR, print it to stdout via `ir::printer::print_module()`, and exit without running the program. This makes it a zero-risk IR retrieval mechanism for diagnostic purposes. The new function invokes it as a subprocess on the failing fixture and captures stdout (or stderr on validation error) for display.

The diagnostic function is `#[cfg(feature = "jit")]` gated, matching the guard on `parity_by_feature()`.

## Validation

```
cargo build --features jit   → Finished dev (0 warnings introduced, 20 pre-existing)
cargo test --features jit    → test result: ok. 317 passed; 0 failed; 0 ignored
```

## Linear Ticket

CX-134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved diagnostic output when test fixtures fail, including detailed metadata comparison of expected vs. actual results (exit codes, output, error messages) and on-demand intermediate representation inspection for enhanced troubleshooting of parity issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/177)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->