### PR TITLE
CX-187: Add exit-code-based JIT parity fixtures for CompoundAssign DotAccess and Index lvalue targets

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -27,7 +27,7 @@ set:
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 (output-verified); t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit (exit-code-verified, CX-121) |
-| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151 |
+| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151, t152, t153 (exit-code-verified, CX-187) |
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |
@@ -102,15 +102,17 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-141` (submain as of CX-141 merge window, 2026-05-12).
+Run on branch `stokowski/CX-187` (submain as of CX-187 merge window, 2026-05-15).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
 CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
 exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
 (t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
 CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), and CX-136 print/println intrinsic
-dispatch to cx_printn.
+(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
+dispatch to cx_printn, and CX-187 CompoundAssign DotAccess and Index exit-code
+fixtures (t152_compound_assign_dotaccess_exit, t153_compound_assign_index_exit)
+plus parser support for `arr:[i] op= value` compound assign on array elements.
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -124,7 +126,7 @@ InfiniteLoop              2      1            0
 DirectCall                7      4            0
 Struct                    6      5            0
 Array                     3      2            0
-CompoundAssign            2      2            0
+CompoundAssign            4      2            0
 Unary                     0      1            0
 Cast                      0      2            0
 FloatOps                  0      5            0
@@ -132,7 +134,7 @@ BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    16     48            0
 ------------------------------------------------
-Total: 155 fixtures, 0 PARITY_FAILs
+Total: 157 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -174,13 +176,15 @@ mirrors t20 (TBool three-way), t145 mirrors t21 (range pattern). All 3 are SKIP
 in JIT (when-block lowering not yet implemented; exits 127). Once when-block
 lowering lands, these fixtures will transition from SKIP to PASS without changes.
 
-**CompoundAssign Var-target parity (CX-119):** t151 tests all five compound-assign
+**CompoundAssign parity (CX-119/CX-187):** t151 tests all five compound-assign
 operators (+=, -=, *=, /=, %=) on a typed t64 plain variable, verified by exit
-code. Fixed a semantic-analysis bug where the Var-target branch used
-`info.inferred` only (defaulting to `Unknown` for typed variables declared with an
-explicit type annotation) instead of `binding_type()` which checks `declared`
-first. The 2 PASS reflect t128 (struct field) and t151 (plain variable); the 2
-SKIP are t26 and t41 (print-based originals that remain SKIP).
+code (CX-119). t152 tests all five operators on a struct field (DotAccess target),
+extending t128 which only covered `-=`. t153 tests all five operators on an array
+element (Index target), enabled by CX-187 parser support for `arr:[i] op= value`
+(added `AssignTarget::Index` to the AST and a new `index_compound_assign` parser
+rule). The 4 PASS reflect t128 (struct field -=), t151 (plain variable), t152
+(struct field all operators), and t153 (array element all operators); the 2 SKIP
+are t26 and t41 (print-based originals that remain SKIP).
 
 **ForLoop parity coverage (CX-124/CX-136):** t149 mirrors t48 (top-level for loop at file scope),
 covering exclusive range (`0..5`), empty range (`3..3`, 0 iterations), and inclusive range

--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -27,7 +27,7 @@ set:
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 (output-verified); t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit (exit-code-verified, CX-121) |
-| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151, t152, t153 (exit-code-verified, CX-187) |
+| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151, t152, t153 (mixed output/exit-code fixtures; CX-119, CX-187) |
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -229,6 +229,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t41_compound_assign_dot"
         | "t128_struct_compound_assign_exit"
         | "t151_var_compound_assign_exit"
+        | "t152_compound_assign_dotaccess_exit"
+        | "t153_compound_assign_index_exit"
             => FeatureCategory::CompoundAssign,
 
         // ── Unary ─────────────────────────────────────────────────────────────

--- a/src/frontend/ast.rs
+++ b/src/frontend/ast.rs
@@ -119,7 +119,8 @@ pub struct WhenArm {
 #[derive(Debug, Clone)]
 pub enum AssignTarget {
     Var(String),
-    Field(String, String), // container_name, field_name
+    Field(String, String),          // container_name, field_name
+    Index(String, Box<Expr>),       // array_name, index_expr
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -955,6 +955,34 @@ Stmt::Break { .. } | Stmt::Continue { .. } => {
             })
             .boxed();
 
+        // name:[index_expr] op= operand  — compound assign on an array element
+        let index_compound_assign = ident
+            .clone()
+            .map_with(|name, e: &mut ParseExtra<'a, '_, I>| (name, e.span().start))
+            .then_ignore(just(Token::PunctColon))
+            .then_ignore(just(Token::PunctBracketOpen))
+            .then(expr.clone())
+            .then_ignore(just(Token::PunctBracketClose))
+            .then(choice((
+                just(Token::OpAdd).to(Op::Plus),
+                just(Token::OpSub).to(Op::Minus),
+                just(Token::OpMul).to(Op::Mul),
+                just(Token::OpDiv).to(Op::Div),
+                just(Token::OpMod).to(Op::Mod),
+            )))
+            .then_ignore(just(Token::OpAssign))
+            .then(expr.clone())
+            .then_ignore(semi.clone().or_not())
+            .map(|((((name, pos), idx_expr), op), operand)| {
+                Stmt::CompoundAssign {
+                    target: AssignTarget::Index(name, Box::new(idx_expr)),
+                    op,
+                    operand,
+                    pos,
+                }
+            })
+            .boxed();
+
         // Parse a single outer macro #[name] or #[name(args)]
         let single_outer_macro = just(Token::MacroOuterOpen)
             .ignore_then(select! { Token::Identifier(name) => name })
@@ -1011,6 +1039,7 @@ Stmt::Break { .. } | Stmt::Continue { .. } => {
                 ret.clone().map(|s| (s, true)),
                 typed_assign.clone().map(|s| (s, true)),
                 compound_assign.clone().map(|s| (s, true)),
+                index_compound_assign.clone().map(|s| (s, true)),
                 assign.clone().map(|s| (s, true)),
                 if_stmt.clone().map(|s| (s, true)),
                 while_in_stmt.clone().map(|s| (s, true)),
@@ -1200,6 +1229,7 @@ Stmt::Break { .. } | Stmt::Continue { .. } => {
             ret,
             typed_assign,
             compound_assign,
+            index_compound_assign,
             index_assign,
             assign,
             block,

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -838,6 +838,23 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                         };
                         SemanticLValue::DotAccess { binding, container: container.clone(), field: field.clone(), ty: field_ty, struct_name }
                     }
+                    AssignTarget::Index(arr_name, idx_expr) => {
+                        let arr_info = self.lookup_var(arr_name)
+                            .ok_or_else(|| sem_err!(*pos, "use of undeclared variable '{}'", arr_name))?;
+                        let arr_ty = binding_type(arr_info, &tp);
+                        let elem_ty = match &arr_ty {
+                            SemanticType::Array(_, inner) => *inner.clone(),
+                            _ => SemanticType::Unknown,
+                        };
+                        let arr_pos = *pos;
+                        let sem_target = self.analyze_expr(&Expr::Ident(arr_name.clone(), arr_pos))?;
+                        let sem_index = self.analyze_expr(idx_expr)?;
+                        SemanticLValue::Index {
+                            target: Box::new(sem_target),
+                            index: Box::new(sem_index),
+                            elem_ty,
+                        }
+                    }
                 };
                 Ok(SemanticStmt::CompoundAssign {
                     target: sem_target,

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -844,7 +844,13 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                         let arr_ty = binding_type(arr_info, &tp);
                         let elem_ty = match &arr_ty {
                             SemanticType::Array(_, inner) => *inner.clone(),
-                            _ => SemanticType::Unknown,
+                            SemanticType::Unknown => SemanticType::Unknown,
+                            _ => {
+                                return Err(sem_err!(
+                                    *pos,
+                                    "compound assignment index target must be an array"
+                                ))
+                            }
                         };
                         let arr_pos = *pos;
                         let sem_target = self.analyze_expr(&Expr::Ident(arr_name.clone(), arr_pos))?;

--- a/src/tests/verification_matrix/t152_compound_assign_dotaccess_exit.cx
+++ b/src/tests/verification_matrix/t152_compound_assign_dotaccess_exit.cx
@@ -1,0 +1,24 @@
+// CX-187: exit-code-based JIT parity — compound assign on a struct field (DotAccess).
+// Exercises all five compound-assign operators (+=, -=, *=, /=, %=) via the
+// Load + Binary + Store pattern emitted by DotAccess compound assign lowering.
+// Correctness verified by exit code only (0 = all asserts held).
+struct Counter { value: t64 }
+c: Counter = Counter { value: 100 }
+c.value += 5
+assert_eq(c.value, 105)
+
+c.value = 50
+c.value -= 20
+assert_eq(c.value, 30)
+
+c.value = 6
+c.value *= 7
+assert_eq(c.value, 42)
+
+c.value = 100
+c.value /= 4
+assert_eq(c.value, 25)
+
+c.value = 17
+c.value %= 5
+assert_eq(c.value, 2)

--- a/src/tests/verification_matrix/t153_compound_assign_index_exit.cx
+++ b/src/tests/verification_matrix/t153_compound_assign_index_exit.cx
@@ -1,0 +1,19 @@
+// CX-187: exit-code-based JIT parity — compound assign on an array element (Index).
+// Exercises all five compound-assign operators (+=, -=, *=, /=, %=) via the
+// PtrAdd + Load + Binary + Store pattern emitted by Index compound assign lowering.
+// Correctness verified by exit code only (0 = all asserts held).
+arr: [5: t64] = [10, 20, 30, 40, 50]
+arr:[0] += 5
+assert_eq(arr:[0], 15)
+
+arr:[1] -= 8
+assert_eq(arr:[1], 12)
+
+arr:[2] *= 3
+assert_eq(arr:[2], 90)
+
+arr:[3] /= 8
+assert_eq(arr:[3], 5)
+
+arr:[4] %= 7
+assert_eq(arr:[4], 1)


### PR DESCRIPTION
Closes CX-187

## Summary

- Added two exit-code-based JIT parity fixtures for compound assignment on struct field (DotAccess) and array element (Index) lvalue targets
- Added parser + AST support for `arr:[i] op= value` syntax (Index compound assign), which was missing despite runtime and IR lowering being fully implemented
- CompoundAssign PASS count: 2 → 4 (157 total fixtures, 0 PARITY_FAILs)

## Changes

### New fixtures

**`t152_compound_assign_dotaccess_exit.cx`** (DotAccess target):
All five operators (+=, -=, *=, /=, %=) on a struct field via the Load + Binary + Store pattern. Extends t128 which only tested `-=`.

**`t153_compound_assign_index_exit.cx`** (Index target):
All five operators on an array element. Required parser support added below.

### Parser / AST extension (required for t153)

`arr:[i] op= value` syntax was not parseable — the `compound_assign` rule only handled `Var` and `Field` targets. This commit adds:

- `AssignTarget::Index(String, Box<Expr>)` variant in `src/frontend/ast.rs`
- `index_compound_assign` parser rule in `src/frontend/parser.rs` (mirroring the existing `index_assign` rule for direct assignment), wired into both the top-level `choice()` and `body_stmt_tagged` inside `func_def`
- `AssignTarget::Index` match arm in `src/frontend/semantic.rs`, mapping to the existing `SemanticLValue::Index` path (runtime at line 857 and IR lowering at line 822 were already complete)

### Registration and docs

- `src/diff_harness.rs`: t152 and t153 registered under `FeatureCategory::CompoundAssign`
- `docs/backend/cx_jit_parity_checklist.md`: baseline updated to 157 fixtures, CompoundAssign PASS 2→4, interpretation section updated

## Files changed

- `src/tests/verification_matrix/t152_compound_assign_dotaccess_exit.cx` (new)
- `src/tests/verification_matrix/t153_compound_assign_index_exit.cx` (new)
- `src/frontend/ast.rs` — `AssignTarget::Index` variant
- `src/frontend/parser.rs` — `index_compound_assign` rule
- `src/frontend/semantic.rs` — `AssignTarget::Index` handling
- `src/diff_harness.rs` — feature_of() registration
- `docs/backend/cx_jit_parity_checklist.md` — updated baseline

## Validation

```
cargo build --features jit   ✓  (no errors, 20 pre-existing warnings)
cargo test --features jit    ✓  325 passed, 0 failed
```

Parity gate result:
```
Feature                PASS   SKIP  PARITY_FAIL
CompoundAssign            4      2            0   (was 2/2/0)
Total: 157 fixtures, 0 PARITY_FAILs
```

## Linear ticket

CX-187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compound-assignment now supports array-element and struct-field targets (e.g., arr:[i] += v and obj.field += v).
* **Documentation**
  * Parity checklist updated to reflect the new Phase 12 baseline and expanded CompoundAssign coverage.
* **Tests**
  * Added verification tests covering dot-access and index compound-assignment cases; total fixtures increased to 157.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/228)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->