### PR TITLE
CX-175: Add exit-code-based JIT parity fixtures for while-in iterator loop

### DIFF
--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -173,6 +173,9 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t108_nested_loops_in_func"
         | "t132_while_loop_exit"
         | "t133_while_in_func_exit"
+        | "t152_while_in_exit"
+        | "t153_while_in_then_exit"
+        | "t154_while_in_func_exit"
             => FeatureCategory::WhileLoop,
 
         // ── ForLoop ───────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t152_while_in_exit.cx
+++ b/src/tests/verification_matrix/t152_while_in_exit.cx
@@ -1,0 +1,34 @@
+// CX-175: exit-code-based JIT parity — while-in iterator loop at file scope.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// Uses arr:[0] indexed read (not *arr) because unary * on arrays is typed as
+// the array type by the semantic analyser, making it unusable in arithmetic.
+
+arr: [5: t64] = [10, 20, 30, 40, 50]
+
+// Sum all five elements via iteration: 10+20+30+40+50 = 150.
+total: t64 = 0
+while in arr:[0], 0..5 {
+    total = total + arr:[0]
+}
+assert_eq(total, 150)
+
+// Count iterations for exclusive range 0..3 = 3.
+count: t64 = 0
+while in arr:[0], 0..3 {
+    count = count + 1
+}
+assert_eq(count, 3)
+
+// Inclusive range 0..=4 yields 5 iterations.
+count2: t64 = 0
+while in arr:[0], 0..=4 {
+    count2 = count2 + 1
+}
+assert_eq(count2, 5)
+
+// Non-zero lower bound: indices 2..5 cover elements [30, 40, 50] = 120.
+partial: t64 = 0
+while in arr:[0], 2..5 {
+    partial = partial + arr:[0]
+}
+assert_eq(partial, 120)

--- a/src/tests/verification_matrix/t153_while_in_then_exit.cx
+++ b/src/tests/verification_matrix/t153_while_in_then_exit.cx
@@ -1,0 +1,34 @@
+// CX-175: exit-code-based JIT parity — while-in with then-chain at file scope.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// Each test uses fresh arrays because while-in mutates arr[start_slot] in place;
+// re-using an array across loops would produce incorrect accumulated values.
+
+// Test 1: combined primary+then chain: sum(a1) + sum(b1) = 6 + 15 = 21.
+a1: [3: t64] = [1, 2, 3]
+b1: [3: t64] = [4, 5, 6]
+total: t64 = 0
+while in a1:[0], 0..3 {
+    total = total + a1:[0]
+} then in b1:[0], 0..3 {
+    total = total + b1:[0]
+}
+assert_eq(total, 21)
+
+// Test 2: primary chain alone with fresh array: 10+20+30 = 60.
+a2: [3: t64] = [10, 20, 30]
+sum_a: t64 = 0
+while in a2:[0], 0..3 {
+    sum_a = sum_a + a2:[0]
+}
+assert_eq(sum_a, 60)
+
+// Test 3: inclusive range with then-chain: 5+10+3+7 = 25.
+c: [2: t64] = [5, 10]
+d: [2: t64] = [3, 7]
+result: t64 = 0
+while in c:[0], 0..=1 {
+    result = result + c:[0]
+} then in d:[0], 0..=1 {
+    result = result + d:[0]
+}
+assert_eq(result, 25)

--- a/src/tests/verification_matrix/t154_while_in_func_exit.cx
+++ b/src/tests/verification_matrix/t154_while_in_func_exit.cx
@@ -1,0 +1,27 @@
+// CX-175: exit-code-based JIT parity — while-in iterator inside a user-defined function.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+// Uses data:[0] indexed read (not *data) for the same reason as t152/t153.
+
+fnc: t64 sum_array_elems() {
+    data: [4: t64] = [100, 200, 300, 400]
+    total: t64 = 0
+    while in data:[0], 0..4 {
+        total = total + data:[0]
+    }
+    return total
+}
+
+fnc: t64 count_iters() {
+    data: [5: t64] = [1, 2, 3, 4, 5]
+    count: t64 = 0
+    while in data:[0], 0..5 {
+        count = count + 1
+    }
+    return count
+}
+
+// 100+200+300+400 = 1000.
+assert_eq(sum_array_elems(), 1000)
+
+// Five iterations for range 0..5.
+assert_eq(count_iters(), 5)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-175/add-exit-code-based-jit-parity-fixtures-for-while-in-iterator-loop

## Summary

- Adds three `PassAny` exit-code fixtures for the `while in` iterator loop construct (t152, t153, t154), following the pattern established for ForLoop (CX-124) and WhileLoop (CX-97)
- Registers all three fixtures in `feature_of()` under `WhileLoop`
- All fixtures PASS in the interpreter and SKIP in JIT (exit 127 — `WhileIn` is not yet lowerable); zero PARITY_FAILs

## Files Changed

- `src/tests/verification_matrix/t152_while_in_exit.cx` — basic while-in at file scope; exclusive/inclusive ranges, non-zero lower bound
- `src/tests/verification_matrix/t153_while_in_then_exit.cx` — while-in with then-chain; uses fresh arrays per test to avoid slot-mutation side-effects
- `src/tests/verification_matrix/t154_while_in_func_exit.cx` — while-in inside user-defined functions
- `src/diff_harness.rs` — `feature_of()` updated to classify t152/t153/t154 as `WhileLoop`

## Design Notes

The fixtures use `arr:[0]` indexed reads instead of the idiomatic `*arr` dereference. The semantic analyser types unary `*` on arrays as the array type (`[N: T]`) rather than the element type (`T`), which causes a type error when the result is used in arithmetic. `arr:[0]` resolves correctly to the element type and reads the slot that `while in` updates each iteration.

t153 uses distinct named arrays (`a1`, `a2`, `c`, `d`) per test case because `while in arr:[0]` mutates `arr[0]` in-place each iteration — re-using the same array across loops would corrupt subsequent iterations.

## Tests Run

```
cargo build --features jit
cargo test --features jit
```

## Validation Result

```
test diff_harness::tests::interpreter_baseline_all ... ok
test diff_harness::tests::jit_parity_by_feature ... ok

test result: ok. 321 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

JIT parity table (WhileLoop row after this PR):

| Feature   | PASS | SKIP | PARITY_FAIL |
|-----------|------|------|-------------|
| WhileLoop |  5   |  6   |      0      |

(3 existing while-in SKIPs + 3 new while-in-exit SKIPs = 6 total; all non-while-in fixtures continue to PASS)

## Linear Ticket

CX-175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification tests for `while in` iterator behavior across multiple scenarios: file-scope iteration, chaining with conditional operations, and usage within user-defined functions.
  * Updated test categorization to properly classify `while`-related verification tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/215)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->