### PR TITLE
CX-193: Apply CodeRabbit semantic fix from PR #228 review

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -27,7 +27,7 @@ set:
 | DirectCall     | Function definitions, calls, return semantics| t02–t08, t14, t29, t50, t113 |
 | Struct         | Struct definitions, impl blocks, field access| t36, t39, t40, t43, t109, t110, t114_field_type_mismatch_reject, t115_strref_in_struct_reject, t125–t127 |
 | Array          | Array literals and array-of-result           | t33, t112 (output-verified); t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit (exit-code-verified, CX-121) |
-| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151, t152, t153 (exit-code-verified, CX-187) |
+| CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151, t152, t153 (mixed output/exit-code fixtures; CX-119, CX-187) |
 | Unary          | Unary operators (negation, etc.)             | t96 |
 | Cast           | Explicit type casts                          | t139, t140 |
 | FloatOps       | f64 operations                               | t55, t135–t138 |

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -844,7 +844,13 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                         let arr_ty = binding_type(arr_info, &tp);
                         let elem_ty = match &arr_ty {
                             SemanticType::Array(_, inner) => *inner.clone(),
-                            _ => SemanticType::Unknown,
+                            SemanticType::Unknown => SemanticType::Unknown,
+                            _ => {
+                                return Err(sem_err!(
+                                    *pos,
+                                    "compound assignment index target must be an array"
+                                ))
+                            }
                         };
                         let arr_pos = *pos;
                         let sem_target = self.analyze_expr(&Expr::Ident(arr_name.clone(), arr_pos))?;


### PR DESCRIPTION
Closes CX-193

## Summary

Applies the two CodeRabbit review findings from PR #228 (`stokowski/CX-187`).

### Fix 1 — Reject non-array index compound-assignment targets (`src/frontend/semantic.rs`)

The `AssignTarget::Index` arm in compound-assignment semantic analysis previously silently downgraded non-array targets to `SemanticType::Unknown`, allowing invalid code like `x:[0] += 1` to slip past the semantic pass and fail later at runtime or codegen. This mirrors the existing plain-assignment path (`Expr::Index` arm around line 439), which already emits `"index assignment target must be an array"` for the same case.

**Before:**
```rust
let elem_ty = match &arr_ty {
    SemanticType::Array(_, inner) => *inner.clone(),
    _ => SemanticType::Unknown,
};
```

**After:**
```rust
let elem_ty = match &arr_ty {
    SemanticType::Array(_, inner) => *inner.clone(),
    SemanticType::Unknown => SemanticType::Unknown,
    _ => {
        return Err(sem_err!(
            *pos,
            "compound assignment index target must be an array"
        ))
    }
};
```

### Fix 2 — Clarify CompoundAssign fixture provenance in parity checklist (`docs/backend/cx_jit_parity_checklist.md`)

The category table row for CompoundAssign implied all six listed fixtures (`t26`, `t41`, `t128`, `t151`, `t152`, `t153`) were exit-code-verified from CX-187. In fact `t26`/`t41` are print-based and `t151` originates from CX-119. Updated to `(mixed output/exit-code fixtures; CX-119, CX-187)`.

## Files changed

- `src/frontend/semantic.rs` — non-array guard in `AssignTarget::Index` compound-assign path
- `docs/backend/cx_jit_parity_checklist.md` — corrected CompoundAssign fixture-provenance annotation

## Validation

```
cargo build --features jit   ✓  (no errors, 20 pre-existing warnings)
cargo test --features jit    ✓  325 passed, 0 failed
```

## Notes

This PR targets `stokowski/CX-187` (PR #228) and must merge after PR #228. It carries only the two incremental fixes on top of that branch.

## Linear ticket

CX-193