### PR TITLE
CX-151: Add missing example .cx files referenced by README

### DIFF
--- a/examples/arrays_and_loops.cx
+++ b/examples/arrays_and_loops.cx
@@ -1,0 +1,13 @@
+nums: [5: t64] = [10, 20, 30, 40, 50]
+
+print(nums:[0])
+print(nums:[2])
+print(nums:[4])
+
+while in nums:[0], 0..5 {
+    print(*nums)
+}
+
+for i in 0..5 {
+    print(i)
+}

--- a/examples/error_handling.cx
+++ b/examples/error_handling.cx
@@ -1,0 +1,16 @@
+fnc: Result<t32> safe_divide(a: t32, b: t32) {
+    if b == 0 {
+        return Err("division by zero")
+    }
+    return Ok(a / b)
+}
+
+fnc: Result<t32> compute(a: t32, b: t32) {
+    let q;
+    q = safe_divide(a, b)?
+    return Ok(q * 2)
+}
+
+print(compute(10, 2))
+print(compute(10, 0))
+print(compute(9, 3))

--- a/examples/fibonacci.cx
+++ b/examples/fibonacci.cx
@@ -1,0 +1,23 @@
+fnc: t64 fib(n: t64) {
+    if n < 2 {
+        return n
+    }
+    a: t64 = 0
+    b: t64 = 1
+    tmp: t64 = 0
+    i: t64 = 2
+    while (i <= n) {
+        tmp = a + b
+        a = b
+        b = tmp
+        i += 1
+    }
+    return b
+}
+
+let i;
+i = 0
+while (i <= 10) {
+    print(fib(i))
+    i += 1
+}

--- a/examples/fizzbuzz.cx
+++ b/examples/fizzbuzz.cx
@@ -1,0 +1,14 @@
+let i;
+i = 1
+while (i <= 20) {
+    if i % 15 == 0 {
+        print("FizzBuzz")
+    } else if i % 3 == 0 {
+        print("Fizz")
+    } else if i % 5 == 0 {
+        print("Buzz")
+    } else {
+        print(i)
+    }
+    i += 1
+}

--- a/examples/generics.cx
+++ b/examples/generics.cx
@@ -1,0 +1,12 @@
+struct Pair<T> {
+    first: T,
+    second: T,
+}
+
+ints: Pair = Pair { first: 10, second: 20 }
+print(ints.first)
+print(ints.second)
+
+floats: Pair = Pair { first: 3.14, second: 2.71 }
+print(floats.first)
+print(floats.second)

--- a/examples/hello.cx
+++ b/examples/hello.cx
@@ -1,0 +1,7 @@
+name: str = "World"
+age: t32 = 42
+score: f64 = 9.8
+
+print("Hello, {name}!")
+print("Age: {age}")
+print("Score: {score}")

--- a/examples/structs_and_methods.cx
+++ b/examples/structs_and_methods.cx
@@ -1,0 +1,28 @@
+struct Player {
+    health: t32,
+    max_health: t32,
+}
+
+player_methods: impl (p: Player) {
+    fnc: take_damage(amount: t32) {
+        p.health -= amount
+    }
+
+    fnc: heal(amount: t32) {
+        p.health += amount
+    }
+
+    fnc: show() {
+        print(p.health)
+    }
+}
+
+let p;
+p = Player { health: 100, max_health: 100 }
+p.show()
+p.take_damage(30)
+p.show()
+p.heal(10)
+p.show()
+p.take_damage(55)
+p.show()

--- a/examples/tbool_uncertainty.cx
+++ b/examples/tbool_uncertainty.cx
@@ -1,0 +1,27 @@
+a: bool = true
+b: bool = ?
+
+print(is_known(a))
+print(is_known(b))
+
+let x;
+x = true
+
+when x {
+    true    => print("is true"),
+    false   => print("is false"),
+    unknown => print("is unknown"),
+}
+
+let y;
+y = ?
+
+when y {
+    true    => print("is true"),
+    false   => print("is false"),
+    unknown => print("is unknown"),
+}
+
+let z;
+z = a && b
+print(is_known(z))


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-151/cx-151-add-missing-example-cx-files-referenced-by-readme

## Summary

The `examples/README.md` table documented 8 example files but none existed in the repository. This PR adds all 8.

## Files Added

| File | Demonstrates |
|------|-------------|
| `examples/hello.cx` | Variables, types, `print()`, string interpolation `{var}` |
| `examples/fizzbuzz.cx` | `while` loop, `if/else if/else`, modulo `%` |
| `examples/fibonacci.cx` | Functions (`fnc:`), iterative computation, `while` loop |
| `examples/structs_and_methods.cx` | `struct`, `impl` block, method calls, field access |
| `examples/error_handling.cx` | `Result<T>`, `Ok()`, `Err()`, `?` try operator |
| `examples/arrays_and_loops.cx` | Array `[N: Type]`, `for` loop, `while in` cursor iteration |
| `examples/generics.cx` | Generic `struct Pair<T>`, type-parameterized instantiation |
| `examples/tbool_uncertainty.cx` | `tbool`, unknown literal `?`, `is_known()`, propagation |

All examples exit 0 and produce deterministic output. Syntax confirmed against the verification matrix test files.

## Tests Run

- `cargo build --features jit` — passes (20 pre-existing warnings, no errors)
- `cargo test --features jit` — 321 passed, 0 failed
- All 8 examples executed directly with the interpreter binary — all exit 0

## Validation Results

```
exit 0 -- examples/hello.cx
exit 0 -- examples/fizzbuzz.cx
exit 0 -- examples/fibonacci.cx
exit 0 -- examples/structs_and_methods.cx
exit 0 -- examples/error_handling.cx
exit 0 -- examples/arrays_and_loops.cx
exit 0 -- examples/generics.cx
exit 0 -- examples/tbool_uncertainty.cx
```

## Linear Ticket

CX-151