### PR TITLE
CX-180: Add exit code assertions to for-loop JIT determinism tests

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -2457,6 +2457,8 @@ mod determinism_tests {
             }],
         };
         assert_deterministic(&module);
+        let r = HostBoundary::new().execute(&module).expect("JIT failed");
+        assert_eq!(r.exit_code.raw(), 42);
     }
 
     #[test]
@@ -2550,6 +2552,8 @@ mod determinism_tests {
             }],
         };
         assert_deterministic(&module);
+        let r = HostBoundary::new().execute(&module).expect("JIT failed");
+        assert_eq!(r.exit_code.raw(), 42);
     }
 
     #[test]
@@ -2645,6 +2649,8 @@ mod determinism_tests {
             }],
         };
         assert_deterministic(&module);
+        let r = HostBoundary::new().execute(&module).expect("JIT failed");
+        assert_eq!(r.exit_code.raw(), 7);
     }
 
     #[test]
@@ -2761,6 +2767,8 @@ mod determinism_tests {
             }],
         };
         assert_deterministic(&module);
+        let r = HostBoundary::new().execute(&module).expect("JIT failed");
+        assert_eq!(r.exit_code.raw(), 10);
     }
 
     // ── Two-function module ───────────────────────────────────────────────────


### PR DESCRIPTION
Closes CX-180

## Summary

Applies the CodeRabbit fix requested on PR #219. Each of the four for-loop JIT determinism test fixtures now executes its `IrModule` via `HostBoundary::new().execute()` and asserts the expected exit code in addition to the existing determinism check.

## Changes

### `src/backend/cranelift/host_boundary.rs`

After `assert_deterministic(&module)` in each for-loop test, added:

```rust
let r = HostBoundary::new().execute(&module).expect("JIT failed");
assert_eq!(r.exit_code.raw(), <N>);
```

Expected values per fixture:
- `jit_determinism_for_loop_exclusive` → 42
- `jit_determinism_for_loop_inclusive` → 42
- `jit_determinism_for_loop_zero_iterations` → 7
- `jit_determinism_for_loop_with_loop_carried_binding` → 10

## Validation

```
cargo build --features jit   ✓
cargo test --features jit    ✓  215/215 passed
```

Target for-loop tests:
- `jit_determinism_for_loop_exclusive` ... ok
- `jit_determinism_for_loop_inclusive` ... ok
- `jit_determinism_for_loop_zero_iterations` ... ok
- `jit_determinism_for_loop_with_loop_carried_binding` ... ok

## Linear ticket

CX-180