### PR TITLE
CX-172: Add t128 argument support to print/println/printn intrinsic dispatch

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -275,6 +275,23 @@ extern "C" fn cx_printn(n: i64) {
     let _ = writeln!(stdout, "{n}");
 }
 
+/// Runtime intrinsic: print a 128-bit integer to stdout followed by a newline.
+///
+/// Exported as `cx_printn_i128` in the JIT symbol table. JIT-compiled Cx code calls this
+/// via `IrInst::Call { callee: "cx_printn_i128", args: [i128_value] }`.
+///
+/// Cranelift 0.115 does not support I128 in call arguments on x64 unless LLVM ABI
+/// extensions are enabled (isa/x64/abi.rs asserts on this path).  To work around this,
+/// the JIT emitter splits the I128 SSA value with `isplit` before the call and passes
+/// two I64 halves: `lo` (bits 63:0) and `hi` (bits 127:64).  This function reconstructs
+/// the signed i128 and prints it.
+extern "C" fn cx_printn_i128(lo: i64, hi: i64) {
+    let n: i128 = ((hi as i128) << 64) | (lo as u64 as i128);
+    use std::io::{self, Write};
+    let mut stdout = io::stdout().lock();
+    let _ = writeln!(stdout, "{n}");
+}
+
 /// Backend-private symbol name for the F64 remainder host helper.
 ///
 /// Using a mangled name (double-underscore prefix) keeps it out of the user-visible namespace.
@@ -340,6 +357,7 @@ impl HostBoundary {
         let mut jit_builder =
             JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
         jit_builder.symbol("cx_printn", cx_printn as *const u8);
+        jit_builder.symbol("cx_printn_i128", cx_printn_i128 as *const u8);
         jit_builder.symbol(JIT_F64_REM_SYMBOL, host_fmod as *const u8);
         let mut module = JITModule::new(jit_builder);
 
@@ -360,6 +378,23 @@ impl HostBoundary {
                     detail: e.to_string(),
                 })?;
             func_id_map.insert("cx_printn".to_string(), id);
+        }
+
+        // Pre-declare cx_printn_i128(lo: I64, hi: I64) -> void for t128 print support (CX-172).
+        // Cranelift 0.115 x64 ABI does not support I128 call params, so the I128 IR value is
+        // isplit into (lo, hi) I64 halves by the Call emitter before invoking this function.
+        {
+            use cranelift_codegen::ir::{AbiParam, types};
+            let call_conv = module.target_config().default_call_conv;
+            let mut sig = cranelift_codegen::ir::Signature::new(call_conv);
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            let id = module
+                .declare_function("cx_printn_i128", Linkage::Import, &sig)
+                .map_err(|e| JitExecutionError::CodegenFailure {
+                    detail: e.to_string(),
+                })?;
+            func_id_map.insert("cx_printn_i128".to_string(), id);
         }
 
         // Pre-declare __cx_fmod(f64, f64) -> f64 for F64 Rem lowering.
@@ -845,19 +880,36 @@ fn compile_ir_function(
                         }
                     })?;
                     let func_ref = module.declare_func_in_func(callee_id, builder.func);
-                    let cl_args: Vec<cranelift_codegen::ir::Value> = args
-                        .iter()
-                        .map(|vid| {
-                            val_map.get(vid).copied().ok_or_else(|| {
+                    // cx_printn_i128 receives its I128 IR argument as two I64 halves (lo, hi)
+                    // because Cranelift 0.115 x64 ABI does not support I128 call parameters.
+                    // isplit produces (lo, hi) matching the (i64, i64) C-ABI signature.
+                    let cl_args: Vec<cranelift_codegen::ir::Value> =
+                        if callee == "cx_printn_i128" && args.len() == 1 {
+                            let i128_val = *val_map.get(&args[0]).ok_or_else(|| {
                                 JitExecutionError::CodegenFailure {
                                     detail: format!(
-                                        "undefined value {:?} used as call arg",
-                                        vid
+                                        "undefined value {:?} used as cx_printn_i128 arg",
+                                        args[0]
                                     ),
                                 }
-                            })
-                        })
-                        .collect::<Result<_, _>>()?;
+                            })?;
+                            let (lo, hi) = builder.ins().isplit(i128_val);
+                            vec![lo, hi]
+                        } else {
+                            args
+                                .iter()
+                                .map(|vid| {
+                                    val_map.get(vid).copied().ok_or_else(|| {
+                                        JitExecutionError::CodegenFailure {
+                                            detail: format!(
+                                                "undefined value {:?} used as call arg",
+                                                vid
+                                            ),
+                                        }
+                                    })
+                                })
+                                .collect::<Result<_, _>>()?
+                        };
                     let call_inst = builder.ins().call(func_ref, &cl_args);
                     if let Some(dst_vid) = dst {
                         let results = builder.inst_results(call_inst);
@@ -4655,6 +4707,46 @@ mod determinism_tests {
         };
         let result = HostBoundary::new().execute(&module);
         assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    // ── CX-172: cx_printn_i128 intrinsic dispatch ────────────────────────────
+
+    #[test]
+    fn jit_call_cx_printn_i128_executes_without_error() {
+        // Verify that JIT-compiled code can call cx_printn_i128 with an I128 value.
+        //
+        // main() -> i32 {
+        //   v0 = const 42 : I128
+        //   cx_printn_i128(v0)
+        //   v1 = const 0 : I32
+        //   return v1
+        // }
+        let module = IrModule {
+            debug_name: "test_cx_printn_i128".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I128, value: 42 },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn_i128".to_string(),
+                            args: vec![ValueId(0)],
+                            return_ty: None,
+                        },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 0 },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(1)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT cx_printn_i128 failed: {:?}", result.unwrap_err());
         assert!(result.unwrap().exit_code.is_success());
     }
 

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -2668,13 +2668,13 @@ fn ensure_type_match(context: &str, expected: IrType, got: IrType) -> Result<(),
 // Unsupported types (e.g. Ptr, F64, StrRef) produce a structured
 // UnsupportedSemanticConstruct error so the caller gets a clear diagnostic.
 
-/// Lower `printn(n)` to `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
+/// Lower `printn(n)` to a call to the appropriate print runtime intrinsic.
 ///
-/// `printn` is a Cx builtin that prints an integer to stdout.  At the IR level
-/// it lowers to a call to the `cx_printn` runtime intrinsic, which is pre-declared
-/// in the JIT module as an imported C-ABI symbol.
+/// - `I64` arguments lower to `IrInst::Call { callee: "cx_printn", ... }`.
+/// - `I128` arguments lower to `IrInst::Call { callee: "cx_printn_i128", ... }`.
 ///
-/// Only `I64` arguments are accepted; other types produce a structured error.
+/// Both intrinsics are pre-declared in the JIT module as imported C-ABI symbols.
+/// Other argument types produce a structured error.
 fn lower_printn_stmt(
     args: &[SemanticCallArg],
     ctx: &mut LoweringCtx,
@@ -2694,29 +2694,34 @@ fn lower_printn_stmt(
         }
     };
     let arg = lower_expr(arg_expr, ctx, &mut current)?;
-    if arg.ty != IrType::I64 {
-        return Err(LoweringError::UnsupportedSemanticConstruct {
-            construct: format!(
-                "printn argument must be I64, got {:?} — other types not yet supported",
-                arg.ty
-            ),
-        });
-    }
+    let callee = match arg.ty {
+        IrType::I64 => "cx_printn",
+        IrType::I128 => "cx_printn_i128",
+        _ => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: format!(
+                    "printn argument must be I64 or I128, got {:?} — other types not yet supported",
+                    arg.ty
+                ),
+            });
+        }
+    };
     current.emit(IrInst::Call {
         dst: None,
-        callee: "cx_printn".to_string(),
+        callee: callee.to_string(),
         args: vec![arg.value],
         return_ty: None,
     })?;
     Ok(Some(current))
 }
 
-/// Lower `print(n)` or `println(n)` to `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
+/// Lower `print(n)` or `println(n)` to a call to the appropriate print runtime intrinsic.
 ///
-/// Both `print` and `println` in Cx print a value followed by a newline.  For I64
-/// arguments this maps to the `cx_printn` runtime intrinsic which is already registered
-/// in the JIT symbol table.  Non-I64 arguments (e.g. strings) produce a structured
-/// error because string printing requires string ABI support not yet available.
+/// - `I64` arguments lower to `IrInst::Call { callee: "cx_printn", ... }`.
+/// - `I128` arguments lower to `IrInst::Call { callee: "cx_printn_i128", ... }`.
+///
+/// Both intrinsics are pre-declared in the JIT symbol table.
+/// Non-integer arguments (e.g. strings) produce a structured error.
 fn lower_print_stmt(
     builtin_name: &str,
     args: &[SemanticCallArg],
@@ -2737,17 +2742,21 @@ fn lower_print_stmt(
         }
     };
     let arg = lower_expr(arg_expr, ctx, &mut current)?;
-    if arg.ty != IrType::I64 {
-        return Err(LoweringError::UnsupportedSemanticConstruct {
-            construct: format!(
-                "{} argument must be I64, got {:?} — string and other types not yet supported",
-                builtin_name, arg.ty
-            ),
-        });
-    }
+    let callee = match arg.ty {
+        IrType::I64 => "cx_printn",
+        IrType::I128 => "cx_printn_i128",
+        _ => {
+            return Err(LoweringError::UnsupportedSemanticConstruct {
+                construct: format!(
+                    "{} argument must be I64 or I128, got {:?} — string and other types not yet supported",
+                    builtin_name, arg.ty
+                ),
+            });
+        }
+    };
     current.emit(IrInst::Call {
         dst: None,
-        callee: "cx_printn".to_string(),
+        callee: callee.to_string(),
         args: vec![arg.value],
         return_ty: None,
     })?;
@@ -5997,6 +6006,96 @@ mod tests {
             "expected UnsupportedSemanticConstruct mentioning I64, got: {:?}",
             err
         );
+    }
+
+    #[test]
+    fn print_i128_lowers_to_cx_printn_i128_call() {
+        // print(42i128) must lower to IrInst::Call{callee:"cx_printn_i128"} and pass validation.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "print",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I128))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let cx_printn_i128_calls: Vec<_> = main_fn
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn_i128"))
+            .collect();
+        assert_eq!(cx_printn_i128_calls.len(), 1, "expected exactly one cx_printn_i128 call from print");
+        match cx_printn_i128_calls[0] {
+            IrInst::Call { dst, callee, args, return_ty } => {
+                assert!(dst.is_none(), "cx_printn_i128 is void — no destination");
+                assert_eq!(callee, "cx_printn_i128");
+                assert_eq!(args.len(), 1, "cx_printn_i128 takes one argument");
+                assert!(return_ty.is_none(), "cx_printn_i128 returns void");
+            }
+            _ => panic!("expected Call instruction"),
+        }
+    }
+
+    #[test]
+    fn println_i128_lowers_to_cx_printn_i128_call() {
+        // println(42i128) must lower to IrInst::Call{callee:"cx_printn_i128"} and pass validation.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "println",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I128))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let cx_printn_i128_calls: Vec<_> = main_fn
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn_i128"))
+            .collect();
+        assert_eq!(cx_printn_i128_calls.len(), 1, "expected exactly one cx_printn_i128 call from println");
+        match cx_printn_i128_calls[0] {
+            IrInst::Call { dst, callee, args, return_ty } => {
+                assert!(dst.is_none(), "cx_printn_i128 is void — no destination");
+                assert_eq!(callee, "cx_printn_i128");
+                assert_eq!(args.len(), 1, "cx_printn_i128 takes one argument");
+                assert!(return_ty.is_none(), "cx_printn_i128 returns void");
+            }
+            _ => panic!("expected Call instruction"),
+        }
+    }
+
+    #[test]
+    fn printn_i128_lowers_to_cx_printn_i128_call() {
+        // printn(42i128) must lower to IrInst::Call{callee:"cx_printn_i128"} and pass validation.
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "printn",
+                vec![SemanticCallArg::Expr(int_expr(42, SemanticType::I128))],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let main_fn = module.functions.iter().find(|f| f.name == "main").unwrap();
+        let cx_printn_i128_calls: Vec<_> = main_fn
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|inst| matches!(inst, IrInst::Call { callee, .. } if callee == "cx_printn_i128"))
+            .collect();
+        assert_eq!(cx_printn_i128_calls.len(), 1, "expected exactly one cx_printn_i128 call");
+        match cx_printn_i128_calls[0] {
+            IrInst::Call { dst, callee, args, return_ty } => {
+                assert!(dst.is_none(), "cx_printn_i128 is void — no destination");
+                assert_eq!(callee, "cx_printn_i128");
+                assert_eq!(args.len(), 1, "cx_printn_i128 takes one argument");
+                assert!(return_ty.is_none(), "cx_printn_i128 returns void");
+            }
+            _ => panic!("expected Call instruction"),
+        }
     }
 
     // assert and assert_eq are now lowerable (Phase 9 sub-packet 3) so they no

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -83,6 +83,15 @@ fn known_intrinsic_sigs() -> HashMap<String, ValidatorFunctionSig> {
             has_return: false,
         },
     );
+    // cx_printn_i128(n: I128) -> void — CX-172 t128 argument support.
+    sigs.insert(
+        "cx_printn_i128".to_string(),
+        ValidatorFunctionSig {
+            param_count: 1,
+            param_types: vec![IrType::I128],
+            has_return: false,
+        },
+    );
     sigs
 }
 
@@ -1741,5 +1750,33 @@ mod tests {
             "expected void-return shape error for cx_printn, got: {:?}",
             errors
         );
+    }
+
+    #[test]
+    fn validator_accepts_cx_printn_i128_call_with_i128_arg() {
+        // A call to `cx_printn_i128(i128)` must pass validation — seeded by known_intrinsic_sigs.
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I128, value: 42 },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_printn_i128".to_string(),
+                            args: vec![ValueId(0)],
+                            return_ty: None,
+                        },
+                    ],
+                    term: IrTerminator::Return { value: None },
+                }],
+            }],
+        };
+        assert_eq!(validate_module(&module), Ok(()));
     }
 }


### PR DESCRIPTION
Closes CX-172

## Summary

- `print(n)`, `println(n)`, `printn(n)` now accept `t128` (I128) arguments
- I128 args dispatch to a new `cx_printn_i128` runtime intrinsic; I64 args continue using `cx_printn` unchanged
- Cranelift 0.115 does not support I128 in call parameters on x64 (asserts in `isa/x64/abi.rs` unless LLVM ABI extensions are enabled), so the JIT emitter `isplit`s the I128 SSA value into `(lo: I64, hi: I64)` before the call; the host symbol reconstructs the signed i128 from the two halves

## Files changed

- `src/ir/lower.rs` — `lower_printn_stmt` and `lower_print_stmt` match on `IrType::I128` → dispatch to `"cx_printn_i128"`; unsupported-type error message updated to "I64 or I128" (existing rejection tests remain green since the message still contains "I64"); 3 new lowering tests: `print_i128_lowers_to_cx_printn_i128_call`, `println_i128_lowers_to_cx_printn_i128_call`, `printn_i128_lowers_to_cx_printn_i128_call`
- `src/ir/validate.rs` — `known_intrinsic_sigs` gains `cx_printn_i128(I128) -> void`; 1 new test: `validator_accepts_cx_printn_i128_call_with_i128_arg`
- `src/backend/cranelift/host_boundary.rs` — `cx_printn_i128(lo: i64, hi: i64)` host symbol; JIT builder symbol registration; JIT signature declaration as `(I64, I64) -> void`; `isplit` special-case in the `IrInst::Call` emitter for `cx_printn_i128`; 1 new JIT execution test: `jit_call_cx_printn_i128_executes_without_error`

## Validation

```
cargo build --features jit   → Finished (0 errors, pre-existing warnings only)
cargo test --features jit    → test result: ok. 326 passed; 0 failed
```

## Linear ticket

CX-172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added support for printing signed 128-bit integers via `print`, `println`, and `printn` functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/214)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->