### PR TITLE
CX-157: Document unknown propagation strategy as explicitly post-0.1 in cx_abi_v0.1.md

### DIFF
--- a/docs/backend/cx_abi_v0.1.md
+++ b/docs/backend/cx_abi_v0.1.md
@@ -73,10 +73,15 @@ Three-state value: true (1), false (0), unknown (2).
 - TBool function parameters: LOCKED. Follows C ABI treating TBool as I8. Passed in the same integer registers as Bool (RDI/RSI/RDX/RCX/R8/R9 on Linux x64; RCX/RDX/R8/R9 on Windows x64). Values 0/1/2 are preserved across the call boundary without padding or encoding. Zero-extended when widened to a larger integer type (Cast TBool → I32 uses `uextend`, not `sextend`).
 - JIT validation: all three TBool wire values (0 = false, 1 = true, 2 = unknown) round-trip correctly through JIT-compiled function calls (confirmed by CX-127 tests in `host_boundary.rs`).
 
-**Post-0.1 deferred items:**
-- Unknown propagation strategy — does unknown checking happen in IR instructions or as runtime intrinsic calls? This decision gates when-block lowering and unknown-infected arithmetic.
-- Arithmetic on unknown-infected values: propagation cost and mechanism. Blocked on unknown propagation strategy.
-- When-block lowering: TBool three-way branching requires two nested Branch instructions since IR Branch is two-way only. Design work needed before implementation.
+### Unknown Propagation Strategy — POST-0.1
+
+Deferred to post-0.1. The mechanism for propagating `unknown` through expressions is not specified for the compiled backend. The interpreter handles tbool via in-memory value representation; the compiled backend requires an explicit policy before unknown-infected operations can be lowered.
+
+Open question: does unknown checking happen in IR instructions (each arithmetic/comparison op checks its operands for `unknown`) or via runtime intrinsic calls (a helper is invoked when an operand may be `unknown`)?
+
+This decision gates two further items, also deferred to post-0.1:
+- **Arithmetic on unknown-infected values** — propagation cost and mechanism cannot be finalized until propagation strategy is chosen.
+- **When-block lowering** — TBool three-way branching requires two nested Branch instructions since IR Branch is two-way only. Design work is blocked on the propagation strategy.
 
 ### String Layout — OPEN
 - `str` at C boundary is `(*const u8, u32)` — pointer + length, no null termination. LOCKED per frontend dev.


### PR DESCRIPTION
Closes CX-157

## Summary

- Promotes the unknown propagation strategy from an informal bullet point inside the TBool LOCKED section to a dedicated named subsection `### Unknown Propagation Strategy — POST-0.1`
- The new section follows the same explicit pattern used by `### Copy Param Bleed-Back — POST-0.1`
- Retains all existing content: the open question about IR-instruction vs. runtime-intrinsic strategy, and the two downstream blocked items (arithmetic on unknown-infected values, when-block lowering)

## Files Changed

- `docs/backend/cx_abi_v0.1.md`

## Validation

```
cargo build --features jit   → Finished (warnings only, 0 errors)
cargo test --features jit    → test result: ok. 321 passed; 0 failed; 0 ignored
```

## Linear Ticket

CX-157: https://linear.app/cx-lang/issue/CX-157/document-unknown-propagation-strategy-as-explicitly-post-01-in-cx-abi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced backend ABI specification with comprehensive documentation of unknown value propagation strategy. Documents deferred architectural decisions regarding validation mechanisms and explicitly clarifies how these design decisions impact the roadmap, including planned enhancements for arithmetic operations on unknown-infected values and multi-way conditional block lowering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/200)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->