### PR TITLE
CX-176: Add missing markdown fence language identifiers in cx_runtime_intrinsics_v0.1.md

### DIFF
--- a/docs/backend/cx_runtime_intrinsics_v0.1.md
+++ b/docs/backend/cx_runtime_intrinsics_v0.1.md
@@ -31,7 +31,7 @@ Phase 9 replaces those holes with:
 `src/frontend/semantic.rs` recognises these names in `analyze_call()` (around
 line 1446) and assigns `FunctionId(u32::MAX)` to mark them as non-user-defined:
 
-```
+```text
 print    println    printn
 read     input
 assert   assert_eq
@@ -39,7 +39,7 @@ assert   assert_eq
 
 The semantic node produced is:
 
-```
+```rust
 SemanticExprKind::Call {
     callee: "<name>",
     function: FunctionId(u32::MAX),   // sentinel — not a real function
@@ -60,7 +60,7 @@ reached lowering:
   through to `lower_expr`, and the inner lookup failed.
 - In `lower_expr` as `SemanticExprKind::Call`: `ctx.signature_table.get(callee)`
   returned `None`, producing:
-  ```
+  ```rust
   LoweringError::UnresolvedSemanticArtifact { artifact: "function '<name>'" }
   ```
 
@@ -72,7 +72,7 @@ pending feature.
 `is_cx_builtin(name: &str) -> bool` guards both call paths.  Any builtin hit
 during lowering now returns:
 
-```
+```rust
 LoweringError::UnsupportedSemanticConstruct {
     construct: "builtin '<name>' is not yet lowerable to IR — codegen pending (Phase 9)"
 }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-176/cx-174-add-missing-markdown-fence-language-on-cx-171-runtime

## Summary

- Added language identifiers to 4 bare opening code fences in `docs/backend/cx_runtime_intrinsics_v0.1.md`

## Changes

- `docs/backend/cx_runtime_intrinsics_v0.1.md`: Four fences fixed:
  - Line 34: builtin name list — `` ```text ``
  - Line 42: `SemanticExprKind::Call` struct literal — `` ```rust ``
  - Line 63: `LoweringError::UnresolvedSemanticArtifact` example (indented) — `` ```rust ``
  - Line 75: `LoweringError::UnsupportedSemanticConstruct` example — `` ```rust ``

## Validation

```
cargo build --features jit  →  ok (warnings only, pre-existing)
cargo test --features jit   →  321 passed; 0 failed; 0 ignored
```

## Notes

Documentation-only change. No source code modified. All tests pass unchanged.

Linear: CX-176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced backend runtime intrinsics documentation with improved code formatting and clearer error message examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/216)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->