### PR TITLE
CX-148: Add MethodCall SKIP parity fixtures to JIT differential harness (Phase 11 close)

### DIFF
--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -214,6 +214,9 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t125_struct_field_read_exit"
         | "t126_struct_second_field_read_exit"
         | "t127_struct_field_write_exit"
+        | "t152_impl_basic_exit"
+        | "t153_impl_return_exit"
+        | "t154_multi_alias_impl_exit"
             => FeatureCategory::Struct,
 
         // ── Array ─────────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t152_impl_basic_exit.cx
+++ b/src/tests/verification_matrix/t152_impl_basic_exit.cx
@@ -1,0 +1,18 @@
+// CX-148: exit-code-based JIT parity — MethodCall basic (void method, field mutation).
+// Exercises a void method call that mutates a struct field via the self-alias.
+// JIT: exits 127 (SKIP — MethodCall not yet lowered).
+// Interpreter: exits 0 (all asserts held).
+struct Player {
+    health: t32,
+}
+
+player_methods: impl (p: Player) {
+    fnc: take_damage(amount: t32) {
+        p.health -= amount
+    }
+}
+
+let p;
+p = Player { health: 100 }
+p.take_damage(30)
+assert_eq(p.health, 70)

--- a/src/tests/verification_matrix/t153_impl_return_exit.cx
+++ b/src/tests/verification_matrix/t153_impl_return_exit.cx
@@ -1,0 +1,25 @@
+// CX-148: exit-code-based JIT parity — MethodCall return value.
+// Exercises a method that increments a counter field, then reads the value
+// back via a returning method call.
+// JIT: exits 127 (SKIP — MethodCall not yet lowered).
+// Interpreter: exits 0 (all asserts held).
+struct Counter {
+    value: t32,
+}
+
+counter_methods: impl (c: Counter) {
+    fnc: increment() {
+        c.value = c.value + 1
+    }
+
+    fnc: t32 get() {
+        c.value
+    }
+}
+
+let c;
+c = Counter { value: 0 }
+c.increment()
+c.increment()
+c.increment()
+assert_eq(c.get(), 3)

--- a/src/tests/verification_matrix/t154_multi_alias_impl_exit.cx
+++ b/src/tests/verification_matrix/t154_multi_alias_impl_exit.cx
@@ -1,0 +1,33 @@
+// CX-148: exit-code-based JIT parity — MethodCall multi-alias impl (two struct params).
+// Exercises a multi-alias impl block whose methods receive two struct instances
+// and mutate the first via field reads from the second.
+// JIT: exits 127 (SKIP — MethodCall not yet lowered).
+// Interpreter: exits 0 (all asserts held).
+struct Player {
+    health: t32,
+    position: t32,
+}
+
+struct World {
+    origin: t32,
+    gravity: t32,
+}
+
+world_sync: impl (p: Player, w: World) {
+    fnc: sync_position() {
+        p.position = w.origin
+    }
+
+    fnc: apply_gravity() {
+        p.health -= w.gravity
+    }
+}
+
+let p;
+p = Player { health: 100, position: 0 }
+let w;
+w = World { origin: 50, gravity: 10 }
+p.sync_position(w)
+p.apply_gravity(w)
+assert_eq(p.position, 50)
+assert_eq(p.health, 90)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-148/add-methodcall-skip-parity-fixtures-to-jit-differential-harness-phase

## Summary

- Added three exit-code-verified parity fixtures for MethodCall constructs (t152, t153, t154), mirroring the existing print-based t39/t40/t43 fixtures
- Registered all three under `FeatureCategory::Struct` in `feature_of()` in `src/diff_harness.rs`
- Struct category grows from 11 → 14 fixtures; all three new fixtures SKIP in JIT (exit 127, MethodCall not yet lowered in `src/ir/lower.rs`) and pass the interpreter baseline

## Files Changed

- `src/tests/verification_matrix/t152_impl_basic_exit.cx` — void method call mutating a struct field (`p.take_damage(30)`), verified via `assert_eq(p.health, 70)`
- `src/tests/verification_matrix/t153_impl_return_exit.cx` — counter incremented three times via method calls, return value verified via `assert_eq(c.get(), 3)`
- `src/tests/verification_matrix/t154_multi_alias_impl_exit.cx` — multi-alias impl block with two struct params, two assert_eq checks on mutated fields
- `src/diff_harness.rs` — `feature_of()` extended with three new fixture stems under `FeatureCategory::Struct`

## Validation

```
cargo build --features jit   → OK (warnings only, pre-existing)
cargo test --features jit    → 321 passed; 0 failed
```

JIT parity table (Struct row):
```
Feature                PASS   SKIP  PARITY_FAIL
Struct                    6      8            0
```

Total: 158 fixtures checked across 16 feature categories, 0 PARITY_FAILs.

## Notes

All three new fixtures use `PassAny` expectation (no `.expected_output` companion). When MethodCall lowering lands, they will transition from SKIP → PASS automatically with no fixture changes needed.

Linear ticket: CX-148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification tests for struct method calls and field mutations across interpreter and JIT implementations.
  * Tests validate behavior of parameterized methods, return values, and multi-struct interactions with consistent exit-code expectations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->