### PR TITLE
CX-156: Add exit-code-based JIT parity fixtures for Unary operations

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -28,7 +28,7 @@ set:
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 (output-verified); t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit (exit-code-verified, CX-121) |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151 |
-| Unary          | Unary operators (negation, etc.)             | t96 |
+| Unary          | Unary operators (negation, etc.)             | t96; t152_unary_neg_int_exit, t153_unary_not_bool_exit (exit-code-verified, CX-156) |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |
 | BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
@@ -102,15 +102,16 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-141` (submain as of CX-141 merge window, 2026-05-12).
+Run on branch `stokowski/CX-156` (submain as of CX-156 merge window, 2026-05-13).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
 CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
 exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
 (t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
 CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), and CX-136 print/println intrinsic
-dispatch to cx_printn.
+(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
+dispatch to cx_printn, and CX-156 Unary exit-code fixtures
+(t152_unary_neg_int_exit, t153_unary_not_bool_exit).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -125,14 +126,14 @@ DirectCall                7      4            0
 Struct                    6      5            0
 Array                     3      2            0
 CompoundAssign            2      2            0
-Unary                     0      1            0
+Unary                     2      1            0
 Cast                      0      2            0
 FloatOps                  0      5            0
 BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    16     48            0
 ------------------------------------------------
-Total: 155 fixtures, 0 PARITY_FAILs
+Total: 157 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -151,7 +152,7 @@ Total: 155 fixtures, 0 PARITY_FAILs
 
 **SKIP fixtures** are those where IR lowering or JIT codegen has not yet been
 implemented for the construct used. The primary remaining gaps are constructs
-not yet JIT-lowerable (when-blocks, float ops, casts, unary, enums, generics,
+not yet JIT-lowerable (when-blocks, float ops, casts, enums, generics,
 handles, and other Phase 14+ constructs). As subsequent phases land, SKIP
 counts will continue to decrease and PASS counts will increase.
 
@@ -195,6 +196,15 @@ element read/write, and array passing through function calls. The 3 PASS reflect
 fixtures passing via the CX-121 ArrayAlloca JIT emit (`IrInst::ArrayAlloca` lowered to
 Cranelift via `compute_array_layout`). The 2 SKIP are t33 and t112 (print-based originals
 that remain SKIP).
+
+**Unary parity coverage (CX-156):** t152_unary_neg_int_exit covers unary integer negation
+(`-a` where a: t64), verifying via arithmetic round-trip (neg + original = 0), negation of
+zero, and double negation. t153_unary_not_bool_exit covers unary boolean NOT (`!p`, `!q`)
+via if-branch result patterns and negation of a comparison expression (`!(x == 5)`). Both
+fixtures PASS because the IR lowers unary minus as `0 - x` (binary Sub) and unary not as
+`x == 0` (Compare/Eq), constructs the JIT already handles. The 1 remaining SKIP is t96
+(print-based, remains SKIP until t8 print dispatch is implemented). Unary now has 2 PASS,
+up from 0.
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -233,6 +233,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
 
         // ── Unary ─────────────────────────────────────────────────────────────
         "t96_overflow_t8_unary_neg"
+        | "t152_unary_neg_int_exit"
+        | "t153_unary_not_bool_exit"
             => FeatureCategory::Unary,
 
         // ── Cast ─────────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t152_unary_neg_int_exit.cx
+++ b/src/tests/verification_matrix/t152_unary_neg_int_exit.cx
@@ -1,0 +1,12 @@
+// CX-156: exit-code-based JIT parity — unary integer negation.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+a: t64 = 7
+neg_a: t64 = -a
+assert_eq(neg_a + a, 0)
+
+b: t64 = 0
+assert_eq(-b, 0)
+
+c: t64 = 10
+double_neg: t64 = -(-c)
+assert_eq(double_neg, c)

--- a/src/tests/verification_matrix/t153_unary_not_bool_exit.cx
+++ b/src/tests/verification_matrix/t153_unary_not_bool_exit.cx
@@ -1,0 +1,17 @@
+// CX-156: exit-code-based JIT parity — unary boolean NOT.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+p: bool = false
+q: bool = true
+result: t64 = 0
+
+if !p { result = 1 } else { result = 0 }
+assert_eq(result, 1)
+
+result = 0
+if !q { result = 0 } else { result = 2 }
+assert_eq(result, 2)
+
+x: t64 = 10
+result = 0
+if !(x == 5) { result = 3 } else { result = 0 }
+assert_eq(result, 3)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-156/cx-156-add-exit-code-based-jit-parity-fixtures-for-unary-operations

## Summary

- Add `t152_unary_neg_int_exit.cx`: exit-code-verified fixture for unary integer negation (`-x` on t64), covering negation of a positive value (round-trip assert), negation of zero, and double negation.
- Add `t153_unary_not_bool_exit.cx`: exit-code-verified fixture for unary boolean NOT (`!x`), covering `!false`, `!true`, and `!(expr == val)`.
- Register both fixtures under `FeatureCategory::Unary` in `feature_of()` in `src/diff_harness.rs`.
- Update `docs/backend/cx_jit_parity_checklist.md`: Section 1 table, Section 3 baseline, and interpretation paragraph.

## Files Changed

- `src/tests/verification_matrix/t152_unary_neg_int_exit.cx` (new)
- `src/tests/verification_matrix/t153_unary_not_bool_exit.cx` (new)
- `src/diff_harness.rs` — added t152 and t153 to the Unary arm of `feature_of()`
- `docs/backend/cx_jit_parity_checklist.md` — updated baseline and interpretation

## Outcome

Both new fixtures **PASS** immediately. The IR lowers unary minus as `0 - x` (binary Sub) and unary not as `x == 0` (Compare/Eq), constructs the JIT already handles. Unary PASS count moves from 0 → 2.

## Tests Run

```
cargo build --features jit
cargo test --features jit
```

## Validation Results

```
Feature                PASS   SKIP  PARITY_FAIL
------------------------------------------------
Unary                     2      1            0
...
Total: 157 fixtures, 0 PARITY_FAILs

test result: ok. 321 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Known Limitations

t96_overflow_t8_unary_neg remains SKIP (print-based, t8 print dispatch not yet implemented). The 1 SKIP in Unary is that fixture.

## Linear Ticket

CX-156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new verification tests for unary integer negation and boolean NOT operations.

* **Documentation**
  * Updated JIT parity checklist with Phase 12 baseline results and expanded unary operation feature coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/199)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->