### PR TITLE
CX-147: Update cx_runtime_intrinsics_v0.1.md to reflect Phase 9 sub-packets 2 and 3 completion

### DIFF
--- a/docs/backend/cx_runtime_intrinsics_v0.1.md
+++ b/docs/backend/cx_runtime_intrinsics_v0.1.md
@@ -1,6 +1,6 @@
 # Cx Runtime Intrinsics Boundary — v0.1
 Phase 9 specification  
-Status: sub-packet 1 complete (audit + structured errors), codegen pending
+Status: sub-packets 1–3 complete, sub-packet 4 blocked on Phase 8 str layout
 
 ---
 
@@ -85,29 +85,37 @@ correct and contains the builtin name.
 
 ## Builtin Classification Table
 
-| Builtin      | Category            | Return  | Planned backend mechanism        | Blocking condition |
-|--------------|---------------------|---------|----------------------------------|--------------------|
-| `print`      | I/O — stdout        | void    | runtime call to `cx_print`       | frontend must promote to function first |
-| `println`    | I/O — stdout        | void    | runtime call to `cx_println`     | same as `print` |
-| `printn`     | I/O — stdout        | void    | runtime call to `cx_printn`      | same as `print` |
-| `read`       | I/O — stdin         | str     | runtime call to `cx_read`        | str/strref layout must be locked (Phase 8 open item) |
-| `input`      | I/O — stdin         | str     | runtime call to `cx_input`       | same as `read` |
-| `assert`     | Debug / assertion   | void    | inline Branch + trap, or runtime | semantics TBD — does assert abort or panic? |
-| `assert_eq`  | Debug / assertion   | void    | inline cmp + Branch + trap       | same as `assert` |
+| Builtin      | Category            | Return  | Backend mechanism                                  | Status |
+|--------------|---------------------|---------|-----------------------------------------------------|--------|
+| `print`      | I/O — stdout        | void    | `IrInst::Call` → `cx_printn` (I64 only)            | **DONE** — CX-136 |
+| `println`    | I/O — stdout        | void    | `IrInst::Call` → `cx_printn` (I64 only)            | **DONE** — CX-136 |
+| `printn`     | I/O — stdout        | void    | `IrInst::Call` → `cx_printn`                       | **DONE** |
+| `read`       | I/O — stdin         | str     | runtime call to `cx_read`                          | BLOCKED — str/strref layout (Phase 8) |
+| `input`      | I/O — stdin         | str     | runtime call to `cx_input`                         | BLOCKED — same as `read` |
+| `assert`     | Debug / assertion   | void    | `IrInst::Branch` + `IrTerminator::Trap` (abort)    | **DONE** — Phase 9 sub-packet 3 |
+| `assert_eq`  | Debug / assertion   | void    | `IrInst::Compare(Eq)` + Branch + Trap (abort)      | **DONE** — Phase 9 sub-packet 3 |
 
 ### I/O builtins — print family
 
 `print`, `println`, `printn` are stdout I/O.  They do not return a value.
+All three are **COMPLETE** as of Phase 9 sub-packet 2 (CX-136, 2026-05-10).
 
-Cross-roadmap dependency: **the frontend has not promoted these to real
-functions yet**.  Until they have a proper call signature (parameter types,
-arity rules) Phase 9 cannot define their ABI.  Phase 9 tracks this as its
-primary blocker.
+**Implementation** (`src/ir/lower.rs`):
 
-Planned mechanism: a thin runtime shim (`cx_runtime.c` or equivalent)
-exported as a C-ABI symbol.  JIT-compiled code calls it via `IrInst::Call`
-with the shim's name as callee.  The shim writes to stdout using the platform
-C runtime (`puts` / `printf`).  No in-process pipe redirection.
+- `printn(n)` → `lower_printn_stmt()`: emits `IrInst::Call { callee: "cx_printn", args: [n] }` directly.
+- `print(n)` and `println(n)` → `lower_print_stmt()`: both route to the same `cx_printn` call.
+  In Cx both print and println already produce a newline (matching `cx_printn`'s `writeln!` behaviour),
+  so a single runtime symbol covers all three.
+
+**Type restriction**: Only `I64` arguments are supported.  Non-I64 arguments produce a structured
+`UnsupportedSemanticConstruct` error naming the actual builtin (e.g. `"print argument must be I64"`).
+String printing awaits the Phase 8 str/strref layout decision.
+
+**Runtime symbol**: `cx_printn` is declared in the JIT module as an imported C-ABI symbol
+(`src/backend/cranelift/host_boundary.rs`) and registered in `RESERVED_RUNTIME_INTRINSICS`.
+
+**Diagnostic fix** (CX-141): `lower_print_stmt` threads `builtin_name: &str` through all error
+paths so diagnostics correctly name `print` vs `println` rather than a generic label.
 
 ### I/O builtins — read / input
 
@@ -121,66 +129,82 @@ decision is made.
 ### Debug builtins — assert / assert_eq
 
 `assert(cond)` and `assert_eq(lhs, rhs)` are diagnostic assertions.
+Both are **COMPLETE** as of Phase 9 sub-packet 3.
 
-Design decision needed before these can be lowered:
+**Semantics locked**: abort (like C `assert`).  No unwinding, no Cx panic path.
+The design decision was resolved in favour of the simpler model for 0.1.
 
-- Do they abort the process (like C `assert`)? If so, the backend emits a
-  conditional Branch to a trap block.
-- Do they raise a Cx panic that can be caught? If so, a runtime-call mechanism
-  is needed.
+**Implementation** (`src/ir/lower.rs` — `lower_assert_stmt` / `lower_assert_eq_stmt`):
 
-For 0.1 the expected answer is "abort" (simple, no unwinding machinery).
-That decision must be confirmed before implementation.
+Both builtins lower to a two-block CFG pattern:
+
+```
+[current block]
+  ... condition computation ...
+  Branch { cond, then: pass_block, else: trap_block }
+
+[pass_block]          ← execution continues here if assertion passes
+  (empty — caller receives this as the new current block)
+
+[trap_block]
+  Trap                ← abort; Cranelift emits a hardware trap instruction
+```
+
+- `assert(cond)`: condition must be Bool or a truthy integer (I8/I16/I32/I64 ≠ 0).
+- `assert_eq(lhs, rhs)`: both operands must have the same type; a `Compare(Eq)` instruction
+  produces the Bool passed to the branch.  Supported types: Bool, I8, I16, I32, I64.
+
+Unsupported types (Ptr, F64, StrRef, etc.) produce a structured `UnsupportedSemanticConstruct`
+error so the caller gets a clear diagnostic rather than a crash.
 
 ---
 
-## Planned Implementation Path (Phase 9 remaining sub-packets)
+## Implementation Path (Phase 9 sub-packets)
 
-**Sub-packet 2 — print family (blocked on frontend)**
+**Sub-packet 1 — Audit + structured errors** ✓ COMPLETE
 
-When the frontend promotes `print`, `println`, `printn` to real functions:
+Added `is_cx_builtin()` guard producing `UnsupportedSemanticConstruct` errors for all seven
+builtins.  Seven tests verify the error family (one per builtin).
 
-1. Add shim symbols to `src/backend/cranelift/jit.rs` — declare them as
-   external C-ABI functions in the Cranelift module.
-2. Remove them from `is_cx_builtin()`.
-3. They then flow through the normal `IrInst::Call` path.
-4. Tests: a `.cx` program that calls `print` executes through the JIT and
-   produces matching stdout in the differential harness.
+**Sub-packet 2 — print family** ✓ COMPLETE (CX-136, 2026-05-10; CX-141 diagnostic fix)
 
-**Sub-packet 3 — assert / assert_eq**
+1. Added `cx_printn` to `RESERVED_RUNTIME_INTRINSICS` and declared it in the JIT module
+   as an imported C-ABI symbol.
+2. Removed `print`, `println`, `printn` from `is_cx_builtin()`; they are now intercepted
+   at the tier-1 `ExprStmt` gate in `lower_stmt()`.
+3. `lower_print_stmt()` and `lower_printn_stmt()` emit `IrInst::Call { callee: "cx_printn" }`.
+4. Tests added: `print_i64_lowers_to_cx_printn_call`, `println_i64_lowers_to_cx_printn_call`,
+   `print_non_i64_arg_returns_unsupported_construct`.
 
-After the abort-vs-panic decision is locked:
+**Sub-packet 3 — assert / assert_eq** ✓ COMPLETE
 
-1. If abort: lower to `IrInst::Branch` + `IrTerminator::Trap` (or equivalent).
-   Requires adding `IrTerminator::Trap` to the IR.
-2. Remove them from `is_cx_builtin()`.
-3. Tests: a program that hits a failing assert produces exit code 126 (JIT
-   runtime failure).
+1. Abort semantics confirmed.  `IrTerminator::Trap` was already present in the IR.
+2. Removed `assert`, `assert_eq` from `is_cx_builtin()`; intercepted at tier-1 gate.
+3. `lower_assert_stmt()` and `lower_assert_eq_stmt()` emit Branch + Trap pattern.
+4. Tests verify correct Branch IR generation for passing and failing assertion cases.
 
-**Sub-packet 4 — read / input (blocked on Phase 8 str layout)**
+**Sub-packet 4 — read / input** BLOCKED on Phase 8 str layout
 
 Deferred until `str` and `strref` layout is locked in Phase 8.
 
 ---
 
-## Runtime Entry Point Registry (draft)
+## Runtime Entry Point Registry
 
-This section will list the stable C-ABI symbols that JIT-compiled Cx code
-may call.  It is a stub until sub-packets 2–4 land.
+C-ABI symbols that JIT-compiled Cx code may call.  Sub-packets 2–3 are live;
+sub-packet 4 symbols are TBD pending Phase 8 str layout.
 
-| Symbol         | Signature (C)                     | Provided by       |
-|----------------|-----------------------------------|-------------------|
-| `cx_print`     | `void cx_print(const char* s)`    | cx_runtime shim   |
-| `cx_println`   | `void cx_println(const char* s)`  | cx_runtime shim   |
-| `cx_printn`    | `void cx_printn(int64_t n)`       | cx_runtime shim   |
-| `cx_read`      | TBD — blocked on str layout       | —                 |
-| `cx_input`     | TBD — blocked on str layout       | —                 |
+| Symbol         | Signature (C)                     | Provided by                              | Status |
+|----------------|-----------------------------------|------------------------------------------|--------|
+| `cx_printn`    | `void cx_printn(int64_t n)`       | `src/backend/cranelift/host_boundary.rs` | **LIVE** |
+| `cx_read`      | TBD — blocked on str layout       | —                                        | pending Phase 8 |
+| `cx_input`     | TBD — blocked on str layout       | —                                        | pending Phase 8 |
 
-Ownership rules:
-- All string pointers passed to I/O shims are read-only; the shim does not
-  take ownership and does not free.
-- The caller (JIT code) is responsible for keeping the backing memory alive
-  for the duration of the call.
+Notes:
+- `cx_print` and `cx_println` are **not** separate runtime symbols.  Both
+  `print` and `println` builtins lower to `cx_printn` (see sub-packet 2).
+- `assert` and `assert_eq` lower to inline IR (`Branch` + `Trap`) — no
+  runtime symbol needed.
 
 ---
 
@@ -197,7 +221,10 @@ Ownership rules:
 ## References
 
 - `src/frontend/semantic.rs` — builtin recognition in `analyze_call()` (~line 1446)
-- `src/ir/lower.rs` — `is_cx_builtin()` guard and structured error
-- `docs/backend/cx_abi_v0.1.md` — scalar layout and calling convention
-- `docs/backend/cx_backend_roadmap_v3_1.md` — Phase 9 and its blockers
-- `src/backend/cranelift/host_boundary.rs` — JIT host boundary documentation
+- `src/ir/lower.rs` — `is_cx_builtin()` guard (~line 94); tier-1 ExprStmt intercept (~line 666);
+  `lower_printn_stmt` (~line 2678); `lower_print_stmt` (~line 2720);
+  `lower_assert_stmt` (~line 2763); `lower_assert_eq_stmt` (~line 2796)
+- `src/backend/cranelift/host_boundary.rs` — `cx_printn` extern C implementation (~line 267);
+  JIT symbol registration (~line 342)
+- `docs/backend/cx_abi_v0.1.md` — scalar layout, calling convention, and expression evaluation order
+- `docs/backend/cx_backend_roadmap_v3_1.md` — Phase 9 and its sub-packets


### PR DESCRIPTION
Closes CX-147

## Summary

Updates `docs/backend/cx_runtime_intrinsics_v0.1.md` to accurately reflect the completion of Phase 9 sub-packets 2 and 3, which were implemented in CX-136, CX-138, and CX-141 but not yet reflected in the spec document.

## Changes

**`docs/backend/cx_runtime_intrinsics_v0.1.md`**

- **Status line**: Updated from "sub-packet 1 complete, codegen pending" to "sub-packets 1–3 complete, sub-packet 4 blocked on Phase 8 str layout"
- **Builtin Classification Table**: Updated print/println/printn/assert/assert_eq entries to show DONE status with mechanism and commit references; replaced "Planned backend mechanism / Blocking condition" columns with "Backend mechanism / Status"
- **Print family section**: Replaced the "frontend blocker" text with completed implementation details — both print and println route to `cx_printn`, I64-only restriction, diagnostic fix from CX-141
- **Assert/assert_eq section**: Replaced "design decision needed" with abort semantics confirmed and full Branch+Trap CFG pattern documentation
- **Implementation Path section**: Renamed from "Planned Implementation Path" and marked sub-packets 1–3 as ✓ COMPLETE with dates and commit references; sub-packet 4 remains BLOCKED
- **Runtime Entry Point Registry**: Removed phantom `cx_print`/`cx_println` symbols (they don't exist; both builtins route to `cx_printn`); added notes clarifying assert/assert_eq use inline IR not runtime calls; promoted from "draft" to live
- **References**: Added precise line number pointers for all lowering functions (`lower_printn_stmt`, `lower_print_stmt`, `lower_assert_stmt`, `lower_assert_eq_stmt`) and `cx_printn` registration in `host_boundary.rs`

## Files Changed

- `docs/backend/cx_runtime_intrinsics_v0.1.md`

## Validation

```
cargo build --features jit  → Finished (20 warnings, 0 errors)
cargo test --features jit   → test result: ok. 321 passed; 0 failed
```

## Linear Ticket

CX-147 — https://linear.app/cx-lang/issue/CX-147/update-cx-runtime-intrinsics-v01md-to-reflect-phase-9-sub-packets-2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend runtime specification documentation to reflect current implementation status and registry information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/190)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->