### PR TITLE
CX-194: Unify lower.rs reserved intrinsic list with validate.rs registry

### DIFF
--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -361,7 +361,7 @@ pub fn lower_program(program: &SemanticProgram) -> Result<IrModule, LoweringErro
 }
 
 fn lower_program_inner(program: &SemanticProgram, trace: bool) -> Result<IrModule, LoweringError> {
-    const RESERVED_RUNTIME_INTRINSICS: &[&str] = &["cx_printn"];
+    let reserved_runtime_intrinsics = crate::ir::validate::runtime_intrinsic_names();
 
     if program.stmts.is_empty() {
         return Ok(IrModule {
@@ -385,7 +385,7 @@ fn lower_program_inner(program: &SemanticProgram, trace: bool) -> Result<IrModul
     for stmt in &program.stmts {
         match stmt {
             SemanticStmt::FuncDef(function) => {
-                if RESERVED_RUNTIME_INTRINSICS.contains(&function.name.as_str()) {
+                if reserved_runtime_intrinsics.contains(function.name.as_str()) {
                     return Err(LoweringError::UnsupportedSemanticConstruct {
                         construct: format!(
                             "function name '{}' is reserved for runtime intrinsics",
@@ -5862,6 +5862,26 @@ mod tests {
             ),
             "builtin '{}' should produce UnsupportedSemanticConstruct mentioning its name, got: {:?}",
             name, err
+        );
+    }
+
+    #[test]
+    fn rejects_user_function_named_cx_printn() {
+        // lower_program_inner derives reserved C-ABI names from validate::runtime_intrinsic_names();
+        // a user function named "cx_printn" must be rejected regardless of the hardcoded list.
+        let program = SemanticProgram {
+            stmts: vec![semantic_function("cx_printn", vec![], None, vec![], None)],
+            enums: vec![],
+        };
+        let err = lower_program(&program).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                LoweringError::UnsupportedSemanticConstruct { construct }
+                if construct.contains("cx_printn") && construct.contains("reserved")
+            ),
+            "expected reserved-name error for 'cx_printn', got: {:?}",
+            err
         );
     }
 

--- a/src/ir/validate.rs
+++ b/src/ir/validate.rs
@@ -86,6 +86,14 @@ fn known_intrinsic_sigs() -> HashMap<String, ValidatorFunctionSig> {
     sigs
 }
 
+/// Return the C-ABI names of every known runtime intrinsic.
+///
+/// Authoritative set shared between the validator and the IR lowering pass so
+/// that both agree on which names are reserved JIT runtime symbols.
+pub fn runtime_intrinsic_names() -> HashSet<String> {
+    known_intrinsic_sigs().into_keys().collect()
+}
+
 pub fn validate_module(module: &IrModule) -> Result<(), Vec<IrValidationError>> {
     let mut errors = Vec::new();
 


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-194/cx-apply-coderabbit-intrinsic-registry-cleanup-on-pr-220

## Summary

Applies the CodeRabbit nitpick from the review of PR #220 (CX-179):

`RESERVED_RUNTIME_INTRINSICS` in `lower_program_inner` was a hardcoded `&[&str]` constant that could drift from `known_intrinsic_sigs()` in `validate.rs` whenever a new C-ABI intrinsic was added. This was the exact scenario CodeRabbit flagged: when CX-179 added `cx_print_tbool`, the constant in `lower.rs` had to be manually updated alongside the registry in `validate.rs` — a fragile two-place update.

Fix: export a `pub fn runtime_intrinsic_names() -> HashSet<String>` from `validate.rs`, derived from `known_intrinsic_sigs()`, and have `lower_program_inner` call it instead of maintaining its own literal array. Both the lowering guard and the validator now share a single authoritative source. Future intrinsics added to `known_intrinsic_sigs()` are automatically reserved in the lowering pass.

## Files Changed

| File | Change |
|------|--------|
| `src/ir/validate.rs` | Add `pub fn runtime_intrinsic_names()` derived from `known_intrinsic_sigs()` |
| `src/ir/lower.rs` | Replace `const RESERVED_RUNTIME_INTRINSICS` with `let reserved_runtime_intrinsics = crate::ir::validate::runtime_intrinsic_names()`; add `rejects_user_function_named_cx_printn` test |

## Tests Run

```
cargo build --features jit
cargo test --features jit
```

## Validation Results

- `cargo build --features jit` — **PASS** (20 pre-existing warnings, no new warnings)
- `cargo test --features jit` — **PASS** — 326 passed, 0 failed
  - `ir::lower::tests::rejects_user_function_named_cx_printn` ✓ (new)

## Linear Ticket

CX-194 — https://linear.app/cx-lang/issue/CX-194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced function name validation to consistently prevent users from creating functions with names that conflict with reserved runtime identifiers, ensuring clearer error detection and more reliable function definition.

* **Tests**
  * Added test coverage to verify that user-defined functions with reserved function names are properly rejected with appropriate error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/235)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->