### PR TITLE
CX-200: Rebase CX-190 Unary determinism tests onto submain

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -3287,6 +3287,136 @@ mod determinism_tests {
         assert_deterministic(&module);
     }
 
+    // ── Unary operations ─────────────────────────────────────────────────────
+
+    #[test]
+    fn jit_determinism_unary_neg_int() {
+        // NegInt is lowered as `0 - x` (ConstInt zero + Binary/Sub).
+        // main() -> I32 { v0=-42i32; v1=0i32; v2=v1-v0=42; return v2 }  → 42
+        let module = IrModule {
+            debug_name: "det_neg_int".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: -42 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 0 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Sub,
+                            ty: IrType::I32,
+                            lhs: ValueId(1),
+                            rhs: ValueId(0),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
+
+    #[test]
+    fn jit_determinism_unary_neg_float() {
+        // NegFloat is lowered as `0.0 - x` (ConstFloat zero + Binary/Sub on F64).
+        // Cast F64→I32 to produce a verifiable integer exit code.
+        // main() -> I32 { v0=-7.0f64; v1=0.0f64; v2=v1-v0=7.0; v3=cast F64→I32 7.0=7; return v3 }  → 7
+        let module = IrModule {
+            debug_name: "det_neg_float".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstFloat { dst: ValueId(0), value: -7.0 },
+                        IrInst::ConstFloat { dst: ValueId(1), value: 0.0 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Sub,
+                            ty: IrType::F64,
+                            lhs: ValueId(1),
+                            rhs: ValueId(0),
+                        },
+                        IrInst::Cast { dst: ValueId(3), from: IrType::F64, to: IrType::I32, value: ValueId(2) },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 7);
+    }
+
+    #[test]
+    fn jit_determinism_unary_bool_not_true() {
+        // BoolNot is lowered as `x == 0` (Compare/Eq against Bool zero).
+        // NOT true: (1 == 0) → false (0); Cast Bool→I32 for exit code.
+        // main() -> I32 { v0=1(Bool); v1=0(Bool); v2=(v0==v1)=0; v3=cast Bool→I32 0=0; return v3 }  → 0
+        let module = IrModule {
+            debug_name: "det_bool_not_true".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::Bool, value: 1 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::Bool, value: 0 },
+                        IrInst::Compare {
+                            dst: ValueId(2),
+                            op: CompareOp::Eq,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Cast { dst: ValueId(3), from: IrType::Bool, to: IrType::I32, value: ValueId(2) },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 0);
+    }
+
+    #[test]
+    fn jit_determinism_unary_bool_not_false() {
+        // BoolNot is lowered as `x == 0` (Compare/Eq against Bool zero).
+        // NOT false: (0 == 0) → true (1); Cast Bool→I32 for exit code.
+        // main() -> I32 { v0=0(Bool); v1=0(Bool); v2=(v0==v1)=1; v3=cast Bool→I32 1=1; return v3 }  → 1
+        let module = IrModule {
+            debug_name: "det_bool_not_false".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::Bool, value: 0 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::Bool, value: 0 },
+                        IrInst::Compare {
+                            dst: ValueId(2),
+                            op: CompareOp::Eq,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Cast { dst: ValueId(3), from: IrType::Bool, to: IrType::I32, value: ValueId(2) },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 1);
+    }
+
     // ── Alloca + Store + Load ─────────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-200/cx-rebase-cx-190-unary-determinism-pr

## Summary

- Cherry-picks CX-190 commit (`d5ea1ba`) onto current `submain` (`b1a3537`)
- Adds four JIT determinism tests for Unary operations in `src/backend/cranelift/host_boundary.rs`
- No conflicts: `host_boundary.rs` was untouched by all intermediate submain commits (CX-187, CX-193, CX-194, CX-196)

## Tests added (`determinism_tests` mod)

- `jit_determinism_unary_neg_int` — NegInt lowered as `0 - x` (ConstInt/Binary/Sub on I32), expects exit code 42
- `jit_determinism_unary_neg_float` — NegFloat lowered as `0.0 - x` (ConstFloat/Binary/Sub on F64 + Cast→I32), expects exit code 7
- `jit_determinism_unary_bool_not_true` — BoolNot lowered as `x == 0` (Compare/Eq on Bool + Cast→I32), NOT true → 0
- `jit_determinism_unary_bool_not_false` — BoolNot NOT false → 1

## Files changed

- `src/backend/cranelift/host_boundary.rs` — +130 lines (4 new `#[test]` functions)

## Validation

```
cargo build --features jit   → ok (20 pre-existing warnings, 0 errors)
cargo test --features jit    → test result: ok. 330 passed; 0 failed; 0 ignored
```

New tests confirmed passing:
- `jit_determinism_unary_neg_int` ... ok
- `jit_determinism_unary_neg_float` ... ok
- `jit_determinism_unary_bool_not_true` ... ok
- `jit_determinism_unary_bool_not_false` ... ok

## Linear ticket

CX-200: https://linear.app/cx-lang/issue/CX-200/cx-rebase-cx-190-unary-determinism-pr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added deterministic execution tests for unary operations (integer and float negation, boolean NOT) to verify consistent behavior across independent runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->