### PR TITLE
CX-159: Add CompoundAssign lowering for DotAccess and Index lvalue targets

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -27,7 +27,7 @@ set:
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 (output-verified); t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit (exit-code-verified, CX-121) |
-| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151 |
+| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151, t152, t153 |
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |
@@ -102,15 +102,17 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-141` (submain as of CX-141 merge window, 2026-05-12).
+Run on branch `stokowski/CX-159` (submain as of CX-159 merge window, 2026-05-13).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
 CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
 exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
 (t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
 CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), and CX-136 print/println intrinsic
-dispatch to cx_printn.
+(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
+dispatch to cx_printn, and CX-159 CompoundAssign DotAccess/Index exit-code fixtures
+(t152_dotaccess_compound_assign_exit, t153_index_compound_assign_exit) including
+Index compound assign parser/semantic support (AssignTarget::Index).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -124,7 +126,7 @@ InfiniteLoop              2      1            0
 DirectCall                7      4            0
 Struct                    6      5            0
 Array                     3      2            0
-CompoundAssign            2      2            0
+CompoundAssign            4      2            0
 Unary                     0      1            0
 Cast                      0      2            0
 FloatOps                  0      5            0
@@ -132,7 +134,7 @@ BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    16     48            0
 ------------------------------------------------
-Total: 155 fixtures, 0 PARITY_FAILs
+Total: 157 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -179,8 +181,17 @@ operators (+=, -=, *=, /=, %=) on a typed t64 plain variable, verified by exit
 code. Fixed a semantic-analysis bug where the Var-target branch used
 `info.inferred` only (defaulting to `Unknown` for typed variables declared with an
 explicit type annotation) instead of `binding_type()` which checks `declared`
-first. The 2 PASS reflect t128 (struct field) and t151 (plain variable); the 2
-SKIP are t26 and t41 (print-based originals that remain SKIP).
+first.
+
+**CompoundAssign DotAccess/Index parity (CX-159):** t152 tests all five compound-assign
+operators on a t64 struct field (DotAccess target), verified by exit code. t153 tests
+all five operators on t64 array elements (Index target), verified by exit code. Index
+compound assign required adding `AssignTarget::Index(String, Expr)` to the AST,
+an `index_compound_assign` parser (mirroring `index_assign`), and semantic analysis
+for the new variant; the IR lowering and Cranelift JIT codegen were already in place.
+The 4 PASS reflect t128 (struct field, single operator), t151 (plain variable, all
+five), t152 (struct field, all five), and t153 (array element, all five); the 2 SKIP
+are t26 and t41 (print-based originals that remain SKIP).
 
 **ForLoop parity coverage (CX-124/CX-136):** t149 mirrors t48 (top-level for loop at file scope),
 covering exclusive range (`0..5`), empty range (`3..3`, 0 iterations), and inclusive range

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -229,6 +229,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t41_compound_assign_dot"
         | "t128_struct_compound_assign_exit"
         | "t151_var_compound_assign_exit"
+        | "t152_dotaccess_compound_assign_exit"
+        | "t153_index_compound_assign_exit"
             => FeatureCategory::CompoundAssign,
 
         // ── Unary ─────────────────────────────────────────────────────────────

--- a/src/frontend/ast.rs
+++ b/src/frontend/ast.rs
@@ -120,6 +120,7 @@ pub struct WhenArm {
 pub enum AssignTarget {
     Var(String),
     Field(String, String), // container_name, field_name
+    Index(String, Expr),   // array_name, index_expr
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -955,6 +955,33 @@ Stmt::Break { .. } | Stmt::Continue { .. } => {
             })
             .boxed();
 
+        let index_compound_assign = ident
+            .clone()
+            .map_with(|name, e: &mut ParseExtra<'a, '_, I>| (name, e.span().start))
+            .then_ignore(just(Token::PunctColon))
+            .then_ignore(just(Token::PunctBracketOpen))
+            .then(expr.clone())
+            .then_ignore(just(Token::PunctBracketClose))
+            .then(choice((
+                just(Token::OpAdd).to(Op::Plus),
+                just(Token::OpSub).to(Op::Minus),
+                just(Token::OpMul).to(Op::Mul),
+                just(Token::OpDiv).to(Op::Div),
+                just(Token::OpMod).to(Op::Mod),
+            )))
+            .then_ignore(just(Token::OpAssign))
+            .then(expr.clone())
+            .then_ignore(semi.clone().or_not())
+            .map(|((((name, pos), idx_expr), op), operand)| {
+                Stmt::CompoundAssign {
+                    target: AssignTarget::Index(name, idx_expr),
+                    op,
+                    operand,
+                    pos,
+                }
+            })
+            .boxed();
+
         // Parse a single outer macro #[name] or #[name(args)]
         let single_outer_macro = just(Token::MacroOuterOpen)
             .ignore_then(select! { Token::Identifier(name) => name })
@@ -1011,6 +1038,7 @@ Stmt::Break { .. } | Stmt::Continue { .. } => {
                 ret.clone().map(|s| (s, true)),
                 typed_assign.clone().map(|s| (s, true)),
                 compound_assign.clone().map(|s| (s, true)),
+                index_compound_assign.clone().map(|s| (s, true)),
                 assign.clone().map(|s| (s, true)),
                 if_stmt.clone().map(|s| (s, true)),
                 while_in_stmt.clone().map(|s| (s, true)),
@@ -1200,6 +1228,7 @@ Stmt::Break { .. } | Stmt::Continue { .. } => {
             ret,
             typed_assign,
             compound_assign,
+            index_compound_assign,
             index_assign,
             assign,
             block,

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -838,6 +838,20 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                         };
                         SemanticLValue::DotAccess { binding, container: container.clone(), field: field.clone(), ty: field_ty, struct_name }
                     }
+                    AssignTarget::Index(name, index_expr) => {
+                        let sem_array = self.analyze_expr(&Expr::Ident(name.clone(), *pos))?;
+                        let elem_ty = match &sem_array.ty {
+                            SemanticType::Array(_, elem_ty) => *elem_ty.clone(),
+                            SemanticType::Unknown => SemanticType::Unknown,
+                            _ => return Err(sem_err!(*pos, "compound assign index target must be an array")),
+                        };
+                        let sem_index = self.analyze_expr(index_expr)?;
+                        SemanticLValue::Index {
+                            target: Box::new(sem_array),
+                            index: Box::new(sem_index),
+                            elem_ty,
+                        }
+                    }
                 };
                 Ok(SemanticStmt::CompoundAssign {
                     target: sem_target,

--- a/src/tests/verification_matrix/t152_dotaccess_compound_assign_exit.cx
+++ b/src/tests/verification_matrix/t152_dotaccess_compound_assign_exit.cx
@@ -1,0 +1,23 @@
+// CX-159: exit-code-based JIT parity — compound assign on a struct field.
+// Exercises all five compound-assign operators (+=, -=, *=, /=, %=) on a
+// t64 struct field. Correctness verified by exit code only (0 = all asserts held).
+struct Counter { score: t64 }
+c: Counter = Counter { score: 10 }
+c.score += 5
+assert_eq(c.score, 15)
+
+c.score = 20
+c.score -= 8
+assert_eq(c.score, 12)
+
+c.score = 6
+c.score *= 7
+assert_eq(c.score, 42)
+
+c.score = 100
+c.score /= 4
+assert_eq(c.score, 25)
+
+c.score = 17
+c.score %= 5
+assert_eq(c.score, 2)

--- a/src/tests/verification_matrix/t153_index_compound_assign_exit.cx
+++ b/src/tests/verification_matrix/t153_index_compound_assign_exit.cx
@@ -1,0 +1,18 @@
+// CX-159: exit-code-based JIT parity — compound assign on an array element.
+// Exercises all five compound-assign operators (+=, -=, *=, /=, %=) on
+// t64 array elements. Correctness verified by exit code only (0 = all asserts held).
+arr: [5: t64] = [10, 20, 6, 100, 17]
+arr:[0] += 5
+assert_eq(arr:[0], 15)
+
+arr:[1] -= 8
+assert_eq(arr:[1], 12)
+
+arr:[2] *= 7
+assert_eq(arr:[2], 42)
+
+arr:[3] /= 4
+assert_eq(arr:[3], 25)
+
+arr:[4] %= 5
+assert_eq(arr:[4], 2)


### PR DESCRIPTION
Closes CX-159

## Summary

- Adds `AssignTarget::Index(String, Expr)` to the AST so array element compound assign is representable at the syntax level (`arr:[i] += expr`)
- Adds `index_compound_assign` parser (mirrors `index_assign`), wired into both function-body and top-level statement parsers
- Adds semantic analysis for `AssignTarget::Index` → `SemanticLValue::Index` in `CompoundAssign`; the IR lowering and Cranelift JIT codegen paths were already complete
- Adds two exit-code-verified parity fixtures: t152 (DotAccess, all 5 operators on struct field) and t153 (Index, all 5 operators on array elements)
- Maps t152 and t153 to `FeatureCategory::CompoundAssign` in `diff_harness.rs`
- Updates JIT parity checklist baseline: CompoundAssign 2 → 4 PASS, 157 total fixtures, 0 PARITY_FAILs

## Files Changed

- `src/frontend/ast.rs` — added `AssignTarget::Index(String, Expr)` variant
- `src/frontend/parser.rs` — added `index_compound_assign` parser and wired it into `body_stmt_tagged` and top-level `choice`
- `src/frontend/semantic.rs` — added `AssignTarget::Index` arm in `Stmt::CompoundAssign` analysis
- `src/diff_harness.rs` — mapped t152 and t153 to `CompoundAssign` feature category
- `src/tests/verification_matrix/t152_dotaccess_compound_assign_exit.cx` — new fixture
- `src/tests/verification_matrix/t153_index_compound_assign_exit.cx` — new fixture
- `docs/backend/cx_jit_parity_checklist.md` — updated baseline table and added CX-159 interpretation note

## Notable Discovery

The `index_compound_assign` parser must be placed before `compound_assign` (or as a separate choice) because `.val` is reserved as handle-dereference syntax (`handle_val` parser matches `ident.val`). The fixture for DotAccess uses `score` as the field name instead of `val` to avoid this parser ambiguity.

## Validation

```
cargo build --features jit   → ok (no new warnings)
cargo test --features jit    → 321 passed, 0 failed
jit_parity_by_feature:
  CompoundAssign: 4 PASS, 2 SKIP, 0 PARITY_FAIL (was 2/2/0)
  Total: 157 fixtures, 0 PARITY_FAILs
```

## Linear Ticket

CX-159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compound assignment operators (+=, -=, *=, /=, %=) now support array element targets.
  * Compound assignment operators now work with struct field access.

* **Documentation**
  * Updated test parity documentation with expanded baseline metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/202)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->