### PR TITLE
CX-163: Add exit-code parity fixtures for const declarations and block-scope variable shadowing

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -19,7 +19,7 @@ set:
 | Category       | Description                                  | Key fixtures |
 |----------------|----------------------------------------------|--------------|
 | Arithmetic     | Integer arithmetic, overflow, eval order     | t01, t89–t95, t103, t114_eval_order_binary_arith, t115_eval_order_compare, t116–t121 |
-| VariableDecl   | Variable/const declarations, scope, type errors | t15, t56, t57, t101, t102, t122–t124 |
+| VariableDecl   | Variable/const declarations, scope, type errors | t15, t56, t57, t101, t102, t122–t124, t152, t153 |
 | IfElse         | Conditional branches                         | t44, t45, t46 (output-verified); t129, t130, t131 (exit-code-verified, CX-102/CX-111) |
 | WhileLoop      | While loops and while-in construct           | t23, t34, t35, t105, t107, t108 (output-verified); t132, t133 (exit-code-verified, CX-102) |
 | ForLoop        | For-in loops                                 | t48, t104 (output-verified); t149, t150 (exit-code-verified, CX-124) |
@@ -102,21 +102,22 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-141` (submain as of CX-141 merge window, 2026-05-12).
+Run on branch `stokowski/CX-163` (submain as of CX-163 merge window, 2026-05-13).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
 CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
 exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
 (t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
 CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), and CX-136 print/println intrinsic
-dispatch to cx_printn.
+(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
+dispatch to cx_printn, and CX-163 const-declaration and block-scope-shadow
+exit-code fixtures (t152_const_decl_exit, t153_block_scope_shadow_exit).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
 ------------------------------------------------
 Arithmetic                8      9            0
-VariableDecl              5      3            0
+VariableDecl              5      5            0
 IfElse                    4      2            0
 WhileLoop                 5      3            0
 ForLoop                   4      0            0
@@ -132,7 +133,7 @@ BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    16     48            0
 ------------------------------------------------
-Total: 155 fixtures, 0 PARITY_FAILs
+Total: 157 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -195,6 +196,15 @@ element read/write, and array passing through function calls. The 3 PASS reflect
 fixtures passing via the CX-121 ArrayAlloca JIT emit (`IrInst::ArrayAlloca` lowered to
 Cranelift via `compute_array_layout`). The 2 SKIP are t33 and t112 (print-based originals
 that remain SKIP).
+
+**VariableDecl const and block-scope parity (CX-163):** t152_const_decl_exit exercises
+three `const` declarations with `t64` type verified by `assert_eq`. t153_block_scope_shadow_exit
+mirrors t15_block_scope_shadow using `assert_eq` instead of `print`: outer variable x=10,
+shadowed to x=99 in an inner block, then outer x=10 restored. Both are SKIP in JIT
+(`ConstDecl` and `Block` lowering not yet implemented; exit 127). The 5 PASS remain the
+3 expected-fail fixtures (t57, t101, t102) plus 2 exit-code-verified fixtures (t122, t123)
+that already PASS. Once `ConstDecl` and `Block` lowering lands, t152 and t153 will
+transition from SKIP to PASS without changes.
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -153,6 +153,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t122_vardecl_int_exit"
         | "t123_vardecl_reassign_exit"
         | "t124_vardecl_arith_exit"
+        | "t152_const_decl_exit"
+        | "t153_block_scope_shadow_exit"
             => FeatureCategory::VariableDecl,
 
         // ── IfElse ────────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t152_const_decl_exit.cx
+++ b/src/tests/verification_matrix/t152_const_decl_exit.cx
@@ -1,0 +1,8 @@
+// CX-163: exit-code-based JIT parity — const declarations.
+// Verifies that const-declared values are stored and accessible correctly.
+const LIMIT: t64 = 100
+assert_eq(LIMIT, 100)
+const OFFSET: t64 = 1
+assert_eq(OFFSET, 1)
+const MAX: t64 = 999
+assert_eq(MAX, 999)

--- a/src/tests/verification_matrix/t153_block_scope_shadow_exit.cx
+++ b/src/tests/verification_matrix/t153_block_scope_shadow_exit.cx
@@ -1,0 +1,9 @@
+// CX-163: exit-code-based JIT parity — block-scope variable shadowing.
+// Outer x is shadowed inside the inner block; outer value is restored on exit.
+x: t64 = 10
+assert_eq(x, 10)
+{
+    x: t64 = 99
+    assert_eq(x, 99)
+}
+assert_eq(x, 10)


### PR DESCRIPTION
Closes CX-163

## Summary

- Add `t152_const_decl_exit.cx`: three `const` declarations with `t64` type, each verified via `assert_eq`. No `print` calls — correctness proved by exit code alone.
- Add `t153_block_scope_shadow_exit.cx`: outer variable `x = 10` shadowed inside an inner block as `x = 99`, outer value restored after block exits, all verified via `assert_eq`. Mirrors `t15_block_scope_shadow` without `print`.
- Register both fixtures under `FeatureCategory::VariableDecl` in `feature_of()` in `src/diff_harness.rs`.
- Update `docs/backend/cx_jit_parity_checklist.md`: Section 1 table now lists t152 and t153; Section 3 baseline updated to reflect 5P/5S for VariableDecl and 157 total fixtures.

## Files Changed

- `src/tests/verification_matrix/t152_const_decl_exit.cx` (new)
- `src/tests/verification_matrix/t153_block_scope_shadow_exit.cx` (new)
- `src/diff_harness.rs` — two fixture names added to VariableDecl match arm
- `docs/backend/cx_jit_parity_checklist.md` — Section 1 and Section 3 updated

## JIT Behaviour

Both fixtures SKIP in JIT (exit 127). `ConstDecl` is marked `unsupported!` in `src/ir/lower.rs:949`; `Block` is marked `unsupported!` at line 868. Once those lowering paths land, t152 and t153 will transition from SKIP to PASS without changes to the fixtures.

## Validation

```
cargo build --features jit && cargo test --features jit
```

```
test result: ok. 321 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.33s
```

JIT parity table (jit_parity_by_feature):

```
Feature                PASS   SKIP  PARITY_FAIL
------------------------------------------------
VariableDecl              5      5            0   ← was 5/3/0; +2 SKIP
...
------------------------------------------------
Total: 157 fixtures, 0 PARITY_FAILs
```

## Linear Ticket

CX-163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for const variable declarations
  * Expanded test coverage for block-scope variable shadowing behavior

* **Documentation**
  * Updated verification checklist with new test fixtures and baseline counts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/206)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->