### PR TITLE
CX-161: Add exit-code-verified parity fixtures for BuiltinAssert JIT coverage

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -31,7 +31,7 @@ set:
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |
-| BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
+| BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 (output-verified); t152–t153 (exit-code-verified, CX-161) |
 | LogicalOps     | Logical AND/OR short-circuit operators       | t141, t142 |
 | Other          | Enums, generics, when-blocks, handles, macros, imports, Result/try, string interp, semicolons, copy semantics, and any fixture not matching a named category | t09–t22, t24, t27–t32, t37–t38, t42, t47, t49, t51–t54, t58–t76, t81–t88, t97–t100, t111; exit-code-verified: t143–t145 (CX-113) |
 
@@ -109,8 +109,9 @@ CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
 exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
 (t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
 CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), and CX-136 print/println intrinsic
-dispatch to cx_printn.
+(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
+dispatch to cx_printn, and CX-161 BuiltinAssert exit-code fixtures
+(t152_assert_bool_exit, t153_assert_eq_int_exit).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -128,11 +129,11 @@ CompoundAssign            2      2            0
 Unary                     0      1            0
 Cast                      0      2            0
 FloatOps                  0      5            0
-BuiltinAssert             2      2            0
+BuiltinAssert             2      4            0
 LogicalOps                2      0            0
 Other                    16     48            0
 ------------------------------------------------
-Total: 155 fixtures, 0 PARITY_FAILs
+Total: 157 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -195,6 +196,15 @@ element read/write, and array passing through function calls. The 3 PASS reflect
 fixtures passing via the CX-121 ArrayAlloca JIT emit (`IrInst::ArrayAlloca` lowered to
 Cranelift via `compute_array_layout`). The 2 SKIP are t33 and t112 (print-based originals
 that remain SKIP).
+
+**BuiltinAssert parity coverage (CX-161):** t152_assert_bool_exit covers `assert` with a
+boolean literal, a numeric-truthy literal, and a computed numeric variable. t153_assert_eq_int_exit
+covers `assert_eq` with integer literals, arithmetic expressions, and variables. Both are PassAny
+exit-code-verified fixtures; they carry no `.expected_output` companion. The 2 PASS are t79 and
+t80 (expected-fail, semantic-rejection fixtures). The 4 SKIP are t77, t78 (print-based output-verified),
+and t152, t153 (exit-code-verified): all four produce non-empty stderr from Cranelift because
+`IrTerminator::Trap` (the assert-failure path) is not yet lowered. Once Trap lowering lands,
+t77, t78, t152, and t153 will all transition from SKIP to PASS without fixture changes.
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -253,6 +253,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t78_assert_eq_strings"
         | "t79_assert_false_reject"
         | "t80_assert_eq_mismatch_reject"
+        | "t152_assert_bool_exit"
+        | "t153_assert_eq_int_exit"
             => FeatureCategory::BuiltinAssert,
 
         // ── LogicalOps ────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t152_assert_bool_exit.cx
+++ b/src/tests/verification_matrix/t152_assert_bool_exit.cx
@@ -1,0 +1,14 @@
+// CX-161: exit-code-based JIT parity — assert with boolean and numeric conditions.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+
+// Boolean literal: assert(true) must hold.
+assert(true)
+
+// Numeric truthy: assert(1) must hold (non-zero integer is truthy).
+assert(1)
+
+// Numeric computed: variable accumulation must remain truthy.
+a: t64 = 3
+b: t64 = 4
+sum: t64 = a + b
+assert(sum)

--- a/src/tests/verification_matrix/t153_assert_eq_int_exit.cx
+++ b/src/tests/verification_matrix/t153_assert_eq_int_exit.cx
@@ -1,0 +1,16 @@
+// CX-161: exit-code-based JIT parity — assert_eq with integer values.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+
+// Literal equality.
+assert_eq(1, 1)
+
+// Arithmetic equality: 2 + 3 must equal 5.
+assert_eq(2 + 3, 5)
+
+// Variable equality: same value in two variables.
+x: t64 = 10
+y: t64 = 10
+assert_eq(x, y)
+
+// Computed equality: sum of two variables.
+assert_eq(x + y, 20)


### PR DESCRIPTION
Closes CX-161

## Summary

- Add `t152_assert_bool_exit.cx`: PassAny fixture exercising `assert()` with a boolean literal, numeric-truthy literal, and computed `t64` variable.
- Add `t153_assert_eq_int_exit.cx`: PassAny fixture exercising `assert_eq()` with integer literals, arithmetic expressions, and variable equality.
- Register both in `feature_of()` under `FeatureCategory::BuiltinAssert`.
- Update parity checklist: Section 1 table, Section 3 baseline (BuiltinAssert SKIP 2→4, Total 155→157), and Section 3 interpretation note.

## Files Changed

| File | Change |
|------|--------|
| `src/tests/verification_matrix/t152_assert_bool_exit.cx` | New fixture |
| `src/tests/verification_matrix/t153_assert_eq_int_exit.cx` | New fixture |
| `src/diff_harness.rs` | Register t152, t153 in `feature_of()` |
| `docs/backend/cx_jit_parity_checklist.md` | Section 1, Section 3 baseline + interpretation |

## Parity Behavior

Both new fixtures SKIP today: `IrTerminator::Trap` (the assert-failure branch) is not yet lowered in the Cranelift backend, causing exit 0 with non-empty stderr → classified as SKIP. This is expected and matches the existing behavior of t77/t78. Once Trap lowering lands, t152 and t153 will transition from SKIP to PASS without any fixture changes.

PARITY_FAIL remains 0 across all 16 categories.

## Validation

```
cargo build --features jit && cargo test --features jit
```

```
test diff_harness::tests::interpreter_baseline_all ... ok
test diff_harness::tests::jit_parity_by_feature ... ok

test result: ok. 321 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.36s
```

## Linear

CX-161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Phase 12 per-feature JIT parity checklist with expanded baseline capture notes and increased fixture coverage.

* **Tests**
  * Added new exit-code-based verification tests for assert boolean and assert equality functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/204)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->