### PR TITLE
CX-155: Add bool argument support to print/println intrinsic dispatch

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -275,6 +275,18 @@ extern "C" fn cx_printn(n: i64) {
     let _ = writeln!(stdout, "{n}");
 }
 
+/// Runtime intrinsic: print a boolean value to stdout followed by a newline.
+///
+/// Exported as `cx_printb` in the JIT symbol table. JIT-compiled Cx code calls
+/// this via `IrInst::Call { callee: "cx_printb", args: [i8_value] }`.
+/// `b == 0` prints `"false"`, `b == 1` prints `"true"`.
+extern "C" fn cx_printb(b: i8) {
+    use std::io::{self, Write};
+    let mut stdout = io::stdout().lock();
+    let s = if b == 0 { "false" } else { "true" };
+    let _ = writeln!(stdout, "{s}");
+}
+
 /// Backend-private symbol name for the F64 remainder host helper.
 ///
 /// Using a mangled name (double-underscore prefix) keeps it out of the user-visible namespace.
@@ -340,6 +352,7 @@ impl HostBoundary {
         let mut jit_builder =
             JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
         jit_builder.symbol("cx_printn", cx_printn as *const u8);
+        jit_builder.symbol("cx_printb", cx_printb as *const u8);
         jit_builder.symbol(JIT_F64_REM_SYMBOL, host_fmod as *const u8);
         let mut module = JITModule::new(jit_builder);
 
@@ -360,6 +373,20 @@ impl HostBoundary {
                     detail: e.to_string(),
                 })?;
             func_id_map.insert("cx_printn".to_string(), id);
+        }
+
+        // Pre-declare cx_printb(i8) -> void for Bool print lowering (CX-155).
+        {
+            use cranelift_codegen::ir::{AbiParam, types};
+            let call_conv = module.target_config().default_call_conv;
+            let mut sig = cranelift_codegen::ir::Signature::new(call_conv);
+            sig.params.push(AbiParam::new(types::I8));
+            let id = module
+                .declare_function("cx_printb", Linkage::Import, &sig)
+                .map_err(|e| JitExecutionError::CodegenFailure {
+                    detail: e.to_string(),
+                })?;
+            func_id_map.insert("cx_printb".to_string(), id);
         }
 
         // Pre-declare __cx_fmod(f64, f64) -> f64 for F64 Rem lowering.

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -361,7 +361,7 @@ pub fn lower_program(program: &SemanticProgram) -> Result<IrModule, LoweringErro
 }
 
 fn lower_program_inner(program: &SemanticProgram, trace: bool) -> Result<IrModule, LoweringError> {
-    const RESERVED_RUNTIME_INTRINSICS: &[&str] = &["cx_printn"];
+    const RESERVED_RUNTIME_INTRINSICS: &[&str] = &["cx_printn", "cx_printb"];
 
     if program.stmts.is_empty() {
         return Ok(IrModule {
@@ -2711,12 +2711,15 @@ fn lower_printn_stmt(
     Ok(Some(current))
 }
 
-/// Lower `print(n)` or `println(n)` to `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
+/// Lower `print(n)` or `println(n)` to a runtime intrinsic call.
 ///
-/// Both `print` and `println` in Cx print a value followed by a newline.  For I64
-/// arguments this maps to the `cx_printn` runtime intrinsic which is already registered
-/// in the JIT symbol table.  Non-I64 arguments (e.g. strings) produce a structured
-/// error because string printing requires string ABI support not yet available.
+/// Both `print` and `println` in Cx print a value followed by a newline.
+///
+/// Dispatch table:
+/// - `I64`  → `cx_printn(i64)` — pre-existing integer intrinsic
+/// - `Bool` → `cx_printb(i8)`  — CX-155 boolean intrinsic ("false"/"true")
+///
+/// Other argument types produce a structured error.
 fn lower_print_stmt(
     builtin_name: &str,
     args: &[SemanticCallArg],
@@ -2737,17 +2740,21 @@ fn lower_print_stmt(
         }
     };
     let arg = lower_expr(arg_expr, ctx, &mut current)?;
-    if arg.ty != IrType::I64 {
-        return Err(LoweringError::UnsupportedSemanticConstruct {
-            construct: format!(
-                "{} argument must be I64, got {:?} — string and other types not yet supported",
-                builtin_name, arg.ty
-            ),
-        });
-    }
+    let callee = match arg.ty {
+        IrType::I64 => "cx_printn",
+        IrType::Bool => "cx_printb",
+        _ => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: format!(
+                    "{} argument must be I64 or Bool, got {:?} — string and other types not yet supported",
+                    builtin_name, arg.ty
+                ),
+            });
+        }
+    };
     current.emit(IrInst::Call {
         dst: None,
-        callee: "cx_printn".to_string(),
+        callee: callee.to_string(),
         args: vec![arg.value],
         return_ty: None,
     })?;
@@ -5997,6 +6004,78 @@ mod tests {
             "expected UnsupportedSemanticConstruct mentioning I64, got: {:?}",
             err
         );
+    }
+
+    #[test]
+    fn print_bool_true_lowers_to_cx_printb_call() {
+        // print(true) must lower to IrInst::Call{callee:"cx_printb"} and pass validation.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "print",
+                vec![SemanticCallArg::Expr(bool_expr(true))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let printb_calls: Vec<_> = main_fn
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printb"))
+            .collect();
+        assert_eq!(printb_calls.len(), 1, "expected exactly one cx_printb call from print(true)");
+        match printb_calls[0] {
+            IrInst::Call { dst, callee, args, return_ty } => {
+                assert!(dst.is_none(), "cx_printb is void — no destination");
+                assert_eq!(callee, "cx_printb");
+                assert_eq!(args.len(), 1, "cx_printb takes one argument");
+                assert!(return_ty.is_none(), "cx_printb returns void");
+            }
+            _ => panic!("expected Call instruction"),
+        }
+    }
+
+    #[test]
+    fn print_bool_false_lowers_to_cx_printb_call() {
+        // print(false) must lower to IrInst::Call{callee:"cx_printb"} and pass validation.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "print",
+                vec![SemanticCallArg::Expr(bool_expr(false))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let printb_calls: Vec<_> = main_fn
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printb"))
+            .collect();
+        assert_eq!(printb_calls.len(), 1, "expected exactly one cx_printb call from print(false)");
+    }
+
+    #[test]
+    fn println_bool_lowers_to_cx_printb_call() {
+        // println(true) must lower to IrInst::Call{callee:"cx_printb"} and pass validation.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "println",
+                vec![SemanticCallArg::Expr(bool_expr(true))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let printb_calls: Vec<_> = main_fn
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printb"))
+            .collect();
+        assert_eq!(printb_calls.len(), 1, "expected exactly one cx_printb call from println(bool)");
     }
 
     // assert and assert_eq are now lowerable (Phase 9 sub-packet 3) so they no

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -83,6 +83,15 @@ fn known_intrinsic_sigs() -> HashMap<String, ValidatorFunctionSig> {
             has_return: false,
         },
     );
+    // cx_printb(b: Bool) -> void — CX-155 print-boolean intrinsic ("false"/"true").
+    sigs.insert(
+        "cx_printb".to_string(),
+        ValidatorFunctionSig {
+            param_count: 1,
+            param_types: vec![IrType::Bool],
+            has_return: false,
+        },
+    );
     sigs
 }
 


### PR DESCRIPTION
Closes CX-155

## Summary

- Add `cx_printb(b: i8)` host intrinsic that prints `"false"` or `"true"` followed by a newline
- Wire `print(bool)` and `println(bool)` in `lower_print_stmt` to dispatch to `cx_printb` instead of returning `UnsupportedSemanticConstruct`
- Register `cx_printb` in the JIT symbol table, pre-declare with I8 ABI param, and add to validator's known intrinsic sigs
- Add `"cx_printb"` to `RESERVED_RUNTIME_INTRINSICS` to prevent user-defined functions from shadowing it

## Files changed

- `src/ir/lower.rs` — `lower_print_stmt`: add `IrType::Bool` dispatch arm; add `"cx_printb"` to reserved list; add 3 new lowering tests
- `src/backend/cranelift/host_boundary.rs` — `cx_printb` C-ABI function; JIT symbol registration; JIT module pre-declaration
- `src/ir/validate.rs` — `known_intrinsic_sigs`: register `cx_printb(Bool) -> void`

## Design decisions

- Only `IrType::Bool` is handled; `IrType::TBool` (3-valued ternary bool) is deferred — a separate ticket can wire TBool when that path is needed
- The Bool value is passed directly to `cx_printb` (no cast) since `IrType::Bool` already maps to `types::I8` in Cranelift
- The existing error message for unsupported types now reads "I64 or Bool" — still contains "I64" so the existing `print_non_i64_arg_returns_unsupported_construct` test continues to pass

## Tests run

```
cargo build --features jit
cargo test --features jit
```

## Validation results

```
test result: ok. 324 passed; 0 failed; 0 ignored; 0 measured
```

JIT parity (0 PARITY_FAILs):

```
Feature                PASS   SKIP  PARITY_FAIL
------------------------------------------------
Arithmetic               10      7            0
...
Other                    16     48            0
------------------------------------------------
Total: 155 fixtures, 0 PARITY_FAILs
```

Arithmetic PASS count increased from 8 → 10 as fixtures using `print(bool expr)` (e.g. t01 `print(true == false)`) now execute successfully through the JIT.

## Linear ticket

CX-155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boolean values can now be printed using `print()` and `println()` functions, displaying as `"true"` or `"false"` as appropriate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/198)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->