### PR TITLE
CX-162: Add exit-code-verified parity fixture for t128 arithmetic JIT coverage

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -18,7 +18,7 @@ set:
 
 | Category       | Description                                  | Key fixtures |
 |----------------|----------------------------------------------|--------------|
-| Arithmetic     | Integer arithmetic, overflow, eval order     | t01, t89–t95, t103, t114_eval_order_binary_arith, t115_eval_order_compare, t116–t121 |
+| Arithmetic     | Integer arithmetic, overflow, eval order     | t01, t89–t95, t103, t114_eval_order_binary_arith, t115_eval_order_compare, t116–t121, t152 (exit-code-verified t128, CX-162) |
 | VariableDecl   | Variable/const declarations, scope, type errors | t15, t56, t57, t101, t102, t122–t124 |
 | IfElse         | Conditional branches                         | t44, t45, t46 (output-verified); t129, t130, t131 (exit-code-verified, CX-102/CX-111) |
 | WhileLoop      | While loops and while-in construct           | t23, t34, t35, t105, t107, t108 (output-verified); t132, t133 (exit-code-verified, CX-102) |
@@ -102,20 +102,20 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-141` (submain as of CX-141 merge window, 2026-05-12).
+Run on branch `stokowski/CX-162` (submain as of CX-162 merge window, 2026-05-13).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
 CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
 exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
 (t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
 CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), and CX-136 print/println intrinsic
-dispatch to cx_printn.
+(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
+dispatch to cx_printn, and CX-162 t128 arithmetic exit-code fixture (t152_arith_t128_exit).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
 ------------------------------------------------
-Arithmetic                8      9            0
+Arithmetic                8     10            0
 VariableDecl              5      3            0
 IfElse                    4      2            0
 WhileLoop                 5      3            0
@@ -132,7 +132,7 @@ BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    16     48            0
 ------------------------------------------------
-Total: 155 fixtures, 0 PARITY_FAILs
+Total: 156 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -195,6 +195,12 @@ element read/write, and array passing through function calls. The 3 PASS reflect
 fixtures passing via the CX-121 ArrayAlloca JIT emit (`IrInst::ArrayAlloca` lowered to
 Cranelift via `compute_array_layout`). The 2 SKIP are t33 and t112 (print-based originals
 that remain SKIP).
+
+**Arithmetic t128 parity coverage (CX-162):** t152_arith_t128_exit is an exit-code-verified
+fixture exercising t128 (128-bit signed integer) add, sub, mul, and zero-numerator div/mod.
+The fixture is SKIP in JIT (t128 multi-word codegen not yet implemented; the 128-bit
+Cranelift type path is not yet lowered). Once t128 JIT lowering lands, this fixture will
+transition from SKIP to PASS without changes.
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -142,6 +142,7 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t119_arith_mul_exit"
         | "t120_arith_div_exit"
         | "t121_arith_mod_exit"
+        | "t152_arith_t128_exit"
             => FeatureCategory::Arithmetic,
 
         // ── VariableDecl ──────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t152_arith_t128_exit.cx
+++ b/src/tests/verification_matrix/t152_arith_t128_exit.cx
@@ -1,0 +1,9 @@
+// CX-162: exit-code-based JIT parity — t128 arithmetic.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+a: t128 = 10
+b: t128 = 3
+assert_eq(a + b, 13)
+assert_eq(a - b, 7)
+assert_eq(a * b, 30)
+assert_eq(0 / b, 0)
+assert_eq(0 % b, 0)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-162/add-exit-code-verified-parity-fixture-for-t128-arithmetic-jit-coverage

## Summary

- Adds `t152_arith_t128_exit.cx`: exit-code-verified fixture exercising t128 (128-bit signed integer) arithmetic — add, sub, mul, and zero-numerator div/mod — using `assert_eq` with no print calls.
- Registers `t152_arith_t128_exit` in `feature_of()` under `FeatureCategory::Arithmetic`.
- Updates JIT parity checklist: Arithmetic SKIP 9→10, total fixtures 155→156, baseline branch updated to `stokowski/CX-162`, and adds interpretation note for the new fixture.

## Files Changed

- `src/tests/verification_matrix/t152_arith_t128_exit.cx` — new fixture
- `src/diff_harness.rs` — `feature_of()` registration
- `docs/backend/cx_jit_parity_checklist.md` — Section 1 key fixtures, Section 3 baseline counts and interpretation

## Validation

```
cargo build --features jit   ✓
cargo test --features jit    ✓  321 passed, 0 failed
```

Parity gate output:
```
Feature                PASS   SKIP  PARITY_FAIL
------------------------------------------------
Arithmetic                8     10            0
...all other categories unchanged...
------------------------------------------------
jit_parity_by_feature: 156 fixtures checked across 16 feature categories, 0 PARITY_FAILs
```

## Behavior

The new fixture is SKIP in JIT (t128 multi-word Cranelift lowering not yet implemented; consistent with existing t95_overflow_t128_unchanged being SKIP). It will transition from SKIP to PASS without changes once t128 JIT lowering lands.

## Linear Ticket

CX-162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added 128-bit arithmetic verification test with exit-code validation.

* **Documentation**
  * Updated JIT parity checklist with new arithmetic test coverage information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/205)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->