### PR TITLE
CX-195: Add JIT determinism tests for BuiltinAssert Trap path

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -3492,6 +3492,148 @@ mod determinism_tests {
         assert_deterministic(&module);
     }
 
+    // ── BuiltinAssert Trap path ───────────────────────────────────────────────
+
+    #[test]
+    fn jit_determinism_builtin_assert_pass() {
+        // Models the BuiltinAssert pass path: assert(1 == 1).
+        //
+        // Cx lowers `assert(cond)` to:
+        //   Compare(Eq, lhs, rhs) → Branch { cond, then: pass_block, else: trap_block }
+        //
+        // CFG:
+        //   block0:
+        //     v0 = const 1 : I32
+        //     v1 = const 1 : I32
+        //     v2 = Compare(Eq, v0, v1)   → 1 (true)
+        //     branch v2, block1, block2
+        //   block1:                       // pass path — taken (condition is true)
+        //     v3 = const 0 : I32
+        //     return v3                   // → exit code 0
+        //   block2:                       // abort path — unreachable (condition is always true)
+        //     trap
+        //
+        // Expected: deterministic, exit code 0.
+        let module = IrModule {
+            debug_name: "det_assert_pass".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 1 },
+                            IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 1 },
+                            IrInst::Compare {
+                                dst: ValueId(2),
+                                op: CompareOp::Eq,
+                                lhs: ValueId(0),
+                                rhs: ValueId(1),
+                            },
+                        ],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(2),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(3),
+                            ty: IrType::I32,
+                            value: 0,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Trap,
+                    },
+                ],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 0);
+    }
+
+    #[test]
+    fn jit_determinism_builtin_assert_abort_on_failure() {
+        // Models the BuiltinAssert abort-on-failure CFG structure.
+        //
+        // Cx lowers `assert(cond)` to:
+        //   Branch { cond, then: pass_block, else: trap_block }
+        //
+        // When the condition is false at runtime the else (Trap) block fires.
+        // Executing Trap in-process raises SIGILL, so for test safety the
+        // condition is forced to Bool 1 (true) — the pass path is always taken
+        // and Trap is never entered at runtime.  The test exercises the Trap
+        // instruction in the compiled CFG and confirms that the JIT generates
+        // identical code and exit code across two independent compilations.
+        //
+        // CFG:
+        //   block0:
+        //     v0 = const Bool 1            // forced true — pass condition
+        //     branch v0, block1, block2
+        //   block1:                        // pass path — taken
+        //     v1 = const 0 : I32
+        //     return v1                    // → exit code 0
+        //   block2:                        // abort path — Trap, NOT reached at runtime
+        //     trap
+        //
+        // Expected: deterministic, exit code 0.
+        let module = IrModule {
+            debug_name: "det_assert_abort".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::Bool,
+                            value: 1,
+                        }],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(0),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(1),
+                            ty: IrType::I32,
+                            value: 0,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(1)) },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Trap,
+                    },
+                ],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 0);
+    }
+
     // ── Jump + block parameters ───────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
Closes CX-195

## Summary

- Adds two determinism tests to the `determinism_tests` module in `src/backend/cranelift/host_boundary.rs` for the BuiltinAssert Trap path.
- `jit_determinism_builtin_assert_pass`: models `assert(1 == 1)` — uses `Compare(Eq, 1, 1)` → `Branch` with Trap in the else block; condition is always true so Trap is unreachable; verifies the pass path exits 0 deterministically.
- `jit_determinism_builtin_assert_abort_on_failure`: models the abort-on-failure CFG structure (Trap in the else/abort block) with a forced `Bool 1` condition so the Trap block is never entered at runtime; verifies that the Trap instruction in the compiled CFG produces a deterministic exit code 0 across two independent compilations.

## Design note on abort-on-failure

Cranelift lowers `IrTerminator::Trap` to `ud2` on x86-64. Executing `ud2` in-process sends `SIGILL` and kills the test runner. The abort-on-failure test therefore verifies **codegen determinism** of the Trap path rather than runtime behavior: the Trap instruction is present in the compiled CFG and the JIT generates identical code twice, but the branch condition is held true so the Trap block is never entered at runtime.

## Files changed

- `src/backend/cranelift/host_boundary.rs` — 142 lines added (two tests in `determinism_tests`)

## Validation

```
cargo build --features jit  ✓
cargo test --features jit   ✓  328 passed; 0 failed
```

New tests confirmed passing:
```
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_builtin_assert_pass ... ok
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_builtin_assert_abort_on_failure ... ok
```

## Linear ticket

CX-195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added two JIT determinism tests for the BuiltinAssert lowering path to ensure deterministic compilation behavior. Tests validate proper handling of assertion conditions and abort scenarios, confirming consistent runtime outcomes across different execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/236)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->