### PR TITLE
CX-138: Document expression evaluation order guarantee in cx_abi_v0.1.md and add JIT test

### DIFF
--- a/docs/backend/cx_abi_v0.1.md
+++ b/docs/backend/cx_abi_v0.1.md
@@ -117,6 +117,18 @@ Dynamic arrays (push/pop, runtime-sized) are post-0.1 stdlib work. When those la
 
 Layout computation implemented in `src/ir/types.rs` as `compute_array_layout`. Confidence tests cover i64, i8, bool, i128, and zero-length arrays.
 
+### Expression Evaluation Order — LOCKED (0.1)
+
+All Cx expressions are evaluated strictly left-to-right. Authoritative specification: `docs/backend/cx_eval_order.md`.
+
+ABI impact: the IR instruction stream produced by `lower_binary` and the call argument-lowering loop encodes evaluation order structurally. Instructions for the left operand are emitted before instructions for the right operand within the same basic block. All backends must preserve this instruction order — no reordering of side-effecting instructions across operand boundaries is permitted.
+
+Covered expression forms: binary arithmetic (`+`, `-`, `*`, `/`, `%`), comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`), and function call argument lists. Short-circuit operators (`&&`, `||`) and `when` expressions are post-0.1.
+
+JIT conformance tests in `src/backend/cranelift/host_boundary.rs` (`jit_eval_order_*`) verify that `IrInst::Binary { lhs, rhs }` and `IrInst::Compare { lhs, rhs }` map `lhs` as the left operand and `rhs` as the right operand in emitted Cranelift instructions.
+
+---
+
 ### Enum Layout — LOCKED (tag-only)
 
 Tag-only enums at 0.1. No data-carrying variants.

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -2904,6 +2904,128 @@ mod jit_tests {
         assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
         assert_eq!(result.unwrap().exit_code.raw(), 2);
     }
+
+    // ── Expression evaluation order (CX-138) ────────────────────────────────
+    //
+    // These tests verify that IrInst::Binary and IrInst::Compare map `lhs` as
+    // the left operand and `rhs` as the right operand in emitted Cranelift
+    // instructions.  Subtraction and greater-than comparison are non-commutative,
+    // so swapping operands yields a detectably wrong result without needing print
+    // side-effects.
+
+    #[test]
+    fn jit_eval_order_sub_lhs_before_rhs() {
+        // Binary{Sub, lhs=20, rhs=8} must yield 20-8=12, not 8-20=-12.
+        // A backend that swaps lhs/rhs would return -12.
+        let module = IrModule {
+            debug_name: "test_eval_order_sub".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 20 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 8 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Sub,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 12); // 20 - 8
+    }
+
+    #[test]
+    fn jit_eval_order_nested_sub_is_left_associative() {
+        // (10 - 3) - 2 = 5.  A backend that inverts associativity would compute
+        // 10 - (3 - 2) = 9.  The two Binary instructions encode left-associativity
+        // by making lhs of the outer op the result of the inner op.
+        let module = IrModule {
+            debug_name: "test_eval_order_nested_sub".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 10 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 3 },
+                        IrInst::ConstInt { dst: ValueId(2), ty: IrType::I32, value: 2 },
+                        IrInst::Binary {
+                            dst: ValueId(3),
+                            op: BinaryOp::Sub,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Binary {
+                            dst: ValueId(4),
+                            op: BinaryOp::Sub,
+                            ty: IrType::I32,
+                            lhs: ValueId(3),
+                            rhs: ValueId(2),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(4)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 5); // (10-3)-2
+    }
+
+    #[test]
+    fn jit_eval_order_compare_gt_lhs_is_left_operand() {
+        // Compare{Gt, lhs=10, rhs=3} must yield 1 (10 > 3 = true).
+        // A backend that swaps lhs/rhs would compute 3 > 10 = false → 0.
+        use crate::ir::instr::CompareOp;
+        let module = IrModule {
+            debug_name: "test_eval_order_compare_gt".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 10 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 3 },
+                        IrInst::Compare {
+                            dst: ValueId(2),
+                            op: CompareOp::Gt,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Cast {
+                            dst: ValueId(3),
+                            from: IrType::I8,
+                            to: IrType::I32,
+                            value: ValueId(2),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 1); // 10 > 3 = true
+    }
 }
 
 // ── JIT determinism tests (require the `jit` feature) ────────────────────────


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-138

## Summary

- Added **Expression Evaluation Order — LOCKED (0.1)** section to `docs/backend/cx_abi_v0.1.md` — cross-references `cx_eval_order.md` (the authoritative spec) and documents the ABI-level guarantee: lhs instructions are emitted before rhs instructions in the same basic block, and all backends must preserve this order.
- Added three JIT unit tests (`jit_eval_order_*`) to `src/backend/cranelift/host_boundary.rs` that verify `IrInst::Binary` and `IrInst::Compare` map `lhs`/`rhs` to left/right operands in emitted Cranelift instructions.

## Why non-commutative operations for JIT tests

The high-level evaluation order fixtures (t114–t116) use `print` side effects to observe ordering, but `print` is not yet JIT-lowerable. The JIT unit tests instead use subtraction (`A - B` ≠ `B - A`) and greater-than comparison (`A > B` ≠ `B > A`) — a backend that swaps operands produces a detectably wrong result with no side effects needed.

## Files changed

| File | Change |
|------|--------|
| `docs/backend/cx_abi_v0.1.md` | New section: Expression Evaluation Order — LOCKED (0.1) |
| `src/backend/cranelift/host_boundary.rs` | 3 new JIT tests: `jit_eval_order_sub_lhs_before_rhs`, `jit_eval_order_nested_sub_is_left_associative`, `jit_eval_order_compare_gt_lhs_is_left_operand` |

## Tests run

```
cargo build --features jit   → ok (20 pre-existing warnings, 0 errors)
cargo test --features jit    → 320 passed; 0 failed
```

New tests individually:
```
test jit_tests::jit_eval_order_sub_lhs_before_rhs ... ok
test jit_tests::jit_eval_order_nested_sub_is_left_associative ... ok
test jit_tests::jit_eval_order_compare_gt_lhs_is_left_operand ... ok
```

## Known limitations

None. The documentation change is complete. The JIT tests cover the available observable surface — full side-effect ordering (matching t114–t116) is deferred until `print` is JIT-lowerable.

## Linear ticket

CX-138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification detailing expression evaluation order requirements, ensuring left-to-right evaluation across binary operations, comparisons, and function call arguments.

* **Tests**
  * Added JIT integration tests validating correct operand evaluation order for binary arithmetic operations and comparisons, with coverage for simple and nested cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/181)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->