### PR TITLE
CX-186: Add exit-code-based JIT parity fixtures for BuiltinAssert pass-condition case

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -31,7 +31,7 @@ set:
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |
-| BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
+| BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80; exit-code-verified: t152 (assert pass), t153 (assert_eq pass) (CX-186) |
 | LogicalOps     | Logical AND/OR short-circuit operators       | t141, t142 |
 | Other          | Enums, generics, when-blocks, handles, macros, imports, Result/try, string interp, semicolons, copy semantics, and any fixture not matching a named category | t09–t22, t24, t27–t32, t37–t38, t42, t47, t49, t51–t54, t58–t76, t81–t88, t97–t100, t111; exit-code-verified: t143–t145 (CX-113) |
 
@@ -102,15 +102,16 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-141` (submain as of CX-141 merge window, 2026-05-12).
+Run on branch `stokowski/CX-186` (submain as of CX-186 merge window, 2026-05-15).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
 CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
 exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
 (t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
 CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), and CX-136 print/println intrinsic
-dispatch to cx_printn.
+(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
+dispatch to cx_printn, and CX-186 BuiltinAssert exit-code fixtures
+(t152_assert_pass_exit, t153_assert_eq_pass_exit).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -128,11 +129,11 @@ CompoundAssign            2      2            0
 Unary                     0      1            0
 Cast                      0      2            0
 FloatOps                  0      5            0
-BuiltinAssert             2      2            0
+BuiltinAssert             4      2            0
 LogicalOps                2      0            0
 Other                    16     48            0
 ------------------------------------------------
-Total: 155 fixtures, 0 PARITY_FAILs
+Total: 157 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -195,6 +196,14 @@ element read/write, and array passing through function calls. The 3 PASS reflect
 fixtures passing via the CX-121 ArrayAlloca JIT emit (`IrInst::ArrayAlloca` lowered to
 Cranelift via `compute_array_layout`). The 2 SKIP are t33 and t112 (print-based originals
 that remain SKIP).
+
+**BuiltinAssert pass-condition parity (CX-186):** t152_assert_pass_exit covers `assert(cond)`
+in all pass cases: literal true, truthy integer, comparison expressions, and variable values.
+t153_assert_eq_pass_exit covers `assert_eq(lhs, rhs)` in all pass cases: literal integers,
+variable-vs-literal, two equal variables, and arithmetic expressions. Both fixtures PASS in
+JIT. The 4 PASS reflect t79 and t80 (expected-fail fixtures correctly rejected by JIT) plus
+t152 and t153 (exit-code-verified pass-condition fixtures). The 2 SKIP are t77 and t78
+(output-verified originals that remain SKIP due to print dispatch limits).
 
 ---
 

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -253,6 +253,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t78_assert_eq_strings"
         | "t79_assert_false_reject"
         | "t80_assert_eq_mismatch_reject"
+        | "t152_assert_pass_exit"
+        | "t153_assert_eq_pass_exit"
             => FeatureCategory::BuiltinAssert,
 
         // ── LogicalOps ────────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t152_assert_pass_exit.cx
+++ b/src/tests/verification_matrix/t152_assert_pass_exit.cx
@@ -1,0 +1,22 @@
+// CX-186: exit-code-based JIT parity — assert pass-condition cases.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+
+// Literal true: most basic pass case.
+assert(true)
+
+// Truthy integer literal.
+assert(1)
+
+// Comparison expression that holds.
+x: t64 = 10
+assert(x > 5)
+assert(x == 10)
+
+// Negated comparison.
+assert(x < 20)
+
+// After mutation, assertion on updated value.
+x = 3
+assert(x > 0)
+x = x + 7
+assert(x == 10)

--- a/src/tests/verification_matrix/t153_assert_eq_pass_exit.cx
+++ b/src/tests/verification_matrix/t153_assert_eq_pass_exit.cx
@@ -1,0 +1,27 @@
+// CX-186: exit-code-based JIT parity — assert_eq pass-condition cases.
+// No stdout; correctness verified by exit code only (0 = all asserts held).
+
+// Literal integer equality.
+assert_eq(1, 1)
+
+// Variable equals literal.
+x: t64 = 42
+assert_eq(x, 42)
+
+// Two variables equal.
+a: t64 = 10
+b: t64 = 10
+assert_eq(a, b)
+
+// Arithmetic expression equals expected value.
+assert_eq(2 + 3, 5)
+
+// Compound expression.
+y: t64 = 6
+assert_eq(y * 2, 12)
+
+// Accumulated result.
+sum: t64 = 0
+sum = sum + a
+sum = sum + b
+assert_eq(sum, 20)


### PR DESCRIPTION
Closes CX-186

## Summary

- Add `t152_assert_pass_exit.cx`: exit-code-verified fixture for `assert(cond)` pass-condition cases (literal true, truthy int, comparison expressions, variable values, post-mutation values)
- Add `t153_assert_eq_pass_exit.cx`: exit-code-verified fixture for `assert_eq(lhs, rhs)` pass-condition cases (literal ints, variable vs literal, two equal variables, arithmetic expressions, accumulated sum)
- Register both in `feature_of()` under `FeatureCategory::BuiltinAssert` in `src/diff_harness.rs`
- Update `docs/backend/cx_jit_parity_checklist.md`: Section 1 table and Section 3 baseline + interpretation note

## Files Changed

- `src/tests/verification_matrix/t152_assert_pass_exit.cx` (new)
- `src/tests/verification_matrix/t153_assert_eq_pass_exit.cx` (new)
- `src/diff_harness.rs` — added t152 and t153 to BuiltinAssert block in `feature_of()`
- `docs/backend/cx_jit_parity_checklist.md` — updated baseline: BuiltinAssert PASS 2→4, total 155→157

## Validation

```
cargo build --features jit   ✓
cargo test --features jit    ✓  325 passed; 0 failed
```

Parity gate result:
```
BuiltinAssert   4   2   0
Total: 157 fixtures, 0 PARITY_FAILs
```

Both new fixtures PASS in JIT (not SKIP): `assert()` and `assert_eq()` with t64 values are already JIT-lowerable as confirmed by t141 (LogicalOps) and t149–t151 (ForLoop/CompoundAssign).

## Linear Ticket

CX-186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new verification tests for built-in assert functionality with exit-code validation, expanding test coverage.

* **Documentation**
  * Updated JIT parity verification checklist with expanded feature categories and refreshed baseline references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/227)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->