### PR TITLE
CX-152: Fix VarRef/Assign/CompoundAssign lowering for Numeric/Unknown-typed bindings

### DIFF
--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -608,7 +608,13 @@ fn lower_stmt(
             let lowered = lower_expr(expr, ctx, &mut current)?;
             match target {
                 SemanticLValue::Binding { binding, ty, .. } => {
-                    let target_ty = lower_type(ty)?;
+                    // Numeric/Unknown: binding type is a placeholder; use the
+                    // lowered expression's concrete type as authoritative.
+                    let target_ty = if matches!(ty, SemanticType::Numeric | SemanticType::Unknown) {
+                        lowered.ty.clone()
+                    } else {
+                        lower_type(ty)?
+                    };
                     ensure_type_match("assign", target_ty.clone(), lowered.ty)?;
                     let dst = ctx.fresh_value();
                     current.emit(IrInst::SsaBind {
@@ -742,12 +748,18 @@ fn lower_stmt(
         SemanticStmt::CompoundAssign { target, op, operand, .. } => {
     match target {
         SemanticLValue::Binding { binding, ty, .. } => {
-            let target_ty = lower_type(ty)?;
             let current_val = current.bindings.get(binding).ok_or_else(|| {
                 LoweringError::UnresolvedSemanticArtifact {
                     artifact: format!("compound assign binding {:?}", binding),
                 }
             })?.clone();
+            // Numeric/Unknown: binding type is a placeholder; use the stored
+            // concrete type from the SSA bindings map as authoritative.
+            let target_ty = if matches!(ty, SemanticType::Numeric | SemanticType::Unknown) {
+                current_val.ty.clone()
+            } else {
+                lower_type(ty)?
+            };
             let rhs = lower_expr(operand, ctx, &mut current)?;
             let bin_op = match op {
                 Op::Plus => BinaryOp::Add,
@@ -1549,7 +1561,6 @@ fn lower_expr(
     match &expr.kind {
         SemanticExprKind::Value(value) => lower_value(value, &expr.ty, ctx, active),
         SemanticExprKind::VarRef { binding, name } => {
-            let ty = lower_type(&expr.ty)?;
             let lowered = active.bindings.get(binding).cloned().ok_or_else(|| {
                 LoweringError::InternalInvariantViolation {
                     detail: format!(
@@ -1558,8 +1569,15 @@ fn lower_expr(
                     ),
                 }
             })?;
-            ensure_type_match("var ref", ty, lowered.ty.clone())?;
-            Ok(lowered)
+            if matches!(expr.ty, SemanticType::Numeric | SemanticType::Unknown) {
+                // Placeholder type: the stored binding type (set at first assignment)
+                // is authoritative. Mirrors the fallback in lower_array_lit/lower_index.
+                Ok(lowered)
+            } else {
+                let ty = lower_type(&expr.ty)?;
+                ensure_type_match("var ref", ty, lowered.ty.clone())?;
+                Ok(lowered)
+            }
         }
         SemanticExprKind::Binary { lhs, op, rhs, .. } => {
             lower_binary(lhs, *op, rhs, &expr.ty, ctx, active)
@@ -3320,6 +3338,64 @@ mod tests {
                 }
             ]
         ));
+    }
+
+    // VarRef with SemanticType::Numeric falls back to the stored binding type
+    // (I64 on 64-bit) rather than calling lower_type(Numeric) which would fail.
+    // Mirrors the fallback introduced for array element lowering in CX-121/CX-129.
+    #[test]
+    fn varref_numeric_type_falls_back_to_binding_type() {
+        let binding = BindingId(1);
+        let program = SemanticProgram {
+            stmts: vec![
+                typed_assign(
+                    binding,
+                    "i",
+                    SemanticType::I64,
+                    int_expr(0, SemanticType::I64),
+                ),
+                SemanticStmt::ExprStmt {
+                    expr: binding_ref(binding, "i", SemanticType::Numeric),
+                    pos: 0,
+                },
+            ],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let insts = &module.functions[0].blocks[0].insts;
+        assert!(
+            insts.iter().any(|inst| matches!(inst, IrInst::SsaBind { ty: IrType::I64, .. })),
+            "expected SsaBind(I64) for VarRef with Numeric placeholder type"
+        );
+    }
+
+    // VarRef with SemanticType::Unknown also falls back to the stored binding type.
+    #[test]
+    fn varref_unknown_type_falls_back_to_binding_type() {
+        let binding = BindingId(2);
+        let program = SemanticProgram {
+            stmts: vec![
+                typed_assign(
+                    binding,
+                    "j",
+                    SemanticType::I64,
+                    int_expr(5, SemanticType::I64),
+                ),
+                SemanticStmt::ExprStmt {
+                    expr: binding_ref(binding, "j", SemanticType::Unknown),
+                    pos: 0,
+                },
+            ],
+            enums: vec![],
+        };
+
+        let module = lower_and_validate(&program);
+        let insts = &module.functions[0].blocks[0].insts;
+        assert!(
+            insts.iter().any(|inst| matches!(inst, IrInst::SsaBind { ty: IrType::I64, .. })),
+            "expected SsaBind(I64) for VarRef with Unknown placeholder type"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes CX-152

## Summary

Fixes three lowering paths in `src/ir/lower.rs` that called `lower_type()` on `SemanticType::Numeric` or `SemanticType::Unknown` placeholder types, causing `UnsupportedSemanticType` errors (exit 127 → SKIP in the differential harness).

When a variable is declared without an explicit type (e.g. `let i; i = 0; while (i < 6) { print(i); i += 2 }`), the semantic layer annotates the binding and its LValue targets with `SemanticType::Numeric`. All three statement/expression kinds that touch the binding type need the same Numeric/Unknown guard.

## Root Cause (Recon finding)

The ticket description identified the VarRef arm as the only failure site, but actual tracing revealed three sequential failures for t26:

1. `SemanticStmt::Assign { target: LValue::Binding { ty: Numeric } }` — `lower_type(Numeric)` at line 611 fails **before** the binding is stored in the SSA map
2. `SemanticExprKind::VarRef` with `expr.ty = Numeric` — `lower_type(Numeric)` at line 1552 fails when `print(i)` is lowered
3. `SemanticStmt::CompoundAssign { target: LValue::Binding { ty: Numeric } }` — `lower_type(Numeric)` at line 745 fails for `i += 2`

Without fixing (1), the binding is never stored, making the VarRef fix in (2) moot.

## Changes

**`src/ir/lower.rs`** — the only file modified:

- `SemanticStmt::Assign` (Binding target, ~line 611): when `ty` is `Numeric`/`Unknown`, use `lowered.ty` (from lowering the RHS expression) as the concrete target type
- `SemanticExprKind::VarRef` (~line 1552): reorder to fetch from SSA bindings map first; when `expr.ty` is `Numeric`/`Unknown`, skip `lower_type` and return the stored binding value directly
- `SemanticStmt::CompoundAssign` (Binding target, ~line 745): reorder to fetch the current binding value first; when `ty` is `Numeric`/`Unknown`, use `current_val.ty` as the concrete target type
- Two new unit tests: `varref_numeric_type_falls_back_to_binding_type` and `varref_unknown_type_falls_back_to_binding_type`

All three fixes mirror the Numeric/Unknown fallback pattern established in `lower_array_lit` and `lower_index` (CX-121/CX-129).

## Validation

```
cargo build --features jit   — zero errors, 20 pre-existing warnings (unchanged)
cargo test --features jit    — 323 passed; 0 failed
```

Parity gate (`jit_parity_by_feature --nocapture`):

| Feature       | PASS (before) | PASS (after) | SKIP (after) | PARITY_FAIL |
|---------------|---------------|--------------|--------------|-------------|
| CompoundAssign | 2            | **3**        | 1            | 0           |
| WhileLoop     | 5             | **6**        | 2            | 0           |
| All others    | unchanged     | unchanged    | unchanged    | 0           |

- `t26_compound_add_two.cx`: **SKIP → PASS** (primary target)
- One additional WhileLoop fixture also benefited from the same fix (also uses untyped variable with `print`)
- PARITY_FAIL = 0 across all 16 feature categories

## Linear ticket reference

CX-152: https://linear.app/cx-lang/issue/CX-152/fix-varref-lowering-to-handle-numericunknown-typed-variables-via

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of placeholder types in variable assignments and references for more robust type processing.

* **Tests**
  * Added unit tests to verify correct behavior of placeholder type handling in variable operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/195)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->