### PR TITLE
CX-145: Document str/strref and Handle<T> as explicitly-unsupported in the 0.1 backend ABI

### DIFF
--- a/docs/backend/cx_abi_v0.1.md
+++ b/docs/backend/cx_abi_v0.1.md
@@ -78,10 +78,11 @@ Three-state value: true (1), false (0), unknown (2).
 - Arithmetic on unknown-infected values: propagation cost and mechanism. Blocked on unknown propagation strategy.
 - When-block lowering: TBool three-way branching requires two nested Branch instructions since IR Branch is two-way only. Design work needed before implementation.
 
-### String Layout — OPEN
+### String Layout — OPEN (str and strref not supported in 0.1)
 - `str` at C boundary is `(*const u8, u32)` — pointer + length, no null termination. LOCKED per frontend dev.
 - Arena ownership in JIT mode: does the JIT call into the interpreter's RunTime arena, maintain its own arena, or heap-allocate?
 - `strref` escape rules depend on arena ownership decision.
+- Both `str` and `strref` are explicitly unsupported in backend 0.1 pending the arena decision. See "Explicitly Unsupported in Backend 0.1" section below.
 
 ### Copy Parameter Convention — LOCKED (post-0.1)
 Deferred to post-0.1. See Calling Convention section above for the locked decision and implementation plan.
@@ -142,3 +143,55 @@ Tag-only enums at 0.1. No data-carrying variants.
 Group and super-group membership is a semantic concept only — no impact on wire format. The tag is just a `u8` regardless of group structure.
 
 Note: the interpreter matches enum variants by string name, not numeric tag. The compiled backend will use numeric tags. These are different internal representations for the same value. Enum values cannot be passed between interpreted and compiled code without a translation layer. Not a 0.1 problem — documented here so it doesn't surprise anyone later.
+
+---
+
+## Explicitly Unsupported in Backend 0.1
+
+These types exist in the Cx frontend and semantic layer but have no backend representation in 0.1. Any program that triggers these types at the lowering boundary receives a structured `UnsupportedSemanticType` error — no panics, no silent misbehavior. This section documents the blocking reason and post-0.1 path for each type.
+
+This section was added in Phase 8 Round 4 (CX-145).
+
+### str — NOT SUPPORTED IN 0.1
+
+`str` is an owned string type. The C-boundary wire format is settled (`(*const u8, u32)` — pointer + length, no null termination, per frontend developer decision), but backend support requires resolving arena ownership first.
+
+**Blocking decision — arena ownership in JIT mode.** The tree-walk interpreter allocates strings into a `Vec<u8>` arena in `RunTime`. Three options are open:
+1. JIT calls into the interpreter's `RunTime` arena via intrinsic calls.
+2. JIT maintains its own separate arena.
+3. Strings are heap-allocated in JIT mode (arena is an interpreter-only optimization).
+
+This decision affects `strref` escape rules and gates the Phase 9 read/input intrinsic implementation.
+
+**Current enforcement.** `SemanticType::Str` at the lowering boundary produces `LoweringError::UnsupportedSemanticType { ty: "Str" }`. `SemanticValue::Str(_)` in expression lowering also produces this error. Both are structured and named.
+
+**Post-0.1 path.** Once the arena ownership decision is made, the String Layout section above will be finalized and this entry will move to the type layout sections as a LOCKED entry.
+
+---
+
+### strref — NOT SUPPORTED IN 0.1
+
+`strref` is a borrowed view into a `str`'s backing arena. It cannot outlive the arena that owns the underlying bytes.
+
+**Blocking decision — same as `str`.** `strref` escape rules are entirely dependent on the arena ownership decision that blocks `str`. The two types are co-blocked: `strref` cannot be defined at the backend level until `str`'s arena model is decided.
+
+**Current enforcement.** The semantic layer proactively rejects `strref` in several positions before lowering is reached:
+- Cannot assign a `strref` to a variable (it does not outlive its origin scope).
+- Cannot use `strref` as a struct field type.
+- Cannot return `strref` from a function.
+
+Any `strref` that does reach the lowering pass produces `LoweringError::UnsupportedSemanticType { ty: "StrRef" }`. The semantic rejections live in `src/frontend/semantic.rs`.
+
+**Post-0.1 path.** Blocked on the `str` arena ownership decision. Resolves together with `str`.
+
+---
+
+### Handle\<T\> — NOT SUPPORTED IN 0.1
+
+`Handle<T>` is a typed generational handle into a `HandleRegistry<T>`. The handle itself is two `u32` fields — slot index and generation counter. The registry detects stale handles by bumping the generation counter on removal.
+
+**Reason not supported.** Handle registry operations — insert, get, remove, stale detection — are classified as post-0.1 work. No ABI-level intrinsic protocol for handle registry interaction has been designed. The handle's machine footprint (8 bytes, two u32 fields at natural alignment) is derivable from the struct layout rules, but the runtime intrinsic calls needed to operate on a live registry are not yet defined.
+
+**Current enforcement.** `SemanticType::Handle(_)` at the lowering boundary produces `LoweringError::UnsupportedSemanticType { ty: "Handle" }`. Handle operations in expressions — `HandleNew`, `HandleVal`, `HandleDrop` — produce `UnsupportedSemanticConstruct` errors before the type check is reached. The runtime implementation lives in `src/runtime/handle.rs` but is not wired into the backend codegen path.
+
+**Post-0.1 path.** Tracked as "Handle registry operations — post-0.1" in Phase 9 of `docs/backend/cx_backend_roadmap_v3_1.md`. When the Phase 9 handle sub-packet lands, this section will be updated with the ABI for handle registry intrinsic calls and the handle wire format will be promoted to a LOCKED entry.

--- a/docs/backend/cx_backend_roadmap_v3_1.md
+++ b/docs/backend/cx_backend_roadmap_v3_1.md
@@ -1,5 +1,5 @@
 # Cx Compiler Backend Roadmap
-v4.3 — 2026-05-11
+v4.4 — 2026-05-12
 
 ---
 
@@ -117,6 +117,9 @@ These are conditions, not features. All must be true before 0.1 ships.
 - Closures and lambdas
 - Async and continuations
 - when blocks — produces structured UnsupportedSemanticConstruct error; when lowering will require design work for TBool three-way branching (true/false/unknown requires two nested Branch instructions since IR only has two-way Branch)
+- `str` — produces structured UnsupportedSemanticType error; blocked on arena ownership decision (Phase 8 open item)
+- `strref` — produces structured UnsupportedSemanticType error; co-blocked with `str` on arena ownership decision; semantic layer also proactively rejects strref in assignment targets, struct fields, and return positions
+- `Handle<T>` — produces structured UnsupportedSemanticType error; handle registry intrinsics are post-0.1 (Phase 9)
 
 This list is intentional. Unsupported constructs must produce structured errors, not silently misbehave.
 
@@ -246,14 +249,14 @@ Without this phase, parity testing is incomplete — the backend could produce o
 - Target platform matrix explicit — Windows x64 and Linux x64 ✅
 
 **Still open:**
-- str and strref layout at backend boundary
-  - Arena ownership question: the tree-walk interpreter's arena is a Vec<u8> in RunTime. In JIT mode, does the JIT call into the same RunTime arena via intrinsic calls, maintain its own separate arena, or treat strings as heap-allocated (arena as interpreter-only optimization)? This decision affects strref escape rules since strref is an arena view that cannot outlive the arena. Must be answered before any string layout is defined.
-- Handle<T> runtime representation
 - Unknown propagation strategy — does unknown checking happen in IR instructions or as runtime intrinsic calls? Arithmetic on unknown-infected values: propagation cost and mechanism. This decision gates when-block lowering.
-- Return value rules for large values and void — IrType::Void still pending
 
 **Locked in Round 2 (2026-05-11, CX-127):**
 - TBool calling convention — LOCKED. TBool function parameters follow C ABI treating TBool as I8, passed in the standard integer registers (RDI/RSI/RDX/RCX/R8/R9 on Linux; RCX/RDX/R8/R9 on Windows). Values 0/1/2 preserved across the call boundary. Zero-extended on widening (Cast TBool → I32 uses `uextend`). JIT validation tests confirm all three wire values round-trip correctly.
+
+**Documented in Round 4 (2026-05-12, CX-145):**
+- `str` and `strref` documented as explicitly unsupported in backend 0.1 — wire format wire footprint for `str` is settled (`(*const u8, u32)`), but backend support is blocked on the arena ownership decision. Both types produce structured `UnsupportedSemanticType` errors at the lowering boundary. Full entry in `docs/backend/cx_abi_v0.1.md` under "Explicitly Unsupported in Backend 0.1".
+- `Handle<T>` documented as explicitly unsupported in backend 0.1 — handle registry intrinsics are post-0.1 (Phase 9). Produces structured `UnsupportedSemanticType` error at the lowering boundary. Full entry in `docs/backend/cx_abi_v0.1.md` under "Explicitly Unsupported in Backend 0.1".
 
 Done when:
 - Every core Cx type has a documented backend representation
@@ -647,7 +650,7 @@ Nothing in the post-0.1 compiler targets should start until Phase 15 closes.
 
 **Active**
 - Surface area reduction (Phase 11) — all original open items closed; remaining: `when` block lowering/rejection, method call actual lowering
-- ABI and data layout Round 2 (Phase 8) — TBool calling convention LOCKED (CX-127); str/strref layout, Handle<T>, unknown propagation still open
+- ABI and data layout Round 4 (Phase 8) — str/strref and Handle<T> documented as explicitly unsupported in 0.1 (CX-145); TBool calling convention LOCKED (CX-127); unknown propagation still open
 - Differential backend harness (Phase 12) — harness running, 120 fixtures, 0 PARITY_FAILs; full construct set coverage expansion in progress (CX-34)
 - Cranelift JIT — 0.1 target (Phase 15) — no-panic, float ops, exit-code, PtrOffset, intrinsic validation, numeric casts all landed; cast JIT, DotAccess JIT parity, full fixture coverage still in flight
 
@@ -668,6 +671,16 @@ Nothing in the post-0.1 compiler targets should start until Phase 15 closes.
 **Separate Roadmap**
 - GPU layer — Cx Platform and GPU Roadmap
 - Window and screen system — Cx Platform and GPU Roadmap
+
+---
+
+## Key Changes — v4.4 (2026-05-12)
+
+- Phase 8 Round 4: `str`, `strref`, and `Handle<T>` documented as explicitly unsupported in backend 0.1 (CX-145) — dedicated "Explicitly Unsupported in Backend 0.1" section added to `docs/backend/cx_abi_v0.1.md`; blocking reasons, current enforcement, and post-0.1 paths documented for each type
+- `str` and `strref` removed from Phase 8 "Still open" list — status is now documented (explicitly unsupported), not an undocumented gap
+- `Handle<T>` removed from Phase 8 "Still open" list — same reason
+- Backend Support Matrix updated: `str`, `strref`, `Handle<T>` added to the "Explicitly unsupported in backend 0.1" list with structured-error notes
+- Progress Board updated from Round 2 to Round 4
 
 ---
 


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-145/cx-145-phase-8-round-4-document-strstrref-and-handlet-as-explicitly

## Summary

Phase 8 Round 4. Adds explicit, structured documentation for three types that exist in the Cx frontend but have no backend representation in 0.1: `str`, `strref`, and `Handle<T>`.

Previously these types appeared only as OPEN design questions or were silently absent from the ABI spec. This PR gives each type a formal "Explicitly Unsupported" entry documenting: blocking reason, current enforcement (structured errors at the lowering boundary), and the post-0.1 path.

## Files Changed

- `docs/backend/cx_abi_v0.1.md` — Updated `String Layout` section heading to flag unsupported status. Added new top-level section `## Explicitly Unsupported in Backend 0.1` with entries for `str`, `strref`, and `Handle<T>`.
- `docs/backend/cx_backend_roadmap_v3_1.md` — Bumped to v4.4. Added Phase 8 Round 4 entry. Removed `str`, `strref`, `Handle<T>` from Phase 8 "Still open" (status is now documented, not an undocumented gap). Added all three to the Backend Support Matrix "Explicitly unsupported" list. Updated Progress Board.

## Key decisions documented

| Type | Blocking reason | Current enforcement |
|------|----------------|---------------------|
| `str` | Arena ownership decision unresolved (JIT vs interpreter arena) | `LoweringError::UnsupportedSemanticType { ty: "Str" }` |
| `strref` | Co-blocked with `str`; escape rules depend on arena model | Semantic layer rejects strref in assignments/fields/returns; lowering produces same error |
| `Handle<T>` | Handle registry intrinsics are post-0.1; no ABI for registry calls designed | `LoweringError::UnsupportedSemanticType { ty: "Handle" }`; handle expressions produce `UnsupportedSemanticConstruct` |

## Validation

```
cargo build --features jit   → ok (warnings only, pre-existing)
cargo test  --features jit   → 321 passed; 0 failed
```

## Linear ticket

https://linear.app/cx-lang/issue/CX-145/cx-145-phase-8-round-4-document-strstrref-and-handlet-as-explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend 0.1 technical documentation to explicitly document feature support status and implementation blockers.
  * Advanced backend roadmap to version 4.4 (2026-05-12) with updated feature support matrix and progress tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/188)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->