### PR TITLE
CX-150: Remove default src/tests/test.cx CLI fallback and require explicit input path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -108,9 +108,15 @@ fn run() {
         .iter()
         .find(|a| !a.starts_with("--"))
         .cloned()
-        .unwrap_or_else(|| "src/tests/test.cx".to_string());
+        .unwrap_or_else(|| {
+            eprintln!("error: no input file specified\nusage: cx <file.cx> [--flags...]");
+            std::process::exit(1);
+        });
 
-    let input = fs::read_to_string(&path).expect("failed to read .cx file");
+    let input = fs::read_to_string(&path).unwrap_or_else(|e| {
+        eprintln!("error: failed to read '{}': {}", path, e);
+        std::process::exit(1);
+    });
 
     // LEXER PHASE
     let lex_timer = flags.phase.then(|| PhaseTimer::start("LEXER"));


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-150/cx-150-remove-default-srcteststestcx-cli-fallback-and-require-explicit

## Summary

- Removed the `unwrap_or_else(|| "src/tests/test.cx".to_string())` fallback in `src/main.rs`
- When no positional argument is provided, the CLI now prints a usage error to stderr and exits with code 1
- Also improved the file-read error message (no longer uses `.expect()` — now prints the filename and OS error)

## Files Changed

- `src/main.rs` — CLI argument parsing (lines 107–116)

## Tests Run

```
cargo build --features jit   ✓
cargo test --features jit    ✓  321 passed; 0 failed
```

## Validation Results

All 321 tests pass including `diff_harness::tests::interpreter_baseline_all` and `diff_harness::tests::jit_parity_by_feature`. The diff harness always passes explicit fixture paths, so no existing tests relied on the removed fallback.

## Known Limitations

None.

## Linear Ticket

CX-150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when no input file is specified.
  * Enhanced error reporting for file reading failures with more detailed diagnostic information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/193)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->