### PR TITLE
CX-178: Add TBool support to print/println/printn intrinsic dispatch

### DIFF
--- a/docs/backend/cx_runtime_intrinsics_v0.1.md
+++ b/docs/backend/cx_runtime_intrinsics_v0.1.md
@@ -87,9 +87,9 @@ correct and contains the builtin name.
 
 | Builtin      | Category            | Return  | Backend mechanism                         | Status |
 |--------------|---------------------|---------|-------------------------------------------|--------|
-| `print`      | I/O — stdout        | void    | `IrInst::Call` to `cx_printn`             | DONE (I64 only) |
-| `println`    | I/O — stdout        | void    | `IrInst::Call` to `cx_printn`             | DONE (I64 only) |
-| `printn`     | I/O — stdout        | void    | `IrInst::Call` to `cx_printn`             | DONE (I64 only) |
+| `print`      | I/O — stdout        | void    | `IrInst::Call` to `cx_printn` / `cx_print_tbool` | DONE (I64, TBool) |
+| `println`    | I/O — stdout        | void    | `IrInst::Call` to `cx_printn` / `cx_print_tbool` | DONE (I64, TBool) |
+| `printn`     | I/O — stdout        | void    | `IrInst::Call` to `cx_printn` / `cx_print_tbool` | DONE (I64, TBool) |
 | `read`       | I/O — stdin         | str     | runtime call to `cx_read`                 | BLOCKED — str/strref layout (Phase 8) |
 | `input`      | I/O — stdin         | str     | runtime call to `cx_input`                | BLOCKED — str/strref layout (Phase 8) |
 | `assert`     | Debug / assertion   | void    | inline `Branch` + `IrTerminator::Trap`    | DONE — abort semantics |
@@ -99,25 +99,35 @@ correct and contains the builtin name.
 
 `print`, `println`, `printn` are stdout I/O.  They do not return a value.
 
-**Implementation (sub-packet 2 — COMPLETE):**
+**Implementation (sub-packet 2 — COMPLETE; TBool dispatch added in CX-178):**
 
-All three lower to `IrInst::Call { callee: "cx_printn", args: [i64_value], return_ty: None }`.
+The dispatch is type-driven:
+- `I64` argument → `IrInst::Call { callee: "cx_printn", args: [i64_value], return_ty: None }`
+- `TBool` argument → `IrInst::Call { callee: "cx_print_tbool", args: [tbool_value], return_ty: None }`
+
 Neither `cx_print` nor `cx_println` exist as distinct symbols — both `print` and `println`
-route through `cx_printn`.
+route through the same per-type intrinsic as `printn`.
 
 - `lower_printn_stmt` — handles `printn(n)` directly.
 - `lower_print_stmt` — handles both `print(n)` and `println(n)`; emits the same
-  `cx_printn` call for both (newline is always appended by the runtime shim).
+  type-dispatched call for both (newline is always appended by the runtime shim).
 
-Argument constraint: only `I64` arguments are accepted.  Non-I64 arguments
-(e.g. strings) produce a structured `UnsupportedSemanticConstruct` error, as
-string printing requires string ABI support not yet available.
+Argument constraints:
+- `I64` — integer output via `cx_printn`.
+- `TBool` — ternary-bool output via `cx_print_tbool` ("false"/"true"/"?").
+- All other types produce a structured `UnsupportedSemanticConstruct` error.
 
 The `cx_printn` symbol is:
 - Implemented in `src/backend/cranelift/host_boundary.rs` as `extern "C" fn cx_printn(n: i64)`.
 - Registered in every JIT module via `jit_builder.symbol("cx_printn", cx_printn as *const u8)`.
 - Pre-declared as an imported C-ABI function in the Cranelift module before any
   user function is compiled.
+
+The `cx_print_tbool` symbol is:
+- Implemented in `src/backend/cranelift/host_boundary.rs` as `extern "C" fn cx_print_tbool(n: i8)`.
+- Prints "false" for n=0, "true" for n=1, "?" for any other value (matches interpreter output).
+- Registered via `jit_builder.symbol("cx_print_tbool", cx_print_tbool as *const u8)`.
+- Pre-declared as an imported C-ABI function `(I8) -> void` in the Cranelift module.
 
 ### I/O builtins — read / input
 
@@ -171,9 +181,10 @@ failures.  Seven tests verify one per builtin.
 **Sub-packet 2 — print family — COMPLETE**
 
 `print`, `println`, `printn` lower via `lower_print_stmt` / `lower_printn_stmt`
-to `IrInst::Call` targeting the `cx_printn` runtime symbol.  I64 arguments
-supported; non-I64 returns a structured error.  JIT parity tests cover all
-three builtins.
+to `IrInst::Call` targeting the type-appropriate runtime symbol.  I64 arguments
+route to `cx_printn`; TBool arguments route to `cx_print_tbool` (CX-178).
+Non-supported types return a structured error.  JIT and validation tests cover
+all three builtins for both supported argument types.
 
 **Sub-packet 3 — assert / assert_eq — COMPLETE**
 
@@ -193,15 +204,18 @@ Stable C-ABI symbols that JIT-compiled Cx code may call:
 
 | Symbol         | Signature (C)                     | Provided by                          | Status |
 |----------------|-----------------------------------|--------------------------------------|--------|
-| `cx_printn`    | `void cx_printn(int64_t n)`       | `host_boundary.rs` (`extern "C"`)    | LIVE   |
-| `cx_read`      | TBD — blocked on str layout       | —                                    | BLOCKED |
-| `cx_input`     | TBD — blocked on str layout       | —                                    | BLOCKED |
+| `cx_printn`       | `void cx_printn(int64_t n)`      | `host_boundary.rs` (`extern "C"`)    | LIVE   |
+| `cx_print_tbool`  | `void cx_print_tbool(int8_t n)`  | `host_boundary.rs` (`extern "C"`)    | LIVE   |
+| `cx_read`         | TBD — blocked on str layout      | —                                    | BLOCKED |
+| `cx_input`        | TBD — blocked on str layout      | —                                    | BLOCKED |
 
 Notes:
 - `cx_print` and `cx_println` do not exist as separate symbols.  Both `print`
-  and `println` lower to calls to `cx_printn`.
+  and `println` lower to the same type-dispatched intrinsic as `printn`.
 - `cx_printn` always appends a newline (`writeln!`), matching the expected
   behaviour of all three stdout builtins for I64 values.
+- `cx_print_tbool` always appends a newline, printing "false" (n=0), "true" (n=1),
+  or "?" (any other n) to match the interpreter's `value_to_string()` output.
 - All string pointers passed to future I/O shims will be read-only; the shim
   will not take ownership and will not free.
 
@@ -212,7 +226,7 @@ Notes:
 - Handle<T> registry intrinsics — post-0.1
 - Arena allocation intrinsics — post-0.1
 - Error and panic propagation through the backend — post-0.1
-- TBool Unknown propagation — open design question tracked in Phase 8
+- TBool Unknown propagation beyond print dispatch — open design question tracked in Phase 8
 - String copy-on-boundary rules — blocked on str layout decision
 
 ---

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -275,6 +275,25 @@ extern "C" fn cx_printn(n: i64) {
     let _ = writeln!(stdout, "{n}");
 }
 
+/// Runtime intrinsic: print a ternary boolean to stdout followed by a newline.
+///
+/// Exported as `cx_print_tbool` in the JIT symbol table. JIT-compiled Cx code calls this
+/// via `IrInst::Call { callee: "cx_print_tbool", args: [tbool_value] }`.
+/// The symbol is pre-declared as an Import in every JIT module (see `execute`).
+///
+/// TBool values are stored as i8: 0 = false, 1 = true, any other value = unknown.
+/// Output matches the interpreter's `value_to_string()` for `Value::TBool(b)`.
+extern "C" fn cx_print_tbool(n: i8) {
+    use std::io::{self, Write};
+    let mut stdout = io::stdout().lock();
+    let s = match n {
+        0 => "false",
+        1 => "true",
+        _ => "?",
+    };
+    let _ = writeln!(stdout, "{s}");
+}
+
 /// Backend-private symbol name for the F64 remainder host helper.
 ///
 /// Using a mangled name (double-underscore prefix) keeps it out of the user-visible namespace.
@@ -340,6 +359,7 @@ impl HostBoundary {
         let mut jit_builder =
             JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
         jit_builder.symbol("cx_printn", cx_printn as *const u8);
+        jit_builder.symbol("cx_print_tbool", cx_print_tbool as *const u8);
         jit_builder.symbol(JIT_F64_REM_SYMBOL, host_fmod as *const u8);
         let mut module = JITModule::new(jit_builder);
 
@@ -360,6 +380,20 @@ impl HostBoundary {
                     detail: e.to_string(),
                 })?;
             func_id_map.insert("cx_printn".to_string(), id);
+        }
+
+        // Pre-declare cx_print_tbool(i8) -> void for TBool print dispatch (CX-178).
+        {
+            use cranelift_codegen::ir::AbiParam;
+            let call_conv = module.target_config().default_call_conv;
+            let mut sig = cranelift_codegen::ir::Signature::new(call_conv);
+            sig.params.push(AbiParam::new(cranelift_codegen::ir::types::I8));
+            let id = module
+                .declare_function("cx_print_tbool", Linkage::Import, &sig)
+                .map_err(|e| JitExecutionError::CodegenFailure {
+                    detail: e.to_string(),
+                })?;
+            func_id_map.insert("cx_print_tbool".to_string(), id);
         }
 
         // Pre-declare __cx_fmod(f64, f64) -> f64 for F64 Rem lowering.
@@ -4655,6 +4689,82 @@ mod determinism_tests {
         };
         let result = HostBoundary::new().execute(&module);
         assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    // ── cx_print_tbool intrinsic dispatch (CX-178) ───────────────────────────
+    //
+    // These tests verify that the `cx_print_tbool` JIT intrinsic executes
+    // successfully for all three TBool states (false=0, true=1, unknown=2).
+    //
+    // TBool values cannot be created via ConstInt (the validator rejects
+    // IrType::TBool for ConstInt); instead each test uses the same
+    // ConstInt(I8, n) → Alloca → Store → Load(TBool) materialization pattern
+    // used by the TBool calling-convention tests above.
+    //
+    // Module shape:
+    //   main() -> I32:
+    //     B0: v0 = ConstInt(I8, <raw>)
+    //         v1 = Alloca(1, 1)
+    //         Store(v1, v0)
+    //         v2 = Load(TBool, v1)
+    //         Call(cx_print_tbool, [v2])
+    //         v3 = ConstInt(I32, 0)
+    //         return v3
+
+    fn cx_print_tbool_module(raw_value: i128) -> IrModule {
+        IrModule {
+            debug_name: format!("test_cx_print_tbool_{}", raw_value),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I8, value: raw_value },
+                        IrInst::Alloca { dst: ValueId(1), size: 1, align: 1 },
+                        IrInst::Store { ptr: ValueId(1), value: ValueId(0) },
+                        IrInst::Load { dst: ValueId(2), ty: IrType::TBool, ptr: ValueId(1) },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_print_tbool".to_string(),
+                            args: vec![ValueId(2)],
+                            return_ty: None,
+                        },
+                        IrInst::ConstInt { dst: ValueId(3), ty: IrType::I32, value: 0 },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn jit_cx_print_tbool_false_executes_without_error() {
+        // TBool(0) = false: cx_print_tbool should print "false" without JIT error.
+        let module = cx_print_tbool_module(0);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed for TBool(0): {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    #[test]
+    fn jit_cx_print_tbool_true_executes_without_error() {
+        // TBool(1) = true: cx_print_tbool should print "true" without JIT error.
+        let module = cx_print_tbool_module(1);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed for TBool(1): {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    #[test]
+    fn jit_cx_print_tbool_unknown_executes_without_error() {
+        // TBool(2) = unknown: cx_print_tbool should print "?" without JIT error.
+        let module = cx_print_tbool_module(2);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed for TBool(2): {:?}", result.unwrap_err());
         assert!(result.unwrap().exit_code.is_success());
     }
 

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -361,7 +361,7 @@ pub fn lower_program(program: &SemanticProgram) -> Result<IrModule, LoweringErro
 }
 
 fn lower_program_inner(program: &SemanticProgram, trace: bool) -> Result<IrModule, LoweringError> {
-    const RESERVED_RUNTIME_INTRINSICS: &[&str] = &["cx_printn"];
+    const RESERVED_RUNTIME_INTRINSICS: &[&str] = &["cx_printn", "cx_print_tbool"];
 
     if program.stmts.is_empty() {
         return Ok(IrModule {
@@ -2668,13 +2668,17 @@ fn ensure_type_match(context: &str, expected: IrType, got: IrType) -> Result<(),
 // Unsupported types (e.g. Ptr, F64, StrRef) produce a structured
 // UnsupportedSemanticConstruct error so the caller gets a clear diagnostic.
 
-/// Lower `printn(n)` to `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
+/// Lower `printn(n)` to the appropriate type-specific runtime intrinsic call.
 ///
-/// `printn` is a Cx builtin that prints an integer to stdout.  At the IR level
-/// it lowers to a call to the `cx_printn` runtime intrinsic, which is pre-declared
+/// `printn` is a Cx builtin that prints a value to stdout.  At the IR level
+/// it lowers to a call to a type-specific runtime intrinsic, which is pre-declared
 /// in the JIT module as an imported C-ABI symbol.
 ///
-/// Only `I64` arguments are accepted; other types produce a structured error.
+/// Supported argument types:
+/// - `I64`   → `IrInst::Call { callee: "cx_printn", args: [i64_value] }`
+/// - `TBool` → `IrInst::Call { callee: "cx_print_tbool", args: [tbool_value] }` (CX-178)
+///
+/// Other argument types produce a structured `UnsupportedSemanticConstruct` error.
 fn lower_printn_stmt(
     args: &[SemanticCallArg],
     ctx: &mut LoweringCtx,
@@ -2694,29 +2698,37 @@ fn lower_printn_stmt(
         }
     };
     let arg = lower_expr(arg_expr, ctx, &mut current)?;
-    if arg.ty != IrType::I64 {
-        return Err(LoweringError::UnsupportedSemanticConstruct {
+    let callee = match arg.ty {
+        IrType::I64 => "cx_printn",
+        IrType::TBool => "cx_print_tbool",
+        _ => return Err(LoweringError::UnsupportedSemanticConstruct {
             construct: format!(
-                "printn argument must be I64, got {:?} — other types not yet supported",
+                "printn argument must be I64 or TBool, got {:?} — other types not yet supported",
                 arg.ty
             ),
-        });
-    }
+        }),
+    };
     current.emit(IrInst::Call {
         dst: None,
-        callee: "cx_printn".to_string(),
+        callee: callee.to_string(),
         args: vec![arg.value],
         return_ty: None,
     })?;
     Ok(Some(current))
 }
 
-/// Lower `print(n)` or `println(n)` to `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
+/// Lower `print(n)` or `println(n)` to the appropriate type-specific runtime intrinsic call.
 ///
-/// Both `print` and `println` in Cx print a value followed by a newline.  For I64
-/// arguments this maps to the `cx_printn` runtime intrinsic which is already registered
-/// in the JIT symbol table.  Non-I64 arguments (e.g. strings) produce a structured
-/// error because string printing requires string ABI support not yet available.
+/// Both `print` and `println` in Cx print a value followed by a newline.  The callee
+/// is selected by argument type; both builtins route through the same dispatch logic.
+///
+/// Supported argument types:
+/// - `I64`   → `IrInst::Call { callee: "cx_printn", args: [i64_value] }`
+/// - `TBool` → `IrInst::Call { callee: "cx_print_tbool", args: [tbool_value] }` (CX-178)
+///
+/// Non-supported arguments (e.g. strings) produce a structured
+/// `UnsupportedSemanticConstruct` error because string printing requires
+/// string ABI support not yet available.
 fn lower_print_stmt(
     builtin_name: &str,
     args: &[SemanticCallArg],
@@ -2737,17 +2749,19 @@ fn lower_print_stmt(
         }
     };
     let arg = lower_expr(arg_expr, ctx, &mut current)?;
-    if arg.ty != IrType::I64 {
-        return Err(LoweringError::UnsupportedSemanticConstruct {
+    let callee = match arg.ty {
+        IrType::I64 => "cx_printn",
+        IrType::TBool => "cx_print_tbool",
+        _ => return Err(LoweringError::UnsupportedSemanticConstruct {
             construct: format!(
-                "{} argument must be I64, got {:?} — string and other types not yet supported",
+                "{} argument must be I64 or TBool, got {:?} — string and other types not yet supported",
                 builtin_name, arg.ty
             ),
-        });
-    }
+        }),
+    };
     current.emit(IrInst::Call {
         dst: None,
-        callee: "cx_printn".to_string(),
+        callee: callee.to_string(),
         args: vec![arg.value],
         return_ty: None,
     })?;

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -83,6 +83,15 @@ fn known_intrinsic_sigs() -> HashMap<String, ValidatorFunctionSig> {
             has_return: false,
         },
     );
+    // cx_print_tbool(n: TBool) -> void — CX-178 ternary-bool print intrinsic.
+    sigs.insert(
+        "cx_print_tbool".to_string(),
+        ValidatorFunctionSig {
+            param_count: 1,
+            param_types: vec![IrType::TBool],
+            has_return: false,
+        },
+    );
     sigs
 }
 
@@ -1739,6 +1748,79 @@ mod tests {
                 if detail.contains("Call to 'cx_printn': callee returns void")
             )),
             "expected void-return shape error for cx_printn, got: {:?}",
+            errors
+        );
+    }
+
+    // ── cx_print_tbool intrinsic validation (CX-178) ─────────────────────────
+
+    #[test]
+    fn validator_accepts_cx_print_tbool_call_with_tbool_arg() {
+        // A well-formed call to cx_print_tbool(TBool) must pass validation.
+        // TBool cannot be created via ConstInt; materialize via ConstInt(I8) → Alloca → Store → Load(TBool).
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I8, value: 0 },
+                        IrInst::Alloca { dst: ValueId(1), size: 1, align: 1 },
+                        IrInst::Store { ptr: ValueId(1), value: ValueId(0) },
+                        IrInst::Load { dst: ValueId(2), ty: IrType::TBool, ptr: ValueId(1) },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_print_tbool".to_string(),
+                            args: vec![ValueId(2)],
+                            return_ty: None,
+                        },
+                    ],
+                    term: IrTerminator::Return { value: None },
+                }],
+            }],
+        };
+        assert_eq!(validate_module(&module), Ok(()));
+    }
+
+    #[test]
+    fn validator_rejects_cx_print_tbool_call_with_wrong_arg_type() {
+        // cx_print_tbool expects TBool; passing I64 must produce a type-mismatch error.
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I64, value: 42 },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_print_tbool".to_string(),
+                            args: vec![ValueId(0)],
+                            return_ty: None,
+                        },
+                    ],
+                    term: IrTerminator::Return { value: None },
+                }],
+            }],
+        };
+        let errors = validate_module(&module)
+            .expect_err("validator must reject wrong-type arg to cx_print_tbool");
+        assert!(
+            errors.iter().any(|err| matches!(
+                err,
+                IrValidationError::InvalidTypeUsage { detail, .. }
+                if detail.contains("Call to 'cx_print_tbool': argument 0 has type")
+                    && detail.contains("expected TBool")
+            )),
+            "expected type-mismatch error for cx_print_tbool, got: {:?}",
             errors
         );
     }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-178/cx-add-tbool-support-to-printprintlnprintn-intrinsic-dispatch

## Summary

- Adds `cx_print_tbool(n: i8)` runtime intrinsic that prints ternary boolean values — "false" (n=0), "true" (n=1), "?" (any other) — matching the interpreter's `value_to_string()` output for `Value::TBool`.
- Extends `lower_print_stmt` and `lower_printn_stmt` to dispatch `IrType::TBool` arguments to `"cx_print_tbool"` instead of returning `UnsupportedSemanticConstruct`.
- Registers `cx_print_tbool` in the validator's known intrinsic signatures (`(TBool) -> void`) and in `RESERVED_RUNTIME_INTRINSICS`.

## Files Changed

| File | Change |
|------|--------|
| `src/ir/lower.rs` | Replace `if arg.ty != IrType::I64` guard with a `match` in both `lower_print_stmt` and `lower_printn_stmt`; add `"cx_print_tbool"` to `RESERVED_RUNTIME_INTRINSICS` |
| `src/ir/validate.rs` | Add `cx_print_tbool(TBool)->void` to `known_intrinsic_sigs()`; add 2 validator unit tests |
| `src/backend/cranelift/host_boundary.rs` | Implement `extern "C" fn cx_print_tbool(n: i8)`; register JIT symbol; pre-declare `(I8)->void` import; add 3 JIT execution tests |
| `docs/backend/cx_runtime_intrinsics_v0.1.md` | Update builtin classification table, I/O section, implementation path, and runtime entry-point registry |

## Design Notes

- `IrType::TBool` maps to Cranelift `I8` (same as `IrType::Bool`). The intrinsic takes `i8` directly — no cast is needed in the JIT path.
- `SemanticType::TBool` does not exist; the semantic layer cannot currently produce `IrType::TBool` from Cx source via `lower_type()`. The dispatch changes are forward-looking for when the semantic layer adds TBool support.
- Tests are at the IR/JIT level (using the `ConstInt(I8) → Alloca → Store → Load(TBool)` materialization pattern) since `ConstInt` rejects `IrType::TBool` directly and no semantic path produces TBool-typed values.
- Output format matches interpreter: `Value::TBool(0) → "false"`, `Value::TBool(1) → "true"`, `Value::TBool(2) → "?"`.
- The name `cx_print_tbool` is reserved in `RESERVED_RUNTIME_INTRINSICS` so user-defined Cx functions cannot shadow it.
- No `.cx` fixture files added — TBool print is not yet reachable from Cx source through the semantic lowering path.

## Tests Run

```
cargo build --features jit
cargo test --features jit
```

## Validation Results

- `cargo build --features jit` — **PASS** (19 pre-existing warnings, no new warnings)
- `cargo test --features jit` — **PASS** — 326 passed, 0 failed
  - `backend::cranelift::host_boundary::determinism_tests::jit_cx_print_tbool_false_executes_without_error` ✓
  - `backend::cranelift::host_boundary::determinism_tests::jit_cx_print_tbool_true_executes_without_error` ✓
  - `backend::cranelift::host_boundary::determinism_tests::jit_cx_print_tbool_unknown_executes_without_error` ✓
  - `ir::validate::tests::validator_accepts_cx_print_tbool_call_with_tbool_arg` ✓
  - `ir::validate::tests::validator_rejects_cx_print_tbool_call_with_wrong_arg_type` ✓
  - `diff_harness::tests::jit_parity_by_feature` ✓ (0 PARITY_FAILs)

## Known Limitations

- TBool print cannot be tested end-to-end through Cx source because `SemanticType::TBool` does not exist and `SemanticType::Unknown` maps to an unsupported-type error in `lower_type()`. This is by design per the ticket scope.
- Future work: when the semantic layer gains TBool type support, `.cx` fixture coverage can be added.

## Linear Ticket

CX-178 — https://linear.app/cx-lang/issue/CX-178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Print functions now support printing boolean values (in addition to integers).

* **Documentation**
  * Updated runtime intrinsic specifications for print operations to document boolean type support.

* **Tests**
  * Added test coverage for printing boolean values with all possible encodings and type validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/217)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->