### PR TITLE
CX-190: Add JIT determinism tests for Unary operations (NegInt, NegFloat, BoolNot)

### DIFF
--- a/docs/backend/cx_jit_determinism.md
+++ b/docs/backend/cx_jit_determinism.md
@@ -1,5 +1,5 @@
 # Cx JIT Determinism Guarantee
-v1.2 — 2026-05-09
+v1.3 — 2026-05-15
 
 ---
 
@@ -131,6 +131,10 @@ This is sufficient to verify the guarantee: if the JIT pipeline were non-determi
 | `jit_determinism_logical_and_short_circuit_lhs_false` | AND short-circuit CFG — LHS false, sc_false block taken (RHS unreachable); exit 0 |
 | `jit_determinism_logical_or_lhs_false_rhs_true` | OR short-circuit CFG — LHS false, RHS block taken; path tokens (TOKEN_TRUE=42, TOKEN_RHS=7) + `Compare::Eq` + `Cast` I8→I32 verify branch identity; exit 1 |
 | `jit_determinism_logical_or_short_circuit_lhs_true` | OR short-circuit CFG — LHS true, sc_true block taken (RHS unreachable); exit 1 |
+| `jit_determinism_unary_neg_int` | `Unary::NegInt` — negation via `0 − x` (ConstInt zero + Binary/Sub on I32); expects exit 42 |
+| `jit_determinism_unary_neg_float` | `Unary::NegFloat` — negation via `0.0 − x` (ConstFloat zero + Binary/Sub on F64) + Cast F64→I32; expects exit 7 |
+| `jit_determinism_unary_bool_not_true` | `Unary::BoolNot` — NOT true: `1 == 0` (Compare/Eq on Bool) + Cast Bool→I32; expects exit 0 |
+| `jit_determinism_unary_bool_not_false` | `Unary::BoolNot` — NOT false: `0 == 0` (Compare/Eq on Bool) + Cast Bool→I32; expects exit 1 |
 
 ### Running the Tests
 


### PR DESCRIPTION
Closes CX-190

## Summary

Adds four JIT determinism tests in `mod determinism_tests` (inside `src/backend/cranelift/host_boundary.rs`) that exercise each of the three named unary operations as they are lowered by the IR:

- **NegInt** — lowered as `0 - x` (ConstInt zero + Binary/Sub): test negates −42 → 42
- **NegFloat** — lowered as `0.0 - x` (ConstFloat zero + Binary/Sub on F64), then Cast F64→I32: test negates −7.0 → 7 (exit code 7)
- **BoolNot (true)** — lowered as `x == 0` (Compare/Eq against Bool zero), then Cast Bool→I32: NOT true → 0
- **BoolNot (false)** — same lowering path: NOT false → 1

Each test calls `assert_deterministic_with_expected`, which runs two independent `HostBoundary` executions and asserts both succeed, both agree, and both match the expected exit code.

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — 130 lines added (new `// ── Unary operations ──` section after the binary arithmetic section)

## Tests Run

```
cargo build --features jit   ✓
cargo test --features jit    ✓  329 passed; 0 failed
```

### New tests (all pass)

```
jit_determinism_unary_neg_int         ok
jit_determinism_unary_neg_float       ok
jit_determinism_unary_bool_not_true   ok
jit_determinism_unary_bool_not_false  ok
```

## Linear Ticket

CX-190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Updated JIT determinism testing documentation with expanded test case coverage. Added four new unary operation test cases: integer negation, float negation with type conversion, and boolean NOT operations for true and false conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->