### PR TITLE
CX-179: Apply CodeRabbit validator fix on PR #217 — derive is_reserved_runtime_intrinsic from known_intrinsic_sigs

### DIFF
--- a/docs/backend/cx_runtime_intrinsics_v0.1.md
+++ b/docs/backend/cx_runtime_intrinsics_v0.1.md
@@ -87,9 +87,9 @@ correct and contains the builtin name.
 
 | Builtin      | Category            | Return  | Backend mechanism                         | Status |
 |--------------|---------------------|---------|-------------------------------------------|--------|
-| `print`      | I/O — stdout        | void    | `IrInst::Call` to `cx_printn`             | DONE (I64 only) |
-| `println`    | I/O — stdout        | void    | `IrInst::Call` to `cx_printn`             | DONE (I64 only) |
-| `printn`     | I/O — stdout        | void    | `IrInst::Call` to `cx_printn`             | DONE (I64 only) |
+| `print`      | I/O — stdout        | void    | `IrInst::Call` to `cx_printn` / `cx_print_tbool` | DONE (I64, TBool) |
+| `println`    | I/O — stdout        | void    | `IrInst::Call` to `cx_printn` / `cx_print_tbool` | DONE (I64, TBool) |
+| `printn`     | I/O — stdout        | void    | `IrInst::Call` to `cx_printn` / `cx_print_tbool` | DONE (I64, TBool) |
 | `read`       | I/O — stdin         | str     | runtime call to `cx_read`                 | BLOCKED — str/strref layout (Phase 8) |
 | `input`      | I/O — stdin         | str     | runtime call to `cx_input`                | BLOCKED — str/strref layout (Phase 8) |
 | `assert`     | Debug / assertion   | void    | inline `Branch` + `IrTerminator::Trap`    | DONE — abort semantics |
@@ -99,25 +99,35 @@ correct and contains the builtin name.
 
 `print`, `println`, `printn` are stdout I/O.  They do not return a value.
 
-**Implementation (sub-packet 2 — COMPLETE):**
+**Implementation (sub-packet 2 — COMPLETE; TBool dispatch added in CX-178):**
 
-All three lower to `IrInst::Call { callee: "cx_printn", args: [i64_value], return_ty: None }`.
+The dispatch is type-driven:
+- `I64` argument → `IrInst::Call { callee: "cx_printn", args: [i64_value], return_ty: None }`
+- `TBool` argument → `IrInst::Call { callee: "cx_print_tbool", args: [tbool_value], return_ty: None }`
+
 Neither `cx_print` nor `cx_println` exist as distinct symbols — both `print` and `println`
-route through `cx_printn`.
+route through the same per-type intrinsic as `printn`.
 
 - `lower_printn_stmt` — handles `printn(n)` directly.
 - `lower_print_stmt` — handles both `print(n)` and `println(n)`; emits the same
-  `cx_printn` call for both (newline is always appended by the runtime shim).
+  type-dispatched call for both (newline is always appended by the runtime shim).
 
-Argument constraint: only `I64` arguments are accepted.  Non-I64 arguments
-(e.g. strings) produce a structured `UnsupportedSemanticConstruct` error, as
-string printing requires string ABI support not yet available.
+Argument constraints:
+- `I64` — integer output via `cx_printn`.
+- `TBool` — ternary-bool output via `cx_print_tbool` ("false"/"true"/"?").
+- All other types produce a structured `UnsupportedSemanticConstruct` error.
 
 The `cx_printn` symbol is:
 - Implemented in `src/backend/cranelift/host_boundary.rs` as `extern "C" fn cx_printn(n: i64)`.
 - Registered in every JIT module via `jit_builder.symbol("cx_printn", cx_printn as *const u8)`.
 - Pre-declared as an imported C-ABI function in the Cranelift module before any
   user function is compiled.
+
+The `cx_print_tbool` symbol is:
+- Implemented in `src/backend/cranelift/host_boundary.rs` as `extern "C" fn cx_print_tbool(n: i8)`.
+- Prints "false" for n=0, "true" for n=1, "?" for any other value (matches interpreter output).
+- Registered via `jit_builder.symbol("cx_print_tbool", cx_print_tbool as *const u8)`.
+- Pre-declared as an imported C-ABI function `(I8) -> void` in the Cranelift module.
 
 ### I/O builtins — read / input
 
@@ -171,9 +181,10 @@ failures.  Seven tests verify one per builtin.
 **Sub-packet 2 — print family — COMPLETE**
 
 `print`, `println`, `printn` lower via `lower_print_stmt` / `lower_printn_stmt`
-to `IrInst::Call` targeting the `cx_printn` runtime symbol.  I64 arguments
-supported; non-I64 returns a structured error.  JIT parity tests cover all
-three builtins.
+to `IrInst::Call` targeting the type-appropriate runtime symbol.  I64 arguments
+route to `cx_printn`; TBool arguments route to `cx_print_tbool` (CX-178).
+Non-supported types return a structured error.  JIT and validation tests cover
+all three builtins for both supported argument types.
 
 **Sub-packet 3 — assert / assert_eq — COMPLETE**
 
@@ -193,15 +204,18 @@ Stable C-ABI symbols that JIT-compiled Cx code may call:
 
 | Symbol         | Signature (C)                     | Provided by                          | Status |
 |----------------|-----------------------------------|--------------------------------------|--------|
-| `cx_printn`    | `void cx_printn(int64_t n)`       | `host_boundary.rs` (`extern "C"`)    | LIVE   |
-| `cx_read`      | TBD — blocked on str layout       | —                                    | BLOCKED |
-| `cx_input`     | TBD — blocked on str layout       | —                                    | BLOCKED |
+| `cx_printn`       | `void cx_printn(int64_t n)`      | `host_boundary.rs` (`extern "C"`)    | LIVE   |
+| `cx_print_tbool`  | `void cx_print_tbool(int8_t n)`  | `host_boundary.rs` (`extern "C"`)    | LIVE   |
+| `cx_read`         | TBD — blocked on str layout      | —                                    | BLOCKED |
+| `cx_input`        | TBD — blocked on str layout      | —                                    | BLOCKED |
 
 Notes:
 - `cx_print` and `cx_println` do not exist as separate symbols.  Both `print`
-  and `println` lower to calls to `cx_printn`.
+  and `println` lower to the same type-dispatched intrinsic as `printn`.
 - `cx_printn` always appends a newline (`writeln!`), matching the expected
   behaviour of all three stdout builtins for I64 values.
+- `cx_print_tbool` always appends a newline, printing "false" (n=0), "true" (n=1),
+  or "?" (any other n) to match the interpreter's `value_to_string()` output.
 - All string pointers passed to future I/O shims will be read-only; the shim
   will not take ownership and will not free.
 
@@ -212,7 +226,7 @@ Notes:
 - Handle<T> registry intrinsics — post-0.1
 - Arena allocation intrinsics — post-0.1
 - Error and panic propagation through the backend — post-0.1
-- TBool Unknown propagation — open design question tracked in Phase 8
+- TBool Unknown propagation beyond print dispatch — open design question tracked in Phase 8
 - String copy-on-boundary rules — blocked on str layout decision
 
 ---

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -275,6 +275,25 @@ extern "C" fn cx_printn(n: i64) {
     let _ = writeln!(stdout, "{n}");
 }
 
+/// Runtime intrinsic: print a ternary boolean to stdout followed by a newline.
+///
+/// Exported as `cx_print_tbool` in the JIT symbol table. JIT-compiled Cx code calls this
+/// via `IrInst::Call { callee: "cx_print_tbool", args: [tbool_value] }`.
+/// The symbol is pre-declared as an Import in every JIT module (see `execute`).
+///
+/// TBool values are stored as i8: 0 = false, 1 = true, any other value = unknown.
+/// Output matches the interpreter's `value_to_string()` for `Value::TBool(b)`.
+extern "C" fn cx_print_tbool(n: i8) {
+    use std::io::{self, Write};
+    let mut stdout = io::stdout().lock();
+    let s = match n {
+        0 => "false",
+        1 => "true",
+        _ => "?",
+    };
+    let _ = writeln!(stdout, "{s}");
+}
+
 /// Backend-private symbol name for the F64 remainder host helper.
 ///
 /// Using a mangled name (double-underscore prefix) keeps it out of the user-visible namespace.
@@ -340,6 +359,7 @@ impl HostBoundary {
         let mut jit_builder =
             JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
         jit_builder.symbol("cx_printn", cx_printn as *const u8);
+        jit_builder.symbol("cx_print_tbool", cx_print_tbool as *const u8);
         jit_builder.symbol(JIT_F64_REM_SYMBOL, host_fmod as *const u8);
         let mut module = JITModule::new(jit_builder);
 
@@ -360,6 +380,20 @@ impl HostBoundary {
                     detail: e.to_string(),
                 })?;
             func_id_map.insert("cx_printn".to_string(), id);
+        }
+
+        // Pre-declare cx_print_tbool(i8) -> void for TBool print dispatch (CX-178).
+        {
+            use cranelift_codegen::ir::AbiParam;
+            let call_conv = module.target_config().default_call_conv;
+            let mut sig = cranelift_codegen::ir::Signature::new(call_conv);
+            sig.params.push(AbiParam::new(cranelift_codegen::ir::types::I8));
+            let id = module
+                .declare_function("cx_print_tbool", Linkage::Import, &sig)
+                .map_err(|e| JitExecutionError::CodegenFailure {
+                    detail: e.to_string(),
+                })?;
+            func_id_map.insert("cx_print_tbool".to_string(), id);
         }
 
         // Pre-declare __cx_fmod(f64, f64) -> f64 for F64 Rem lowering.
@@ -4655,6 +4689,82 @@ mod determinism_tests {
         };
         let result = HostBoundary::new().execute(&module);
         assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    // ── cx_print_tbool intrinsic dispatch (CX-178) ───────────────────────────
+    //
+    // These tests verify that the `cx_print_tbool` JIT intrinsic executes
+    // successfully for all three TBool states (false=0, true=1, unknown=2).
+    //
+    // TBool values cannot be created via ConstInt (the validator rejects
+    // IrType::TBool for ConstInt); instead each test uses the same
+    // ConstInt(I8, n) → Alloca → Store → Load(TBool) materialization pattern
+    // used by the TBool calling-convention tests above.
+    //
+    // Module shape:
+    //   main() -> I32:
+    //     B0: v0 = ConstInt(I8, <raw>)
+    //         v1 = Alloca(1, 1)
+    //         Store(v1, v0)
+    //         v2 = Load(TBool, v1)
+    //         Call(cx_print_tbool, [v2])
+    //         v3 = ConstInt(I32, 0)
+    //         return v3
+
+    fn cx_print_tbool_module(raw_value: i128) -> IrModule {
+        IrModule {
+            debug_name: format!("test_cx_print_tbool_{}", raw_value),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I8, value: raw_value },
+                        IrInst::Alloca { dst: ValueId(1), size: 1, align: 1 },
+                        IrInst::Store { ptr: ValueId(1), value: ValueId(0) },
+                        IrInst::Load { dst: ValueId(2), ty: IrType::TBool, ptr: ValueId(1) },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_print_tbool".to_string(),
+                            args: vec![ValueId(2)],
+                            return_ty: None,
+                        },
+                        IrInst::ConstInt { dst: ValueId(3), ty: IrType::I32, value: 0 },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn jit_cx_print_tbool_false_executes_without_error() {
+        // TBool(0) = false: cx_print_tbool should print "false" without JIT error.
+        let module = cx_print_tbool_module(0);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed for TBool(0): {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    #[test]
+    fn jit_cx_print_tbool_true_executes_without_error() {
+        // TBool(1) = true: cx_print_tbool should print "true" without JIT error.
+        let module = cx_print_tbool_module(1);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed for TBool(1): {:?}", result.unwrap_err());
+        assert!(result.unwrap().exit_code.is_success());
+    }
+
+    #[test]
+    fn jit_cx_print_tbool_unknown_executes_without_error() {
+        // TBool(2) = unknown: cx_print_tbool should print "?" without JIT error.
+        let module = cx_print_tbool_module(2);
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed for TBool(2): {:?}", result.unwrap_err());
         assert!(result.unwrap().exit_code.is_success());
     }
 

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -361,7 +361,7 @@ pub fn lower_program(program: &SemanticProgram) -> Result<IrModule, LoweringErro
 }
 
 fn lower_program_inner(program: &SemanticProgram, trace: bool) -> Result<IrModule, LoweringError> {
-    const RESERVED_RUNTIME_INTRINSICS: &[&str] = &["cx_printn"];
+    const RESERVED_RUNTIME_INTRINSICS: &[&str] = &["cx_printn", "cx_print_tbool"];
 
     if program.stmts.is_empty() {
         return Ok(IrModule {
@@ -2668,13 +2668,17 @@ fn ensure_type_match(context: &str, expected: IrType, got: IrType) -> Result<(),
 // Unsupported types (e.g. Ptr, F64, StrRef) produce a structured
 // UnsupportedSemanticConstruct error so the caller gets a clear diagnostic.
 
-/// Lower `printn(n)` to `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
+/// Lower `printn(n)` to the appropriate type-specific runtime intrinsic call.
 ///
-/// `printn` is a Cx builtin that prints an integer to stdout.  At the IR level
-/// it lowers to a call to the `cx_printn` runtime intrinsic, which is pre-declared
+/// `printn` is a Cx builtin that prints a value to stdout.  At the IR level
+/// it lowers to a call to a type-specific runtime intrinsic, which is pre-declared
 /// in the JIT module as an imported C-ABI symbol.
 ///
-/// Only `I64` arguments are accepted; other types produce a structured error.
+/// Supported argument types:
+/// - `I64`   → `IrInst::Call { callee: "cx_printn", args: [i64_value] }`
+/// - `TBool` → `IrInst::Call { callee: "cx_print_tbool", args: [tbool_value] }` (CX-178)
+///
+/// Other argument types produce a structured `UnsupportedSemanticConstruct` error.
 fn lower_printn_stmt(
     args: &[SemanticCallArg],
     ctx: &mut LoweringCtx,
@@ -2694,29 +2698,37 @@ fn lower_printn_stmt(
         }
     };
     let arg = lower_expr(arg_expr, ctx, &mut current)?;
-    if arg.ty != IrType::I64 {
-        return Err(LoweringError::UnsupportedSemanticConstruct {
+    let callee = match arg.ty {
+        IrType::I64 => "cx_printn",
+        IrType::TBool => "cx_print_tbool",
+        _ => return Err(LoweringError::UnsupportedSemanticConstruct {
             construct: format!(
-                "printn argument must be I64, got {:?} — other types not yet supported",
+                "printn argument must be I64 or TBool, got {:?} — other types not yet supported",
                 arg.ty
             ),
-        });
-    }
+        }),
+    };
     current.emit(IrInst::Call {
         dst: None,
-        callee: "cx_printn".to_string(),
+        callee: callee.to_string(),
         args: vec![arg.value],
         return_ty: None,
     })?;
     Ok(Some(current))
 }
 
-/// Lower `print(n)` or `println(n)` to `IrInst::Call { callee: "cx_printn", args: [i64_value] }`.
+/// Lower `print(n)` or `println(n)` to the appropriate type-specific runtime intrinsic call.
 ///
-/// Both `print` and `println` in Cx print a value followed by a newline.  For I64
-/// arguments this maps to the `cx_printn` runtime intrinsic which is already registered
-/// in the JIT symbol table.  Non-I64 arguments (e.g. strings) produce a structured
-/// error because string printing requires string ABI support not yet available.
+/// Both `print` and `println` in Cx print a value followed by a newline.  The callee
+/// is selected by argument type; both builtins route through the same dispatch logic.
+///
+/// Supported argument types:
+/// - `I64`   → `IrInst::Call { callee: "cx_printn", args: [i64_value] }`
+/// - `TBool` → `IrInst::Call { callee: "cx_print_tbool", args: [tbool_value] }` (CX-178)
+///
+/// Non-supported arguments (e.g. strings) produce a structured
+/// `UnsupportedSemanticConstruct` error because string printing requires
+/// string ABI support not yet available.
 fn lower_print_stmt(
     builtin_name: &str,
     args: &[SemanticCallArg],
@@ -2737,17 +2749,19 @@ fn lower_print_stmt(
         }
     };
     let arg = lower_expr(arg_expr, ctx, &mut current)?;
-    if arg.ty != IrType::I64 {
-        return Err(LoweringError::UnsupportedSemanticConstruct {
+    let callee = match arg.ty {
+        IrType::I64 => "cx_printn",
+        IrType::TBool => "cx_print_tbool",
+        _ => return Err(LoweringError::UnsupportedSemanticConstruct {
             construct: format!(
-                "{} argument must be I64, got {:?} — string and other types not yet supported",
+                "{} argument must be I64 or TBool, got {:?} — string and other types not yet supported",
                 builtin_name, arg.ty
             ),
-        });
-    }
+        }),
+    };
     current.emit(IrInst::Call {
         dst: None,
-        callee: "cx_printn".to_string(),
+        callee: callee.to_string(),
         args: vec![arg.value],
         return_ty: None,
     })?;

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -80,8 +80,8 @@ impl std::error::Error for LoweringError {}
 //
 //   Category          | Builtins          | Status
 //   ──────────────────┼───────────────────┼──────────────────────────────────
-//   I/O (stdout)      | print, println    | LOWERABLE (I64 only) — routes to cx_printn
-//   I/O (stdout)      | printn            | LOWERABLE — see lower_printn_stmt
+//   I/O (stdout)      | print, println    | LOWERABLE (I64, TBool) — routes to cx_printn / cx_print_tbool
+//   I/O (stdout)      | printn            | LOWERABLE (I64, TBool) — see lower_printn_stmt
 //   I/O (stdin)       | read, input       | blocked on Phase 8 str layout
 //   Debug / assertion | assert, assert_eq | LOWERABLE — Phase 9 sub-packet 3
 //

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -83,6 +83,15 @@ fn known_intrinsic_sigs() -> HashMap<String, ValidatorFunctionSig> {
             has_return: false,
         },
     );
+    // cx_print_tbool(n: TBool) -> void — CX-178 ternary-bool print intrinsic.
+    sigs.insert(
+        "cx_print_tbool".to_string(),
+        ValidatorFunctionSig {
+            param_count: 1,
+            param_types: vec![IrType::TBool],
+            has_return: false,
+        },
+    );
     sigs
 }
 
@@ -1739,6 +1748,79 @@ mod tests {
                 if detail.contains("Call to 'cx_printn': callee returns void")
             )),
             "expected void-return shape error for cx_printn, got: {:?}",
+            errors
+        );
+    }
+
+    // ── cx_print_tbool intrinsic validation (CX-178) ─────────────────────────
+
+    #[test]
+    fn validator_accepts_cx_print_tbool_call_with_tbool_arg() {
+        // A well-formed call to cx_print_tbool(TBool) must pass validation.
+        // TBool cannot be created via ConstInt; materialize via ConstInt(I8) → Alloca → Store → Load(TBool).
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I8, value: 0 },
+                        IrInst::Alloca { dst: ValueId(1), size: 1, align: 1 },
+                        IrInst::Store { ptr: ValueId(1), value: ValueId(0) },
+                        IrInst::Load { dst: ValueId(2), ty: IrType::TBool, ptr: ValueId(1) },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_print_tbool".to_string(),
+                            args: vec![ValueId(2)],
+                            return_ty: None,
+                        },
+                    ],
+                    term: IrTerminator::Return { value: None },
+                }],
+            }],
+        };
+        assert_eq!(validate_module(&module), Ok(()));
+    }
+
+    #[test]
+    fn validator_rejects_cx_print_tbool_call_with_wrong_arg_type() {
+        // cx_print_tbool expects TBool; passing I64 must produce a type-mismatch error.
+        let module = IrModule {
+            debug_name: "m".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I64, value: 42 },
+                        IrInst::Call {
+                            dst: None,
+                            callee: "cx_print_tbool".to_string(),
+                            args: vec![ValueId(0)],
+                            return_ty: None,
+                        },
+                    ],
+                    term: IrTerminator::Return { value: None },
+                }],
+            }],
+        };
+        let errors = validate_module(&module)
+            .expect_err("validator must reject wrong-type arg to cx_print_tbool");
+        assert!(
+            errors.iter().any(|err| matches!(
+                err,
+                IrValidationError::InvalidTypeUsage { detail, .. }
+                if detail.contains("Call to 'cx_print_tbool': argument 0 has type")
+                    && detail.contains("expected TBool")
+            )),
+            "expected type-mismatch error for cx_print_tbool, got: {:?}",
             errors
         );
     }

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -99,15 +99,19 @@ pub fn validate_module(module: &IrModule) -> Result<(), Vec<IrValidationError>> 
     let mut errors = Vec::new();
 
     // Seed known runtime intrinsic signatures before scanning user-defined functions.
+    // User functions whose names collide with reserved intrinsics are rejected by
+    // validate_function; guard the map as well so intrinsic sigs cannot be overwritten.
     let mut function_sigs: HashMap<String, ValidatorFunctionSig> = known_intrinsic_sigs();
     for function in &module.functions {
-        function_sigs.insert(function.name.clone(), ValidatorFunctionSig {
-            param_count: function.params.len(),
-            param_types: function.params.iter().map(|p| p.ty.clone()).collect(),
-            has_return: function.blocks.iter().any(|b| {
-                matches!(b.term, IrTerminator::Return { .. })
-            }),
-        });
+        if !is_reserved_runtime_intrinsic(&function.name) {
+            function_sigs.insert(function.name.clone(), ValidatorFunctionSig {
+                param_count: function.params.len(),
+                param_types: function.params.iter().map(|p| p.ty.clone()).collect(),
+                has_return: function.blocks.iter().any(|b| {
+                    matches!(b.term, IrTerminator::Return { .. })
+                }),
+            });
+        }
     }
 
     for (function_index, function) in module.functions.iter().enumerate() {
@@ -122,11 +126,14 @@ pub fn validate_module(module: &IrModule) -> Result<(), Vec<IrValidationError>> 
 }
 
 fn is_reserved_runtime_intrinsic(name: &str) -> bool {
-    matches!(
-        name,
-        "print" | "println" | "printn" | "read" | "input"
-            | "assert" | "assert_eq" | "is_known"
-    )
+    // Derive from the authoritative intrinsic registry so this check stays
+    // in sync whenever known_intrinsic_sigs() gains a new entry.
+    known_intrinsic_sigs().contains_key(name)
+        || matches!(
+            name,
+            "print" | "println" | "printn" | "read" | "input"
+                | "assert" | "assert_eq" | "is_known"
+        )
 }
 
 fn validate_function(
@@ -1598,6 +1605,32 @@ mod tests {
             err,
             IrValidationError::ReservedRuntimeIntrinsicName { function, .. }
                 if function == "is_known"
+        )));
+    }
+
+    #[test]
+    fn rejects_function_named_cx_print_tbool() {
+        // cx_print_tbool is seeded in known_intrinsic_sigs(); is_reserved_runtime_intrinsic()
+        // must derive from that registry and reject user functions with this name.
+        let errors = validate_module(&single_block_function("cx_print_tbool"))
+            .expect_err("validator should reject function named 'cx_print_tbool'");
+        assert!(errors.iter().any(|err| matches!(
+            err,
+            IrValidationError::ReservedRuntimeIntrinsicName { function, .. }
+                if function == "cx_print_tbool"
+        )));
+    }
+
+    #[test]
+    fn rejects_function_named_cx_printn() {
+        // cx_printn is seeded in known_intrinsic_sigs(); is_reserved_runtime_intrinsic()
+        // must derive from that registry and reject user functions with this name.
+        let errors = validate_module(&single_block_function("cx_printn"))
+            .expect_err("validator should reject function named 'cx_printn'");
+        assert!(errors.iter().any(|err| matches!(
+            err,
+            IrValidationError::ReservedRuntimeIntrinsicName { function, .. }
+                if function == "cx_printn"
         )));
     }
 


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-179/cx-apply-coderabbit-validator-fix-on-pr-217

## Summary

Applies two CodeRabbit fixes from the review of PR #217 (CX-178 — TBool print dispatch):

1. **Validator reservation gap closed** (`src/ir/validate.rs`): `is_reserved_runtime_intrinsic()` previously maintained a hardcoded list of Cx builtin names but did not include `cx_print_tbool` or `cx_printn` (the C-ABI intrinsic names). A user could define a Cx function named `cx_print_tbool` and the validator would not reject it, potentially shadowing the JIT intrinsic. Fixed by consulting `known_intrinsic_sigs()` as the authoritative registry, so the reserved-name check stays in sync whenever new intrinsics are added.

2. **Intrinsic sig overwrite prevented** (`src/ir/validate.rs`): `validate_module()` seeded intrinsic sigs into `function_sigs`, then unconditionally overwrote them with user-function sigs. The population loop now skips reserved names so intrinsic signatures cannot be clobbered.

3. **Stale comment updated** (`src/ir/lower.rs`): Builtin classification table still read "LOWERABLE (I64 only)" for print/println and "LOWERABLE" for printn; updated to "LOWERABLE (I64, TBool)" reflecting CX-178's dispatch changes.

## Files Changed

| File | Change |
|------|--------|
| `src/ir/validate.rs` | `is_reserved_runtime_intrinsic()` derives from `known_intrinsic_sigs()`; `validate_module()` guards intrinsic sig entries; two new rejection tests added |
| `src/ir/lower.rs` | Builtin classification comment updated to show I64, TBool support |

## Tests Run

```
cargo build --features jit
cargo test --features jit
```

## Validation Results

- `cargo build --features jit` — **PASS** (19 pre-existing warnings, no new warnings)
- `cargo test --features jit` — **PASS** — 328 passed, 0 failed
  - `ir::validate::tests::rejects_function_named_cx_print_tbool` ✓ (new)
  - `ir::validate::tests::rejects_function_named_cx_printn` ✓ (new)

## Linear Ticket

CX-179 — https://linear.app/cx-lang/issue/CX-179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for printing ternary boolean values in the print family of functions, displaying as "false", "true", or "?" based on the value state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/220)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->