### PR TITLE
CX-167: Harden branch guard against direct-pushed local merge commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
   branch-guard:
     name: Block Direct Push to Main
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'Merge')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'Merge pull request')
     steps:
       - name: Reject direct push
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,41 @@ jobs:
           fi
 
   branch-guard:
-    name: Block Direct Push to Main
+    name: Block Direct Push to Protected Branches
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'Merge pull request')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/submain')
+    permissions:
+      pull-requests: read
     steps:
+      - name: Verify push came from merged PR
+        id: verify_pr_merge
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const protectedRef = context.ref.replace('refs/heads/', '');
+            const sha = context.sha;
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+            });
+
+            const allowed = prs.some((pr) => {
+              return pr.merged_at &&
+                pr.merge_commit_sha === sha &&
+                pr.base &&
+                pr.base.ref === protectedRef;
+            });
+
+            core.info(`Protected ref: ${protectedRef}`);
+            core.info(`Associated PR count: ${prs.length}`);
+            core.info(`Allowed merged PR push: ${allowed}`);
+            core.setOutput('allowed', String(allowed));
+
       - name: Reject direct push
+        if: steps.verify_pr_merge.outputs.allowed != 'true'
         run: |
-          echo "Direct pushes to main are not allowed."
-          echo "Open a PR from submain or a feature branch."
+          echo "Direct pushes to main or submain are not allowed."
+          echo "Merge through a GitHub pull request targeting the protected branch."
           exit 1


### PR DESCRIPTION
Closes CX-167
Closes CX-168

## Summary

**CX-167** (original change):
- Tightened the `branch-guard` CI condition from `!startsWith(message, 'Merge')` to `!startsWith(message, 'Merge pull request')`
- Blocked locally-created merge commits from bypassing the guard when directly pushed to `main`

**CX-168** (this commit — supersedes CX-167 approach):
- Removed all commit-message-based logic from `branch-guard` (commit messages are user-controlled and spoofable)
- Replaced with `actions/github-script@v7` calling `repos.listPullRequestsAssociatedWithCommit` GitHub API
- A push is allowed only if a PR exists with `merged_at` set, `merge_commit_sha` matching the pushed SHA, and `base.ref` matching the protected branch
- Extended protection to cover `submain` in addition to `main`
- Added explicit `permissions: pull-requests: read` to the job

## What Is Now Blocked

- Local direct commits pushed to `main` or `submain`
- Local merge commits pushed directly (git merge + git push)
- Spoofed commit messages starting with `Merge pull request`

## What Is Now Allowed

- Real GitHub PR merge commits (verified via API: merged_at + merge_commit_sha + base.ref)

## Files Changed

- `.github/workflows/ci.yml` — branch-guard job replaced

## Validation

cargo build --features jit → Finished (20 warnings, 0 errors)
cargo test  --features jit → 321 passed; 0 failed; 0 ignored
git diff --check → clean

Note: local GitHub Actions execution is not available; workflow correctness validated by static inspection against GitHub Actions documentation and the ticket specification.

## Linear Tickets

CX-167 / CX-168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to enforce branch protection for main and submain by blocking direct pushes unless the commit matches a merged PR targeting the protected branch.
  * Reworked verification to check merged-PR association before allowing pushes and improved rejection messaging to reference merging via pull request.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/210)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->