### PR TITLE
CX-139: Apply CodeRabbit fixes on CX-134 parity-fail IR dump diagnostics PR

### DIFF
--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -508,6 +508,60 @@ pub fn run_jit_subprocess(binary: &Path, fixture: &TestFixture) -> InterpOutcome
     }
 }
 
+/// Print a diagnostic for a single PARITY_FAIL and attempt to dump the IR.
+///
+/// Invokes the Cx binary with `--backend=validate` to obtain a textual IR dump
+/// without executing the program.  The dump is written to stderr so it appears
+/// inline with `cargo test --nocapture` output.
+#[cfg(feature = "jit")]
+fn emit_parity_fail_diagnostic(
+    binary: &Path,
+    fixture: &TestFixture,
+    outcome: &InterpOutcome,
+) {
+    eprintln!("PARITY_FAIL: {}", fixture.name);
+    eprintln!("  expected : {:?}", fixture.expectation);
+    eprintln!("  exit_code: {}", outcome.exit_code);
+    if !outcome.stdout.is_empty() {
+        eprintln!("  stdout   : {:?}", normalise(&outcome.stdout));
+    }
+    if !outcome.stderr.is_empty() {
+        let first = outcome.stderr.lines().next().unwrap_or("").trim();
+        if !first.is_empty() {
+            eprintln!("  stderr   : {}", first);
+        }
+    }
+
+    match Command::new(binary)
+        .arg("--backend=validate")
+        .arg(&fixture.path)
+        .env("NO_COLOR", "1")
+        .output()
+    {
+        Ok(out) => {
+            // validate prints IR to stdout on success, stderr on validation error
+            let ir_text = if !out.stdout.is_empty() {
+                String::from_utf8_lossy(&out.stdout).into_owned()
+            } else {
+                String::from_utf8_lossy(&out.stderr).into_owned()
+            };
+            if !ir_text.trim().is_empty() {
+                eprintln!("--- IR dump: {} ---", fixture.name);
+                eprint!("{}", ir_text);
+                if !ir_text.ends_with('\n') {
+                    eprintln!();
+                }
+                eprintln!("--- end IR dump ---");
+            } else {
+                eprintln!("  (IR dump unavailable)");
+            }
+        }
+        Err(e) => {
+            eprintln!("  (IR dump failed: {})", e);
+        }
+    }
+}
+
 /// Run all matrix fixtures through the Cranelift JIT subprocess and aggregate
 /// results by [`FeatureCategory`].
 ///
@@ -562,6 +616,7 @@ pub fn parity_by_feature(
             };
             if is_parity_fail {
                 entry.2 += 1; // PARITY_FAIL
+                emit_parity_fail_diagnostic(binary, fixture, &outcome);
             } else {
                 entry.0 += 1; // pass
             }

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -517,9 +517,10 @@ pub fn run_jit_subprocess(binary: &Path, fixture: &TestFixture) -> InterpOutcome
 fn emit_parity_fail_diagnostic(
     binary: &Path,
     fixture: &TestFixture,
+    category: FeatureCategory,
     outcome: &InterpOutcome,
 ) {
-    eprintln!("PARITY_FAIL: {}", fixture.name);
+    eprintln!("PARITY_FAIL: {} [{}]", fixture.name, category);
     eprintln!("  expected : {:?}", fixture.expectation);
     eprintln!("  exit_code: {}", outcome.exit_code);
     if !outcome.stdout.is_empty() {
@@ -532,33 +533,60 @@ fn emit_parity_fail_diagnostic(
         }
     }
 
-    match Command::new(binary)
+    use std::io::Read;
+    use wait_timeout::ChildExt;
+
+    let mut child = match Command::new(binary)
         .arg("--backend=validate")
         .arg(&fixture.path)
         .env("NO_COLOR", "1")
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
     {
-        Ok(out) => {
+        Ok(child) => child,
+        Err(e) => {
+            eprintln!("  (IR dump failed: {})", e);
+            return;
+        }
+    };
+
+    let mut stdout_pipe = child.stdout.take().expect("stdout is piped");
+    let mut stderr_pipe = child.stderr.take().expect("stderr is piped");
+
+    let ir_text = match child.wait_timeout(JIT_TIMEOUT) {
+        Ok(Some(_status)) => {
+            let mut stdout_bytes = Vec::new();
+            let mut stderr_bytes = Vec::new();
+            let _ = stdout_pipe.read_to_end(&mut stdout_bytes);
+            let _ = stderr_pipe.read_to_end(&mut stderr_bytes);
             // validate prints IR to stdout on success, stderr on validation error
-            let ir_text = if !out.stdout.is_empty() {
-                String::from_utf8_lossy(&out.stdout).into_owned()
+            if !stdout_bytes.is_empty() {
+                String::from_utf8_lossy(&stdout_bytes).into_owned()
             } else {
-                String::from_utf8_lossy(&out.stderr).into_owned()
-            };
-            if !ir_text.trim().is_empty() {
-                eprintln!("--- IR dump: {} ---", fixture.name);
-                eprint!("{}", ir_text);
-                if !ir_text.ends_with('\n') {
-                    eprintln!();
-                }
-                eprintln!("--- end IR dump ---");
-            } else {
-                eprintln!("  (IR dump unavailable)");
+                String::from_utf8_lossy(&stderr_bytes).into_owned()
             }
+        }
+        Ok(None) => {
+            let _ = child.kill();
+            eprintln!("  (IR dump timed out after {}s)", JIT_TIMEOUT.as_secs());
+            return;
         }
         Err(e) => {
             eprintln!("  (IR dump failed: {})", e);
+            return;
         }
+    };
+
+    if !ir_text.trim().is_empty() {
+        eprintln!("--- IR dump: {} ---", fixture.name);
+        eprint!("{}", ir_text);
+        if !ir_text.ends_with('\n') {
+            eprintln!();
+        }
+        eprintln!("--- end IR dump ---");
+    } else {
+        eprintln!("  (IR dump unavailable)");
     }
 }
 
@@ -616,7 +644,7 @@ pub fn parity_by_feature(
             };
             if is_parity_fail {
                 entry.2 += 1; // PARITY_FAIL
-                emit_parity_fail_diagnostic(binary, fixture, &outcome);
+                emit_parity_fail_diagnostic(binary, fixture, cat, &outcome);
             } else {
                 entry.0 += 1; // pass
             }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-139/cx-138-apply-coderabbit-fixes-on-cx-134-parity-fail-ir-dump

Applies two CodeRabbit-requested fixes to `emit_parity_fail_diagnostic` introduced in CX-134.

## Changes

**File changed:** `src/diff_harness.rs`

### Fix 1 — Include feature category in PARITY_FAIL header (line ~517-523)

Added `category: FeatureCategory` parameter and updated the header eprintln from:
```
PARITY_FAIL: <fixture>
```
to:
```
PARITY_FAIL: <fixture> [<Category>]
```
Updated the single call site in `parity_by_feature` to pass `cat`.

### Fix 2 — Add timeout to `--backend=validate` subprocess (line ~535-562)

Replaced blocking `.output()` with spawn + `wait_timeout(JIT_TIMEOUT)`:
- Spawns child with `stdout(Stdio::piped())` and `stderr(Stdio::piped())`
- Waits up to `JIT_TIMEOUT` (30 s) for the child to exit
- On timeout: kills child, emits `(IR dump timed out after Xs)`, returns early
- On spawn/wait failure: emits `(IR dump failed: …)`, returns early
- On success: reads stdout/stderr and formats the IR dump as before

Uses `JIT_TIMEOUT`, `wait_timeout::ChildExt`, and `Stdio` already present in the file.

## Tests run

```
cargo build --features jit   →  Finished (20 pre-existing warnings, 0 new)
cargo test --features jit    →  test result: ok. 317 passed; 0 failed
```

## Linear ticket

CX-139 — https://linear.app/cx-lang/issue/CX-139/cx-138-apply-coderabbit-fixes-on-cx-134-parity-fail-ir-dump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic reporting for validation mismatches with improved error capture and handling capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/182)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->