### PR TITLE
CX-143: Document and validate large-value (struct/array) return convention in cx_abi_v0.1.md

### DIFF
--- a/docs/backend/cx_abi_v0.1.md
+++ b/docs/backend/cx_abi_v0.1.md
@@ -61,6 +61,45 @@ When copy param support lands in the compiled backend:
 
 ---
 
+## Large-Value Return Convention — LOCKED (post-0.1)
+
+Structs and fixed-size arrays are **large-value types** and cannot be returned in registers. All large-value returns use the **hidden out-pointer pattern**:
+
+1. Caller allocates storage for the return value on its own stack frame before the call.
+2. Caller passes a pointer to that storage as a **hidden first parameter** (position 0 in the parameter list, before all declared parameters).
+3. Callee writes the complete return value through the out-pointer before executing `Return`.
+4. Callee's declared return type at IR level is `None` (void return — no register value produced).
+
+**Threshold rule:** A return type requires out-pointer treatment if and only if its `SemanticType` is `Struct` or `Array`. Scalars (I8–I128, F64, Bool, TBool, Ptr) always use register return per the Calling Convention section above. The rule is **type-based**, not size-based — a single-field struct still uses the out-pointer pattern.
+
+**IR encoding:**
+- `IrFunction::return_ty` is `None` for any function returning a struct or array.
+- The hidden out-pointer is injected as the first `IrParam` with type `Ptr` at IR lowering time.
+- The callee stores each field or element to the out-pointer using `PtrOffset` + `Store` (struct) or `PtrAdd` + `Store` (array) before executing `Return { value: None }`.
+- The caller passes the stack-allocated pointer as the first argument in `IrInst::Call`.
+
+**Platform ABI mapping (x86-64):**
+- Linux x64 (SystemV): the out-pointer occupies the first integer register (RDI). Declared parameters shift right by one slot.
+- Windows x64 (fastcall): the out-pointer occupies the first argument slot (RCX). Declared parameters shift right by one slot.
+
+**0.1 status:** Struct and array return is **not supported** in the 0.1 compiled backend. Functions returning structs or arrays produce a structured `CxError::UnsupportedConstruct` at codegen time. They are handled by the interpreter only until the post-0.1 out-pointer lowering pass lands.
+
+**Caller stack allocation sizing:**
+- Struct: use `compute_struct_layout` from `src/ir/types.rs` — allocate `total_size` bytes at `alignment`.
+- Array: use `compute_array_layout` from `src/ir/types.rs` — allocate `total_size` bytes at `alignment`.
+
+Confidence tests in `src/ir/types.rs` validate out-pointer sizing for representative struct and array return shapes.
+
+---
+
+## Void Return at IR Boundary — LOCKED
+
+`void` (no return value) is represented as `None` in `IrFunction::return_ty`. `IrType::Void` is used only transiently during type lowering (`lower_type` maps `SemanticType::Void` to `IrType::Void`) and is canonicalised to `None` before being stored in the IR. `IrType::Void` must never appear in block parameters, instruction operands, or `IrFunction::return_ty` in valid IR.
+
+At the calling convention boundary: no register is written for void functions. Callee executes `Return { value: None }`, which lowers to a Cranelift `return_(&[])` with an empty value list.
+
+---
+
 ## Open Design Questions
 
 ### TBool Representation — LOCKED (0.1)

--- a/docs/backend/cx_backend_roadmap_v3_1.md
+++ b/docs/backend/cx_backend_roadmap_v3_1.md
@@ -250,7 +250,9 @@ Without this phase, parity testing is incomplete — the backend could produce o
   - Arena ownership question: the tree-walk interpreter's arena is a Vec<u8> in RunTime. In JIT mode, does the JIT call into the same RunTime arena via intrinsic calls, maintain its own separate arena, or treat strings as heap-allocated (arena as interpreter-only optimization)? This decision affects strref escape rules since strref is an arena view that cannot outlive the arena. Must be answered before any string layout is defined.
 - Handle<T> runtime representation
 - Unknown propagation strategy — does unknown checking happen in IR instructions or as runtime intrinsic calls? Arithmetic on unknown-infected values: propagation cost and mechanism. This decision gates when-block lowering.
-- Return value rules for large values and void — IrType::Void still pending
+**Locked in Round 3 (2026-05-12, CX-143):**
+- Large-value (struct/array) return convention — LOCKED. Out-pointer pattern: caller allocates stack storage, passes hidden first `Ptr` parameter, callee writes through it, IR return type is `None`. Type-based rule (any struct or array uses out-pointer regardless of size). Platform mapping: RDI on Linux x64, RCX on Windows x64. Implementation post-0.1; 0.1 backend produces `UnsupportedConstruct` for struct/array return. 4 confidence tests added in `src/ir/types.rs`.
+- `IrType::Void` at IR boundary — LOCKED. `SemanticType::Void` maps to `IrType::Void` in `lower_type` and is canonicalised to `None` in `IrFunction::return_ty`. `IrType::Void` must never appear in block parameters, instruction operands, or `IrFunction::return_ty` in valid IR. Void functions lower to Cranelift `return_(&[])`.
 
 **Locked in Round 2 (2026-05-11, CX-127):**
 - TBool calling convention — LOCKED. TBool function parameters follow C ABI treating TBool as I8, passed in the standard integer registers (RDI/RSI/RDX/RCX/R8/R9 on Linux; RCX/RDX/R8/R9 on Windows). Values 0/1/2 preserved across the call boundary. Zero-extended on widening (Cast TBool → I32 uses `uextend`). JIT validation tests confirm all three wire values round-trip correctly.

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -374,4 +374,46 @@ mod tests {
         assert_eq!(IrType::Void.size_bytes(), 0);
         assert_eq!(IrType::Void.align_bytes(), 1);
     }
+
+    // Large-value return convention — out-pointer sizing validation.
+    // These tests confirm the layout used to size caller-allocated return storage per
+    // cx_abi_v0.1.md "Large-Value Return Convention".
+
+    #[test]
+    fn large_value_return_struct_single_i32() {
+        // struct { I32 } — caller allocates 4 bytes @ align 4
+        let layout = compute_struct_layout(&[IrType::I32]);
+        assert_eq!(layout.field_offsets, vec![0]);
+        assert_eq!(layout.total_size, 4);
+        assert_eq!(layout.alignment, 4);
+    }
+
+    #[test]
+    fn large_value_return_struct_i32_then_i64() {
+        // struct { I32, I64 } — I32 @ 0, 4 pad, I64 @ 8 → caller allocates 16 bytes @ align 8
+        let layout = compute_struct_layout(&[IrType::I32, IrType::I64]);
+        assert_eq!(layout.field_offsets, vec![0, 8]);
+        assert_eq!(layout.total_size, 16);
+        assert_eq!(layout.alignment, 8);
+    }
+
+    #[test]
+    fn large_value_return_array_single_i64() {
+        // [1: t64] — even a single-element array uses out-pointer; caller allocates 8 bytes @ align 8
+        let layout = compute_array_layout(&IrType::I64, 1);
+        assert_eq!(layout.element_size, 8);
+        assert_eq!(layout.stride, 8);
+        assert_eq!(layout.total_size, 8);
+        assert_eq!(layout.alignment, 8);
+    }
+
+    #[test]
+    fn large_value_return_array_3_i32() {
+        // [3: t32] — caller allocates 12 bytes @ align 4
+        let layout = compute_array_layout(&IrType::I32, 3);
+        assert_eq!(layout.element_size, 4);
+        assert_eq!(layout.stride, 4);
+        assert_eq!(layout.total_size, 12);
+        assert_eq!(layout.alignment, 4);
+    }
 }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-143/cx-143-document-and-validate-large-value-structarray-return-convention

## Summary

- Added **Large-Value Return Convention — LOCKED (post-0.1)** section to `cx_abi_v0.1.md` documenting the out-pointer pattern for struct/array returns
- Added **Void Return at IR Boundary — LOCKED** section documenting `IrType::Void` canonicalisation behaviour
- Added 4 confidence tests in `src/ir/types.rs` validating out-pointer sizing for representative return shapes
- Updated roadmap Round 3 entry to close the "Return value rules for large values and void" open item

## Convention Locked

**Threshold rule (type-based, not size-based):** any `Struct` or `Array` return type uses the out-pointer pattern; all scalars use register return.

**Out-pointer pattern:**
1. Caller allocates stack storage for the return value (`Alloca`, sized by `compute_struct_layout`/`compute_array_layout`)
2. Caller passes a hidden first `Ptr` parameter pointing to that storage
3. Callee stores all fields/elements through the pointer and executes `Return { value: None }`
4. `IrFunction::return_ty` is `None` at IR level

**Platform mapping:** RDI (Linux x64 / SystemV) or RCX (Windows x64 / fastcall) for the hidden pointer; declared parameters shift right by one slot.

**0.1 status:** struct/array return is not implemented in 0.1 compiled backend — produces `UnsupportedConstruct`. Convention is locked for post-0.1 implementation.

## Files Changed

- `docs/backend/cx_abi_v0.1.md` — added two new LOCKED sections
- `src/ir/types.rs` — added 4 confidence tests
- `docs/backend/cx_backend_roadmap_v3_1.md` — closed open item, added Round 3 entry

## Validation

```
cargo build --features jit   → ok (325 tests, 0 failures)
cargo test --features jit    → ok (325 passed, 0 failed)
```

New tests:
- `ir::types::tests::large_value_return_struct_single_i32` — ok
- `ir::types::tests::large_value_return_struct_i32_then_i64` — ok
- `ir::types::tests::large_value_return_array_single_i64` — ok
- `ir::types::tests::large_value_return_array_3_i32` — ok

## Linear Ticket

CX-143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Backend ABI specifications finalized for large-value returns (structs and fixed-size arrays) with Linux SysV and Windows fastcall platform mappings.
  * Void function return behavior formally specified at the IR boundary.
  * Backend development roadmap updated to reflect locked IR-boundary specifications.

* **Tests**
  * Added unit tests validating struct and array layout calculations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/186)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->