### PR TITLE
CX-160: Add IR + JIT lowering for while-in iterator loop construct

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -102,15 +102,9 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-141` (submain as of CX-141 merge window, 2026-05-12).
-Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
-CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
-exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
-(t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
-CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), and CX-136 print/println intrinsic
-dispatch to cx_printn.
+Run on branch `stokowski/CX-160` (submain as of CX-160 merge window, 2026-05-13).
+Includes all prior work through CX-142 plus CX-160 `while in` IR + JIT lowering
+(lower_while_in_chain, then-chain support) and unary `*` array dereference lowering.
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -118,7 +112,7 @@ Feature                PASS   SKIP  PARITY_FAIL
 Arithmetic                8      9            0
 VariableDecl              5      3            0
 IfElse                    4      2            0
-WhileLoop                 5      3            0
+WhileLoop                 7      1            0
 ForLoop                   4      0            0
 InfiniteLoop              2      1            0
 DirectCall                7      4            0
@@ -163,11 +157,13 @@ including bool-variable negation added in CX-111). The 4 PASS reflect the
 3 exit-code-verified fixtures plus one print-based original now passing via
 CX-136 print dispatch; the 2 SKIP are the remaining print-based originals.
 
-**WhileLoop parity coverage (CX-102/CX-136):** t132 covers basic while loops and
-top-level while at file scope; t133 covers while in a function. The 5 PASS
-reflect the 2 exit-code-verified fixtures plus 3 print-based originals now
-passing via CX-136 print dispatch; the 3 SKIP are while-in/while-in-then
-constructs not yet JIT-lowerable.
+**WhileLoop parity coverage (CX-102/CX-136/CX-160):** t132 covers basic while loops
+and top-level while at file scope; t133 covers while in a function. CX-160 added
+IR + JIT lowering for `while in` iterator loops (lower_while_in_chain) and
+unary `*` array dereference, moving t34 (top-level while_in) and t35 (while_in
+with then-chains) from SKIP to PASS. The 7 PASS reflect the 2 exit-code-verified
+fixtures plus 5 print-based originals; 1 SKIP remains (t105: compound-assign
+inside while in a function, separate concern).
 
 **WhenBlock parity coverage (CX-113):** t143 mirrors t19 (numeric pattern), t144
 mirrors t20 (TBool three-way), t145 mirrors t21 (range pattern). All 3 are SKIP

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -703,6 +703,25 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 result,
                 pos,
             } => {
+                // Resolve the array variable to a binding and element type.
+                // TypedAssign only stores the AST type in `declared`; fall back
+                // to it when `inferred` is None.
+                let (arr_binding, arr_elem_ty) = {
+                    let info = self.lookup_var(arr)
+                        .ok_or_else(|| sem_err!(*pos, "undefined variable: {}", arr))?;
+                    let binding = info.binding;
+                    let elem_ty = match info.inferred.as_ref() {
+                        Some(SemanticType::Array(_, elem_ty)) => *elem_ty.clone(),
+                        Some(t) => return Err(sem_err!(*pos, "'{}' is not an array (got {:?})", arr, t)),
+                        None => match info.declared.as_ref() {
+                            Some(Type::Array(_, elem_type)) => {
+                                semantic_type_from_decl(*elem_type.clone(), &self.current_type_params)
+                            }
+                            _ => return Err(sem_err!(*pos, "array '{}' has unknown type", arr)),
+                        },
+                    };
+                    (binding, elem_ty)
+                };
                 let sem_start = self.analyze_expr(range_start)?;
                 let sem_end = self.analyze_expr(range_end)?;
                 let sem_body = body
@@ -712,6 +731,22 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 let sem_chains = then_chains
                     .iter()
                     .map(|chain| {
+                        let (chain_arr_binding, chain_arr_elem_ty) = {
+                            let info = self.lookup_var(&chain.arr)
+                                .ok_or_else(|| sem_err!(*pos, "undefined variable: {}", chain.arr))?;
+                            let binding = info.binding;
+                            let elem_ty = match info.inferred.as_ref() {
+                                Some(SemanticType::Array(_, elem_ty)) => *elem_ty.clone(),
+                                Some(t) => return Err(sem_err!(*pos, "'{}' is not an array (got {:?})", chain.arr, t)),
+                                None => match info.declared.as_ref() {
+                                    Some(Type::Array(_, elem_type)) => {
+                                        semantic_type_from_decl(*elem_type.clone(), &self.current_type_params)
+                                    }
+                                    _ => return Err(sem_err!(*pos, "array '{}' has unknown type", chain.arr)),
+                                },
+                            };
+                            (binding, elem_ty)
+                        };
                         let cs = self.analyze_expr(&chain.range_start)?;
                         let ce = self.analyze_expr(&chain.range_end)?;
                         let cb = chain
@@ -721,6 +756,8 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                             .collect::<Result<Vec<_>, _>>()?;
                         Ok(SemanticWhileInChain {
                             arr: chain.arr.clone(),
+                            arr_binding: chain_arr_binding,
+                            arr_elem_ty: chain_arr_elem_ty,
                             start_slot: chain.start_slot,
                             range_start: cs,
                             range_end: ce,
@@ -735,6 +772,8 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 };
                 Ok(SemanticStmt::WhileIn {
                     arr: arr.clone(),
+                    arr_binding,
+                    arr_elem_ty,
                     start_slot: *start_slot,
                     range_start: sem_start,
                     range_end: sem_end,

--- a/src/frontend/semantic_types.rs
+++ b/src/frontend/semantic_types.rs
@@ -268,6 +268,8 @@ pub struct SemanticFunction {
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemanticWhileInChain {
     pub arr: String,
+    pub arr_binding: BindingId,
+    pub arr_elem_ty: SemanticType,
     pub start_slot: usize,
     pub range_start: SemanticExpr,
     pub range_end: SemanticExpr,
@@ -354,6 +356,8 @@ ExprStmt {
     },
     WhileIn {
         arr: String,
+        arr_binding: BindingId,
+        arr_elem_ty: SemanticType,
         start_slot: usize,
         range_start: SemanticExpr,
         range_end: SemanticExpr,

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -7,6 +7,7 @@ use crate::frontend::ast::Op;
 use crate::frontend::semantic_types::{
     BindingId, SemanticCallArg, SemanticExpr, SemanticExprKind, SemanticLValue,
     SemanticParamKind, SemanticProgram, SemanticStmt, SemanticType, SemanticValue,
+    SemanticWhileInChain,
 };
 use crate::ir::builder::IrBuilder;
 use crate::ir::instr::{BinaryOp, CompareOp, IrInst, IrTerminator};
@@ -866,7 +867,12 @@ fn lower_stmt(
         }),
         SemanticStmt::EnumDef { .. } => { unsupported!("EnumDef") },
 SemanticStmt::Block { .. } => { unsupported!("Block") },
-        SemanticStmt::WhileIn { .. } => { unsupported!("WhileIn") },
+        SemanticStmt::WhileIn { arr_binding, arr_elem_ty, start_slot, range_start, range_end, inclusive, body, then_chains, .. } => {
+    return match lower_while_in(*arr_binding, arr_elem_ty, *start_slot, range_start, range_end, *inclusive, body, then_chains, ctx, current, spec, loop_ctx)? {
+        Some(new_active) => Ok(Some(new_active)),
+        None => Ok(None),
+    };
+},
         SemanticStmt::While { cond, body, .. } => {
     return match lower_while(cond, body, ctx, current, spec, loop_ctx)? {
         Some(new_active) => Ok(Some(new_active)),
@@ -1530,6 +1536,264 @@ fn lower_for(
     Ok(Some(exit_block))
 }
 
+fn lower_while_in(
+    arr_binding: BindingId,
+    arr_elem_ty: &SemanticType,
+    start_slot: usize,
+    range_start: &SemanticExpr,
+    range_end: &SemanticExpr,
+    inclusive: bool,
+    body: &[SemanticStmt],
+    then_chains: &[SemanticWhileInChain],
+    ctx: &mut LoweringCtx,
+    current: ActiveBlock,
+    spec: &FunctionLoweringSpec,
+    _outer_loop_ctx: Option<&LoopContext>,
+) -> Result<Option<ActiveBlock>, LoweringError> {
+    let mut current = lower_while_in_chain(
+        arr_binding, arr_elem_ty, start_slot,
+        range_start, range_end, inclusive, body,
+        ctx, current, spec,
+    )?;
+    for chain in then_chains {
+        if let Some(active) = current {
+            current = lower_while_in_chain(
+                chain.arr_binding, &chain.arr_elem_ty, chain.start_slot,
+                &chain.range_start, &chain.range_end, chain.inclusive, &chain.body,
+                ctx, active, spec,
+            )?;
+        } else {
+            break;
+        }
+    }
+    Ok(current)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn lower_while_in_chain(
+    arr_binding: BindingId,
+    arr_elem_ty: &SemanticType,
+    start_slot: usize,
+    range_start: &SemanticExpr,
+    range_end: &SemanticExpr,
+    inclusive: bool,
+    body: &[SemanticStmt],
+    ctx: &mut LoweringCtx,
+    mut current: ActiveBlock,
+    spec: &FunctionLoweringSpec,
+) -> Result<Option<ActiveBlock>, LoweringError> {
+    // Derive element IR type and stride for array pointer arithmetic.
+    let elem_ir_ty = if matches!(arr_elem_ty, SemanticType::Numeric | SemanticType::Unknown) {
+        ctx.target.numeric_literal_ir_type()
+    } else {
+        lower_type(arr_elem_ty)?
+    };
+    let stride = compute_array_layout(&elem_ir_ty, 1).stride;
+
+    // Evaluate range bounds in the pre-loop block.
+    let start_val = lower_expr(range_start, ctx, &mut current)?;
+    let end_val = lower_expr(range_end, ctx, &mut current)?;
+
+    let incoming = current.bindings.clone();
+    let mut ordered_bindings: Vec<_> = incoming.keys().copied().collect();
+    ordered_bindings.sort_by_key(|b| b.0);
+
+    // Allocate a synthetic BindingId for the internal loop counter so that
+    // break/continue can locate the counter value in the body's binding map.
+    let max_binding = ordered_bindings.iter().map(|b| b.0).max().unwrap_or(0);
+    let counter_binding = BindingId(max_binding + 1);
+
+    // Build the loop header: [counter(read_only), ...user_bindings].
+    let counter_param = ctx.fresh_value();
+    let mut header_params = vec![BlockParam {
+        value: counter_param,
+        ty: start_val.ty.clone(),
+        read_only: true,
+    }];
+    let mut header_bindings = HashMap::new();
+    let mut entry_args = vec![start_val.value];
+
+    for b in &ordered_bindings {
+        let val = incoming.get(b).unwrap();
+        let pv = ctx.fresh_value();
+        header_params.push(BlockParam { value: pv, ty: val.ty.clone(), read_only: false });
+        header_bindings.insert(*b, LoweredValue { value: pv, ty: val.ty.clone() });
+        entry_args.push(val.value);
+    }
+
+    let mut header = ctx.start_block(header_params, header_bindings.clone());
+    let header_id = header.id();
+
+    current.terminate(IrTerminator::Jump { target: header_id, args: entry_args })?;
+    ctx.seal_block(current)?;
+
+    // Build the increment block: receives [counter, ...user_bindings], emits
+    // counter+1, then jumps back to the header.
+    let inc_counter_param = ctx.fresh_value();
+    let mut inc_params = vec![BlockParam {
+        value: inc_counter_param,
+        ty: start_val.ty.clone(),
+        read_only: true,
+    }];
+    let mut inc_bindings = HashMap::new();
+    for b in &ordered_bindings {
+        let val = incoming.get(b).unwrap();
+        let pv = ctx.fresh_value();
+        inc_params.push(BlockParam { value: pv, ty: val.ty.clone(), read_only: false });
+        inc_bindings.insert(*b, LoweredValue { value: pv, ty: val.ty.clone() });
+    }
+    let mut inc_block = ctx.start_block(inc_params, inc_bindings);
+    let inc_id = inc_block.id();
+
+    let one_v = ctx.fresh_value();
+    inc_block.emit(IrInst::ConstInt { dst: one_v, ty: start_val.ty.clone(), value: 1 })?;
+    let next_counter = ctx.fresh_value();
+    inc_block.emit(IrInst::Binary {
+        dst: next_counter,
+        op: BinaryOp::Add,
+        ty: start_val.ty.clone(),
+        lhs: inc_counter_param,
+        rhs: one_v,
+    })?;
+    let mut inc_jump_args = vec![next_counter];
+    for b in &ordered_bindings {
+        inc_jump_args.push(inc_block.bindings.get(b).unwrap().value);
+    }
+    inc_block.terminate(IrTerminator::Jump { target: header_id, args: inc_jump_args })?;
+    ctx.seal_block(inc_block)?;
+
+    // Emit the loop condition comparison on the header.
+    let cmp_dst = ctx.fresh_value();
+    header.emit(IrInst::Compare {
+        dst: cmp_dst,
+        op: if inclusive { CompareOp::Le } else { CompareOp::Lt },
+        lhs: counter_param,
+        rhs: end_val.value,
+    })?;
+
+    // Build the body block; add the synthetic counter_binding so that
+    // continue/break can pick up the current counter value.
+    let mut body_bindings = header_bindings.clone();
+    body_bindings.insert(counter_binding, LoweredValue { value: counter_param, ty: start_val.ty.clone() });
+    let mut body_block = ctx.start_block(vec![], body_bindings);
+    let body_id = body_block.id();
+
+    // Emit arr[counter] load and arr[start_slot] store at the top of each
+    // iteration body, before the user-written body statements execute.
+    let arr_ptr = body_block.bindings.get(&arr_binding)
+        .ok_or_else(|| LoweringError::InternalInvariantViolation {
+            detail: format!(
+                "while-in: arr_binding ({}) not found in body block bindings",
+                arr_binding.0
+            ),
+        })?
+        .value;
+
+    // Cast counter to I64 for the byte-offset multiply if necessary.
+    let counter_i64 = if start_val.ty == IrType::I64 {
+        counter_param
+    } else {
+        let cast_dst = ctx.fresh_value();
+        body_block.emit(IrInst::Cast {
+            dst: cast_dst,
+            from: start_val.ty.clone(),
+            to: IrType::I64,
+            value: counter_param,
+        })?;
+        cast_dst
+    };
+
+    let stride_v = ctx.fresh_value();
+    body_block.emit(IrInst::ConstInt { dst: stride_v, ty: IrType::I64, value: stride as i128 })?;
+    let byte_offset_v = ctx.fresh_value();
+    body_block.emit(IrInst::Binary {
+        dst: byte_offset_v,
+        op: BinaryOp::Mul,
+        ty: IrType::I64,
+        lhs: counter_i64,
+        rhs: stride_v,
+    })?;
+    let elem_ptr_v = ctx.fresh_value();
+    body_block.emit(IrInst::PtrAdd { dst: elem_ptr_v, base: arr_ptr, offset: byte_offset_v })?;
+    let elem_val_v = ctx.fresh_value();
+    body_block.emit(IrInst::Load { dst: elem_val_v, ty: elem_ir_ty.clone(), ptr: elem_ptr_v })?;
+
+    // Write the loaded element to arr[start_slot].
+    let slot_byte_offset = start_slot * stride;
+    let slot_ptr = if slot_byte_offset == 0 {
+        arr_ptr
+    } else {
+        let slot_ptr_v = ctx.fresh_value();
+        body_block.emit(IrInst::PtrOffset {
+            dst: slot_ptr_v,
+            base: arr_ptr,
+            offset: slot_byte_offset,
+        })?;
+        slot_ptr_v
+    };
+    body_block.emit(IrInst::Store { ptr: slot_ptr, value: elem_val_v })?;
+
+    // Build the exit block: receives all user bindings as params.
+    let mut exit_params = Vec::new();
+    let mut exit_bindings = HashMap::new();
+    for b in &ordered_bindings {
+        let val = incoming.get(b).unwrap();
+        let pv = ctx.fresh_value();
+        exit_params.push(BlockParam { value: pv, ty: val.ty.clone(), read_only: false });
+        exit_bindings.insert(*b, LoweredValue { value: pv, ty: val.ty.clone() });
+    }
+    let exit_block = ctx.start_block(exit_params, exit_bindings);
+    let exit_id = exit_block.id();
+
+    // Terminate the header: branch to body or exit.
+    let mut else_args = Vec::new();
+    for b in &ordered_bindings {
+        else_args.push(header.bindings.get(b).unwrap().value);
+    }
+    header.terminate(IrTerminator::Branch {
+        cond: cmp_dst,
+        then_block: body_id,
+        then_args: vec![],
+        else_block: exit_id,
+        else_args,
+    })?;
+    ctx.seal_block(header)?;
+
+    // Loop context: continue → inc_block (counter + user bindings),
+    //               break   → exit_block (user bindings only).
+    let loop_context = LoopContext {
+        header_id: inc_id,
+        exit_id,
+        ordered_bindings: {
+            // continue passes [counter, ...user_bindings] to inc_block.
+            let mut v = vec![counter_binding];
+            v.extend(ordered_bindings.iter().copied());
+            v
+        },
+        exit_ordered_bindings: ordered_bindings.clone(),
+    };
+
+    let body_result = lower_stmt_sequence(
+        body.iter(),
+        ctx,
+        Some(body_block),
+        spec,
+        Some(&loop_context),
+    )?;
+
+    if let Some(mut body_active) = body_result {
+        // Natural fallthrough: jump to inc_block with [counter, ...user_bindings].
+        let mut args = vec![body_active.bindings.get(&counter_binding).unwrap().value];
+        for b in &ordered_bindings {
+            args.push(body_active.bindings.get(b).unwrap().value);
+        }
+        body_active.terminate(IrTerminator::Jump { target: inc_id, args })?;
+        ctx.seal_block(body_active)?;
+    }
+
+    Ok(Some(exit_block))
+}
+
 fn finalize_active_block(
     ctx: &mut LoweringCtx,
     mut active: ActiveBlock,
@@ -1764,6 +2028,27 @@ fn lower_expr(
                 rhs: zero,
             })?;
             Ok(LoweredValue { value: dst, ty: IrType::Bool })
+        }
+        Op::Mul => {
+            // Array slot-0 dereference: *arr loads arr[0].
+            // The outer expression type retains the array type from the
+            // semantic layer; derive the element IR type from it.
+            let elem_sem_ty = match &expr.ty {
+                SemanticType::Array(_, elem_ty) => elem_ty.as_ref(),
+                _ => {
+                    return Err(LoweringError::UnsupportedSemanticConstruct {
+                        construct: "unary * on non-array value".to_string(),
+                    });
+                }
+            };
+            let elem_ir_ty = if matches!(elem_sem_ty, SemanticType::Numeric | SemanticType::Unknown) {
+                ctx.target.numeric_literal_ir_type()
+            } else {
+                lower_type(elem_sem_ty)?
+            };
+            let dst = ctx.fresh_value();
+            active.emit(IrInst::Load { dst, ty: elem_ir_ty.clone(), ptr: lowered.value })?;
+            Ok(LoweredValue { value: dst, ty: elem_ir_ty })
         }
         _ => {
             return Err(LoweringError::UnsupportedSemanticConstruct {
@@ -4031,42 +4316,50 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_statement() {
+    fn lowers_simple_while_in() {
+        let arr_binding = BindingId(0);
+        let arr_ty = SemanticType::Array(5, Box::new(SemanticType::I64));
         let program = SemanticProgram {
-            stmts: vec![SemanticStmt::WhileIn {
-                arr: "arr".to_string(),
-                start_slot: 0,
-                range_start: int_expr(0, SemanticType::I64),
-                range_end: int_expr(10, SemanticType::I64),
-                inclusive: false,
-                body: vec![],
-                then_chains: vec![],
-                result: None,
-                pos: 0,
-            }],
+            stmts: vec![
+                typed_assign(arr_binding, "arr", arr_ty.clone(), array_lit_i64(vec![10, 20, 30, 40, 50])),
+                SemanticStmt::WhileIn {
+                    arr: "arr".to_string(),
+                    arr_binding,
+                    arr_elem_ty: SemanticType::I64,
+                    start_slot: 0,
+                    range_start: int_expr(0, SemanticType::I64),
+                    range_end: int_expr(5, SemanticType::I64),
+                    inclusive: false,
+                    body: vec![],
+                    then_chains: vec![],
+                    result: None,
+                    pos: 0,
+                },
+            ],
             enums: vec![],
         };
-
-        assert_eq!(
-            lower_program(&program).expect_err("lowering should fail"),
-            LoweringError::UnsupportedSemanticConstruct {
-                construct: "WhileIn".to_string()
-            }
-        );
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        // Expect at least 4 blocks: entry, header, body, exit (inc is a 5th).
+        assert!(main_fn.blocks.len() >= 4, "expected at least 4 blocks, got {}", main_fn.blocks.len());
     }
 
     #[test]
-    fn rejects_unsupported_statement_inside_function() {
+    fn lowers_while_in_inside_function() {
+        let arr_binding = BindingId(0);
+        let arr_ty = SemanticType::Array(3, Box::new(SemanticType::I64));
         let program = SemanticProgram {
             stmts: vec![semantic_function(
-                "bad",
-                vec![],
+                "iterate",
+                vec![typed_param(arr_binding, "arr", arr_ty.clone())],
                 None,
                 vec![SemanticStmt::WhileIn {
                     arr: "arr".to_string(),
+                    arr_binding,
+                    arr_elem_ty: SemanticType::I64,
                     start_slot: 0,
                     range_start: int_expr(0, SemanticType::I64),
-                    range_end: int_expr(10, SemanticType::I64),
+                    range_end: int_expr(3, SemanticType::I64),
                     inclusive: false,
                     body: vec![],
                     then_chains: vec![],
@@ -4077,13 +4370,7 @@ mod tests {
             )],
             enums: vec![],
         };
-
-        assert_eq!(
-            lower_program(&program).expect_err("lowering should fail"),
-            LoweringError::UnsupportedSemanticConstruct {
-                construct: "WhileIn".to_string()
-            }
-        );
+        let _ = lower_and_validate(&program);
     }
 
     #[test]
@@ -4632,17 +4919,7 @@ mod tests {
         let program = SemanticProgram {
             stmts: vec![if_stmt(
                 bool_expr(true),
-                vec![SemanticStmt::WhileIn {
-                    arr: "arr".to_string(),
-                    start_slot: 0,
-                    range_start: int_expr(0, SemanticType::I64),
-                    range_end: int_expr(10, SemanticType::I64),
-                    inclusive: false,
-                    body: vec![],
-                    then_chains: vec![],
-                    result: None,
-                    pos: 0,
-                }],
+                vec![SemanticStmt::Block { stmts: vec![], pos: 0 }],
                 vec![],
                 None,
             )],
@@ -4652,7 +4929,7 @@ mod tests {
         assert_eq!(
             lower_program(&program).expect_err("lowering should fail"),
             LoweringError::UnsupportedSemanticConstruct {
-                construct: "WhileIn".to_string()
+                construct: "Block".to_string()
             }
         );
     }


### PR DESCRIPTION
Closes CX-160

## Summary

- Implements `lower_while_in_chain` and `lower_while_in` in `src/ir/lower.rs`, giving the `while in arr:[slot], start..end { body } [then in ...]` construct full IR + JIT support.
- Adds unary `*` (array slot-0 dereference) lowering to `lower_expr`, enabling `print(*arr)` patterns inside `while in` bodies.
- Extends `SemanticStmt::WhileIn` and `SemanticWhileInChain` with `arr_binding: BindingId` and `arr_elem_ty: SemanticType` so IR lowering can resolve the array pointer without a name-based lookup at codegen time.
- Updates semantic analysis to validate that the named array variable exists and has an array type, with fallback to the AST-level `declared` type when `inferred` is `None` (TypedAssign leaves `inferred=None`).
- Updates parity checklist baseline: WhileLoop 5 PASS 3 SKIP → **7 PASS 1 SKIP**.

## Files changed

- `src/frontend/semantic_types.rs` — add `arr_binding` and `arr_elem_ty` to `SemanticStmt::WhileIn` and `SemanticWhileInChain`
- `src/frontend/semantic.rs` — resolve array BindingId and element type during WhileIn analysis
- `src/ir/lower.rs` — implement `lower_while_in` / `lower_while_in_chain`; add unary `*` array deref; convert WhileIn rejection tests to positive lowering tests; change if-branch rejection test to use `Block`
- `docs/backend/cx_jit_parity_checklist.md` — update baseline table and WhileLoop interpretation paragraph

## Implementation design

`lower_while_in_chain` mirrors `lower_for`: four blocks (header + increment + body + exit) with the loop counter flowing as a `read_only: true` block param. A **synthetic `BindingId(max_user_binding + 1)`** is inserted into the body block's bindings so `break`/`continue` can locate the counter value through the standard `LoopContext` machinery. Then-chains are lowered sequentially by threading the exit block of each chain as the entry to the next.

The body block emits, before user statements: `PtrAdd(arr_ptr, counter * stride)` → `Load` (element at loop index), then `Store` to `arr[start_slot]` (using `PtrOffset` for non-zero slots).

## Tests run

```
cargo build --features jit
cargo test --features jit
```

## Validation results

```
test result: ok. 321 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
WhileLoop: 7 PASS  1 SKIP  0 PARITY_FAIL
```

t34 (top-level while_in) and t35 (while_in with then-chains) move from SKIP to PASS.

## Known limitations

t105 (`while` + compound-assign in a function) remains 1 SKIP — it is blocked by a separate compound-assign-in-while issue unrelated to while_in lowering.

Linear: CX-160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for unary array dereference in expressions.

* **Improvements**
  * Improved semantic handling and type resolution for "while ... in" loops.
  * Extended code generation to correctly lower "while ... in" iterator chains into explicit loop control.

* **Tests**
  * Updated tests to cover successful lowering of "while ... in" (including inside functions) and unary array dereference.

* **Documentation**
  * Updated parity checklist and coverage notes to reflect recent test-run results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/203)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->