### PR TITLE
CX-153: Add narrow integer (t8/t16/t32) argument widening to print/println intrinsic dispatch

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -102,20 +102,21 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-141` (submain as of CX-141 merge window, 2026-05-12).
+Run on branch `stokowski/CX-153` (submain as of CX-153 merge window, 2026-05-13).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
 CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
 exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
 (t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
 CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), and CX-136 print/println intrinsic
-dispatch to cx_printn.
+(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
+dispatch to cx_printn, and CX-153 narrow integer (t8/t16/t32) argument widening
+for print/println/printn.
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
 ------------------------------------------------
-Arithmetic                8      9            0
+Arithmetic               11      6            0
 VariableDecl              5      3            0
 IfElse                    4      2            0
 WhileLoop                 5      3            0
@@ -125,12 +126,12 @@ DirectCall                7      4            0
 Struct                    6      5            0
 Array                     3      2            0
 CompoundAssign            2      2            0
-Unary                     0      1            0
+Unary                     1      0            0
 Cast                      0      2            0
 FloatOps                  0      5            0
 BuiltinAssert             2      2            0
 LogicalOps                2      0            0
-Other                    16     48            0
+Other                    17     47            0
 ------------------------------------------------
 Total: 155 fixtures, 0 PARITY_FAILs
 ```
@@ -145,7 +146,8 @@ Total: 155 fixtures, 0 PARITY_FAILs
   their correctness is verified by exit code 0.
 - **Output-verified fixtures** whose `print` calls were previously SKIP are
   now PASS following CX-136 print/println dispatch to `cx_printn` for i64
-  arguments.
+  arguments, and CX-153 narrow integer widening (t8/t16/t32 → i64) for
+  print/println/printn.
 - A small number of **pass-any fixtures** where the JIT happened to compile
   and execute successfully (no stderr error, exit 0) also appear as PASS.
 

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -4658,6 +4658,143 @@ mod determinism_tests {
         assert!(result.unwrap().exit_code.is_success());
     }
 
+    // ── CX-153: narrow integer widening for cx_printn (t8/t16/t32 → I64) ────
+
+    #[test]
+    fn jit_cx_printn_i32_widens_to_i64() {
+        // Verifies that an I32 value widened to I64 via Cast can be passed to cx_printn.
+        //
+        // main() -> i32 {
+        //   v0 = 42i32
+        //   v1 = Cast(I32→I64, v0)
+        //   cx_printn(v1)
+        //   v2 = 0i32
+        //   return v2
+        // }
+        let module = IrModule {
+            debug_name: "test_cx_printn_i32_widen".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 42 },
+                        IrInst::Cast {
+                            dst: ValueId(1),
+                            from: IrType::I32,
+                            to: IrType::I64,
+                            value: ValueId(0),
+                        },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn".to_string(),
+                            args: vec![ValueId(1)],
+                            return_ty: None,
+                        },
+                        IrInst::ConstInt { dst: ValueId(2), ty: IrType::I32, value: 0 },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    #[test]
+    fn jit_cx_printn_i16_widens_to_i64() {
+        // Verifies that an I16 value widened to I64 via Cast can be passed to cx_printn.
+        //
+        // main() -> i32 {
+        //   v0 = 100i16
+        //   v1 = Cast(I16→I64, v0)
+        //   cx_printn(v1)
+        //   v2 = 0i32
+        //   return v2
+        // }
+        let module = IrModule {
+            debug_name: "test_cx_printn_i16_widen".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I16, value: 100 },
+                        IrInst::Cast {
+                            dst: ValueId(1),
+                            from: IrType::I16,
+                            to: IrType::I64,
+                            value: ValueId(0),
+                        },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn".to_string(),
+                            args: vec![ValueId(1)],
+                            return_ty: None,
+                        },
+                        IrInst::ConstInt { dst: ValueId(2), ty: IrType::I32, value: 0 },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    #[test]
+    fn jit_cx_printn_i8_widens_to_i64() {
+        // Verifies that an I8 value widened to I64 via Cast can be passed to cx_printn.
+        //
+        // main() -> i32 {
+        //   v0 = 7i8
+        //   v1 = Cast(I8→I64, v0)
+        //   cx_printn(v1)
+        //   v2 = 0i32
+        //   return v2
+        // }
+        let module = IrModule {
+            debug_name: "test_cx_printn_i8_widen".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I8, value: 7 },
+                        IrInst::Cast {
+                            dst: ValueId(1),
+                            from: IrType::I8,
+                            to: IrType::I64,
+                            value: ValueId(0),
+                        },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn".to_string(),
+                            args: vec![ValueId(1)],
+                            return_ty: None,
+                        },
+                        IrInst::ConstInt { dst: ValueId(2), ty: IrType::I32, value: 0 },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
     // ── CX-91: F64 binary arithmetic ─────────────────────────────────────────
 
     #[test]

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -80,8 +80,8 @@ impl std::error::Error for LoweringError {}
 //
 //   Category          | Builtins          | Status
 //   ──────────────────┼───────────────────┼──────────────────────────────────
-//   I/O (stdout)      | print, println    | LOWERABLE (I64 only) — routes to cx_printn
-//   I/O (stdout)      | printn            | LOWERABLE — see lower_printn_stmt
+//   I/O (stdout)      | print, println    | LOWERABLE (I8/I16/I32/I64; narrow ints widened) — routes to cx_printn
+//   I/O (stdout)      | printn            | LOWERABLE (I8/I16/I32/I64; narrow ints widened) — see lower_printn_stmt
 //   I/O (stdin)       | read, input       | blocked on Phase 8 str layout
 //   Debug / assertion | assert, assert_eq | LOWERABLE — Phase 9 sub-packet 3
 //
@@ -2674,7 +2674,8 @@ fn ensure_type_match(context: &str, expected: IrType, got: IrType) -> Result<(),
 /// it lowers to a call to the `cx_printn` runtime intrinsic, which is pre-declared
 /// in the JIT module as an imported C-ABI symbol.
 ///
-/// Only `I64` arguments are accepted; other types produce a structured error.
+/// Narrow integer arguments (I8, I16, I32) are widened to I64 via a `Cast` instruction
+/// before the call.  Non-integer types produce a structured error.
 fn lower_printn_stmt(
     args: &[SemanticCallArg],
     ctx: &mut LoweringCtx,
@@ -2694,18 +2695,33 @@ fn lower_printn_stmt(
         }
     };
     let arg = lower_expr(arg_expr, ctx, &mut current)?;
-    if arg.ty != IrType::I64 {
-        return Err(LoweringError::UnsupportedSemanticConstruct {
-            construct: format!(
-                "printn argument must be I64, got {:?} — other types not yet supported",
-                arg.ty
-            ),
-        });
-    }
+    let arg_val = arg.value;
+    let arg_ty = arg.ty;
+    let arg_i64 = match arg_ty {
+        IrType::I64 => arg_val,
+        IrType::I8 | IrType::I16 | IrType::I32 => {
+            let cast_dst = ctx.fresh_value();
+            current.emit(IrInst::Cast {
+                dst: cast_dst,
+                from: arg_ty,
+                to: IrType::I64,
+                value: arg_val,
+            })?;
+            cast_dst
+        }
+        _ => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: format!(
+                    "printn argument must be an integer type, got {:?}",
+                    arg_ty
+                ),
+            });
+        }
+    };
     current.emit(IrInst::Call {
         dst: None,
         callee: "cx_printn".to_string(),
-        args: vec![arg.value],
+        args: vec![arg_i64],
         return_ty: None,
     })?;
     Ok(Some(current))
@@ -2713,10 +2729,11 @@ fn lower_printn_stmt(
 
 /// Lower `print(n)` or `println(n)` to `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
 ///
-/// Both `print` and `println` in Cx print a value followed by a newline.  For I64
+/// Both `print` and `println` in Cx print a value followed by a newline.  For integer
 /// arguments this maps to the `cx_printn` runtime intrinsic which is already registered
-/// in the JIT symbol table.  Non-I64 arguments (e.g. strings) produce a structured
-/// error because string printing requires string ABI support not yet available.
+/// in the JIT symbol table.  Narrow integer arguments (I8, I16, I32) are widened to I64
+/// via a `Cast` instruction before the call.  Non-integer types (e.g. strings) produce a
+/// structured error because string printing requires string ABI support not yet available.
 fn lower_print_stmt(
     builtin_name: &str,
     args: &[SemanticCallArg],
@@ -2737,18 +2754,33 @@ fn lower_print_stmt(
         }
     };
     let arg = lower_expr(arg_expr, ctx, &mut current)?;
-    if arg.ty != IrType::I64 {
-        return Err(LoweringError::UnsupportedSemanticConstruct {
-            construct: format!(
-                "{} argument must be I64, got {:?} — string and other types not yet supported",
-                builtin_name, arg.ty
-            ),
-        });
-    }
+    let arg_val = arg.value;
+    let arg_ty = arg.ty;
+    let arg_i64 = match arg_ty {
+        IrType::I64 => arg_val,
+        IrType::I8 | IrType::I16 | IrType::I32 => {
+            let cast_dst = ctx.fresh_value();
+            current.emit(IrInst::Cast {
+                dst: cast_dst,
+                from: arg_ty,
+                to: IrType::I64,
+                value: arg_val,
+            })?;
+            cast_dst
+        }
+        _ => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: format!(
+                    "{} argument must be an integer type, got {:?}",
+                    builtin_name, arg_ty
+                ),
+            });
+        }
+    };
     current.emit(IrInst::Call {
         dst: None,
         callee: "cx_printn".to_string(),
-        args: vec![arg.value],
+        args: vec![arg_i64],
         return_ty: None,
     })?;
     Ok(Some(current))
@@ -5926,8 +5958,8 @@ mod tests {
     }
 
     #[test]
-    fn print_non_i64_arg_returns_unsupported_construct() {
-        // print with an I32 argument must return UnsupportedSemanticConstruct.
+    fn print_i32_arg_widens_to_i64() {
+        // print(42i32) must emit Cast{I32→I64} then Call{cx_printn} — CX-153.
         let program = SemanticProgram {
             stmts: vec![builtin_stmt(
                 "print",
@@ -5935,14 +5967,106 @@ mod tests {
             )],
             enums: vec![],
         };
-        let err = lower_program(&program).expect_err("lowering should fail for non-I64 print arg");
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let insts: Vec<_> = main_fn.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+        let has_cast = insts.iter().any(|inst| {
+            matches!(inst, IrInst::Cast { from: IrType::I32, to: IrType::I64, .. })
+        });
+        assert!(has_cast, "expected Cast{{I32→I64}} for i32 print arg");
+        let cx_printn_calls: Vec<_> = insts
+            .iter()
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn"))
+            .collect();
+        assert_eq!(cx_printn_calls.len(), 1, "expected exactly one cx_printn call");
+    }
+
+    #[test]
+    fn print_i16_arg_widens_to_i64() {
+        // print(42i16) must emit Cast{I16→I64} then Call{cx_printn} — CX-153.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "print",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I16))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let insts: Vec<_> = main_fn.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+        let has_cast = insts.iter().any(|inst| {
+            matches!(inst, IrInst::Cast { from: IrType::I16, to: IrType::I64, .. })
+        });
+        assert!(has_cast, "expected Cast{{I16→I64}} for i16 print arg");
+        let cx_printn_calls: Vec<_> = insts
+            .iter()
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn"))
+            .collect();
+        assert_eq!(cx_printn_calls.len(), 1, "expected exactly one cx_printn call");
+    }
+
+    #[test]
+    fn print_i8_arg_widens_to_i64() {
+        // print(42i8) must emit Cast{I8→I64} then Call{cx_printn} — CX-153.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "print",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I8))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let insts: Vec<_> = main_fn.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+        let has_cast = insts.iter().any(|inst| {
+            matches!(inst, IrInst::Cast { from: IrType::I8, to: IrType::I64, .. })
+        });
+        assert!(has_cast, "expected Cast{{I8→I64}} for i8 print arg");
+        let cx_printn_calls: Vec<_> = insts
+            .iter()
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn"))
+            .collect();
+        assert_eq!(cx_printn_calls.len(), 1, "expected exactly one cx_printn call");
+    }
+
+    #[test]
+    fn println_i32_arg_widens_to_i64() {
+        // println(42i32) must also widen I32→I64 — CX-153.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "println",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I32))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let insts: Vec<_> = main_fn.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+        let has_cast = insts.iter().any(|inst| {
+            matches!(inst, IrInst::Cast { from: IrType::I32, to: IrType::I64, .. })
+        });
+        assert!(has_cast, "expected Cast{{I32→I64}} for i32 println arg");
+        let cx_printn_calls: Vec<_> = insts
+            .iter()
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn"))
+            .collect();
+        assert_eq!(cx_printn_calls.len(), 1, "expected exactly one cx_printn call");
+    }
+
+    #[test]
+    fn print_non_integer_arg_returns_unsupported_construct() {
+        // print with a Bool argument must still return UnsupportedSemanticConstruct.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "print",
+                vec![SemanticCallArg::Expr(bool_expr(true))],
+            )],
+            enums: vec![],
+        };
+        let err = lower_program(&program).expect_err("lowering should fail for bool print arg");
         assert!(
-            matches!(
-                &err,
-                LoweringError::UnsupportedSemanticConstruct { construct }
-                if construct.contains("I64")
-            ),
-            "expected UnsupportedSemanticConstruct mentioning I64, got: {:?}",
+            matches!(&err, LoweringError::UnsupportedSemanticConstruct { .. }),
+            "expected UnsupportedSemanticConstruct for bool print arg, got: {:?}",
             err
         );
     }
@@ -5978,8 +6102,8 @@ mod tests {
     }
 
     #[test]
-    fn printn_with_non_i64_arg_returns_error() {
-        // printn with an I32 argument must return UnsupportedSemanticConstruct.
+    fn printn_i32_arg_widens_to_i64() {
+        // printn(42i32) must emit Cast{I32→I64} then Call{cx_printn} — CX-153.
         let program = SemanticProgram {
             stmts: vec![builtin_stmt(
                 "printn",
@@ -5987,14 +6111,82 @@ mod tests {
             )],
             enums: vec![],
         };
-        let err = lower_program(&program).expect_err("lowering should fail for non-I64 printn arg");
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let insts: Vec<_> = main_fn.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+        let has_cast = insts.iter().any(|inst| {
+            matches!(inst, IrInst::Cast { from: IrType::I32, to: IrType::I64, .. })
+        });
+        assert!(has_cast, "expected Cast{{I32→I64}} for i32 printn arg");
+        let cx_printn_calls: Vec<_> = insts
+            .iter()
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn"))
+            .collect();
+        assert_eq!(cx_printn_calls.len(), 1, "expected exactly one cx_printn call");
+    }
+
+    #[test]
+    fn printn_i16_arg_widens_to_i64() {
+        // printn(42i16) must emit Cast{I16→I64} then Call{cx_printn} — CX-153.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "printn",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I16))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let insts: Vec<_> = main_fn.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+        let has_cast = insts.iter().any(|inst| {
+            matches!(inst, IrInst::Cast { from: IrType::I16, to: IrType::I64, .. })
+        });
+        assert!(has_cast, "expected Cast{{I16→I64}} for i16 printn arg");
+        let cx_printn_calls: Vec<_> = insts
+            .iter()
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn"))
+            .collect();
+        assert_eq!(cx_printn_calls.len(), 1, "expected exactly one cx_printn call");
+    }
+
+    #[test]
+    fn printn_i8_arg_widens_to_i64() {
+        // printn(42i8) must emit Cast{I8→I64} then Call{cx_printn} — CX-153.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "printn",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I8))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let insts: Vec<_> = main_fn.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+        let has_cast = insts.iter().any(|inst| {
+            matches!(inst, IrInst::Cast { from: IrType::I8, to: IrType::I64, .. })
+        });
+        assert!(has_cast, "expected Cast{{I8→I64}} for i8 printn arg");
+        let cx_printn_calls: Vec<_> = insts
+            .iter()
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn"))
+            .collect();
+        assert_eq!(cx_printn_calls.len(), 1, "expected exactly one cx_printn call");
+    }
+
+    #[test]
+    fn printn_non_integer_arg_returns_unsupported_construct() {
+        // printn with a Bool argument must still return UnsupportedSemanticConstruct.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "printn",
+                vec![SemanticCallArg::Expr(bool_expr(true))],
+            )],
+            enums: vec![],
+        };
+        let err = lower_program(&program).expect_err("lowering should fail for bool printn arg");
         assert!(
-            matches!(
-                &err,
-                LoweringError::UnsupportedSemanticConstruct { construct }
-                if construct.contains("I64")
-            ),
-            "expected UnsupportedSemanticConstruct mentioning I64, got: {:?}",
+            matches!(&err, LoweringError::UnsupportedSemanticConstruct { .. }),
+            "expected UnsupportedSemanticConstruct for bool printn arg, got: {:?}",
             err
         );
     }


### PR DESCRIPTION
Closes CX-153

## Summary

- `lower_printn_stmt` and `lower_print_stmt` in `src/ir/lower.rs` now accept I8/I16/I32 arguments by emitting `IrInst::Cast { from: I8/I16/I32, to: I64 }` before the `cx_printn` call
- Non-integer types (Bool, F64, Str, etc.) still produce `UnsupportedSemanticConstruct`
- The `cx_printn` runtime signature and JIT Cast codegen are unchanged — the widening reuses the existing Cast infrastructure already used for array index widening

## Files changed

- `src/ir/lower.rs` — core widening logic in both lowering functions; replaced two "expects I32 to fail" tests with widening success tests; added I8/I16/I32 widening tests for print/println/printn; added non-integer rejection tests
- `src/backend/cranelift/host_boundary.rs` — three new JIT-level tests: `jit_cx_printn_i32_widens_to_i64`, `jit_cx_printn_i16_widens_to_i64`, `jit_cx_printn_i8_widens_to_i64`
- `docs/backend/cx_jit_parity_checklist.md` — updated baseline to reflect 5 newly-passing fixtures (Arithmetic +3, Unary +1, Other +1)

## Validation

```
cargo build --features jit   → ok (20 pre-existing warnings, no new)
cargo test --features jit    → 331 passed; 0 failed
```

Parity gate: 0 PARITY_FAILs. Five fixtures previously SKIP (using t8/t16/t32 in print calls) now PASS.

## Linear ticket

https://linear.app/cx-lang/issue/CX-153/add-narrow-integer-t8t16t32-argument-widening-to-printprintln

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced print and println functions to support 8, 16, and 32-bit integer types, with automatic widening to 64-bit for processing.

* **Tests**
  * Added JIT tests to verify correct handling of smaller integer types in print operations.

* **Documentation**
  * Updated parity checklist with baseline metadata reflecting expanded integer type coverage in test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/196)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->