### PR TITLE
CX-202: Apply CodeRabbit path-token fix on CX-198 logical OR determinism test

### DIFF
--- a/docs/backend/cx_jit_determinism.md
+++ b/docs/backend/cx_jit_determinism.md
@@ -127,6 +127,10 @@ This is sufficient to verify the guarantee: if the JIT pipeline were non-determi
 | `jit_determinism_call_multiple` | Two calls to the same callee; verifies repeated `declare_func_in_func` stability |
 | `jit_determinism_compound_assign_dot_access` | `CompoundAssign` DotAccess lvalue — `PtrOffset` + `Load` + `Binary::Add` + `Store` on a non-first struct field |
 | `jit_determinism_compound_assign_index` | `CompoundAssign` Index lvalue — `ArrayAlloca` + `PtrAdd` + `Load` + `Binary::Add` + `Store` on an array element |
+| `jit_determinism_logical_and_lhs_true_rhs_true` | AND short-circuit CFG — LHS true, RHS block taken; `ConstInt(Bool)` + `Branch` + `Jump` with block param; exit 1 |
+| `jit_determinism_logical_and_short_circuit_lhs_false` | AND short-circuit CFG — LHS false, sc_false block taken (RHS unreachable); exit 0 |
+| `jit_determinism_logical_or_lhs_false_rhs_true` | OR short-circuit CFG — LHS false, RHS block taken; path tokens (TOKEN_TRUE=42, TOKEN_RHS=7) + `Compare::Eq` + `Cast` I8→I32 verify branch identity; exit 1 |
+| `jit_determinism_logical_or_short_circuit_lhs_true` | OR short-circuit CFG — LHS true, sc_true block taken (RHS unreachable); exit 1 |
 
 ### Running the Tests
 

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -5232,6 +5232,367 @@ mod determinism_tests {
         assert_deterministic(&module);
     }
 
+    // ── Logical AND/OR short-circuit (CX-192) ────────────────────────────────
+    //
+    // Each test models the canonical 4-block short-circuit CFG that lower_logical
+    // produces for `&&` and `||`:
+    //
+    //  AND:  block0 (eval LHS) → Branch(lhs):
+    //            then → block1 (eval RHS)  → Jump block3(rhs_i32)
+    //            else → block2 (sc_false)  → Jump block3(0)
+    //        block3(result: I32) → Return result
+    //
+    //  OR:   block0 (eval LHS) → Branch(lhs):
+    //            then → block1 (sc_true)   → Jump block3(1)
+    //            else → block2 (eval RHS)  → Jump block3(rhs_i32)
+    //        block3(result: I32) → Return result
+    //
+    // All four tests use assert_deterministic_with_expected to verify both
+    // determinism (identical exit codes across two independent JIT runs) and
+    // correct short-circuit semantics.
+
+    #[test]
+    fn jit_determinism_logical_and_lhs_true_rhs_true() {
+        // true && true → 1.
+        // LHS=true (1) → Branch takes rhs block; rhs block emits I32(1) → merge.
+        // sc_false block (unreachable) would emit I32(0).
+        //
+        // main() -> I32 {
+        //   block0: v0=true(Bool); branch v0, block1(rhs), block2(sc)
+        //   block1 (rhs, taken): v1=1(I32); jump block3(v1)
+        //   block2 (sc_false, not taken): v2=0(I32); jump block3(v2)
+        //   block3(v3: I32): return v3
+        // }
+        // Expected: 1
+        let module = IrModule {
+            debug_name: "det_logical_and_true_true".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::Bool,
+                            value: 1,
+                        }],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(0),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(1),
+                            ty: IrType::I32,
+                            value: 1,
+                        }],
+                        term: IrTerminator::Jump {
+                            target: BlockId(3),
+                            args: vec![ValueId(1)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(2),
+                            ty: IrType::I32,
+                            value: 0,
+                        }],
+                        term: IrTerminator::Jump {
+                            target: BlockId(3),
+                            args: vec![ValueId(2)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(3),
+                        params: vec![BlockParam {
+                            value: ValueId(3),
+                            ty: IrType::I32,
+                            read_only: false,
+                        }],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    },
+                ],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 1);
+    }
+
+    #[test]
+    fn jit_determinism_logical_and_short_circuit_lhs_false() {
+        // false && X → 0 (short-circuit: RHS block is unreachable).
+        // LHS=false (0) → Branch takes sc_false block (else arm); result = 0.
+        // rhs block is never entered; the value it would emit does not affect
+        // the result.
+        //
+        // main() -> I32 {
+        //   block0: v0=false(Bool); branch v0, block1(rhs), block2(sc)
+        //   block1 (rhs, not taken): v1=1(I32); jump block3(v1)
+        //   block2 (sc_false, taken): v2=0(I32); jump block3(v2)
+        //   block3(v3: I32): return v3
+        // }
+        // Expected: 0
+        let module = IrModule {
+            debug_name: "det_logical_and_sc_false".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::Bool,
+                            value: 0,
+                        }],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(0),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(1),
+                            ty: IrType::I32,
+                            value: 1,
+                        }],
+                        term: IrTerminator::Jump {
+                            target: BlockId(3),
+                            args: vec![ValueId(1)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(2),
+                            ty: IrType::I32,
+                            value: 0,
+                        }],
+                        term: IrTerminator::Jump {
+                            target: BlockId(3),
+                            args: vec![ValueId(2)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(3),
+                        params: vec![BlockParam {
+                            value: ValueId(3),
+                            ty: IrType::I32,
+                            read_only: false,
+                        }],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    },
+                ],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 0);
+    }
+
+    #[test]
+    fn jit_determinism_logical_or_lhs_false_rhs_true() {
+        // false || true → 1.
+        // LHS=false (0) → Branch takes rhs block (else arm); RHS block emits TOKEN_RHS → merge.
+        // sc_true block (unreachable) would emit TOKEN_TRUE instead.
+        //
+        // Path-token design: both blocks pass a distinct I32 token to block3 so that
+        // taking the wrong branch is detectable even though the logical result is 1
+        // for either path:
+        //   TOKEN_TRUE = 42  (sent if sc_true is wrongly taken)
+        //   TOKEN_RHS  =  7  (sent if rhs is correctly taken)
+        // block3 compares the received token to TOKEN_RHS; returns 1 on match, 0 on mismatch.
+        //
+        // main() -> I32 {
+        //   block0: v0=false(Bool); branch v0, block1(sc_true), block2(rhs)
+        //   block1 (sc_true, not taken): v1=42(I32); jump block3(v1)
+        //   block2 (rhs, taken):         v2=7(I32);  jump block3(v2)
+        //   block3(v3: I32):
+        //     v4=7(I32)            // TOKEN_RHS constant for comparison
+        //     v5=Compare(v3 Eq v4) // I8: 1 if rhs taken, 0 if sc_true wrongly taken
+        //     v6=Cast(I8→I32, v5)
+        //     return v6
+        // }
+        // Expected: 1 (rhs taken → token=7 → 7==7 → 1)
+        let module = IrModule {
+            debug_name: "det_logical_or_false_true".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::Bool,
+                            value: 0,
+                        }],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(0),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(1),
+                            ty: IrType::I32,
+                            value: 42, // TOKEN_TRUE — wrong path; should not be taken
+                        }],
+                        term: IrTerminator::Jump {
+                            target: BlockId(3),
+                            args: vec![ValueId(1)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(2),
+                            ty: IrType::I32,
+                            value: 7, // TOKEN_RHS — correct path
+                        }],
+                        term: IrTerminator::Jump {
+                            target: BlockId(3),
+                            args: vec![ValueId(2)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(3),
+                        params: vec![BlockParam {
+                            value: ValueId(3),
+                            ty: IrType::I32,
+                            read_only: false,
+                        }],
+                        insts: vec![
+                            IrInst::ConstInt {
+                                dst: ValueId(4),
+                                ty: IrType::I32,
+                                value: 7, // TOKEN_RHS: expected token when rhs is taken
+                            },
+                            IrInst::Compare {
+                                dst: ValueId(5),
+                                op: CompareOp::Eq,
+                                lhs: ValueId(3),
+                                rhs: ValueId(4),
+                            },
+                            IrInst::Cast {
+                                dst: ValueId(6),
+                                from: IrType::I8,
+                                to: IrType::I32,
+                                value: ValueId(5),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(6)) },
+                    },
+                ],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 1);
+    }
+
+    #[test]
+    fn jit_determinism_logical_or_short_circuit_lhs_true() {
+        // true || X → 1 (short-circuit: RHS block is unreachable).
+        // LHS=true (1) → Branch takes sc_true block (then arm); result = 1.
+        // rhs block is never entered.
+        //
+        // main() -> I32 {
+        //   block0: v0=true(Bool); branch v0, block1(sc_true), block2(rhs)
+        //   block1 (sc_true, taken): v1=1(I32); jump block3(v1)
+        //   block2 (rhs, not taken): v2=0(I32); jump block3(v2)
+        //   block3(v3: I32): return v3
+        // }
+        // Expected: 1
+        let module = IrModule {
+            debug_name: "det_logical_or_sc_true".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::Bool,
+                            value: 1,
+                        }],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(0),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(1),
+                            ty: IrType::I32,
+                            value: 1,
+                        }],
+                        term: IrTerminator::Jump {
+                            target: BlockId(3),
+                            args: vec![ValueId(1)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(2),
+                            ty: IrType::I32,
+                            value: 0,
+                        }],
+                        term: IrTerminator::Jump {
+                            target: BlockId(3),
+                            args: vec![ValueId(2)],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(3),
+                        params: vec![BlockParam {
+                            value: ValueId(3),
+                            ty: IrType::I32,
+                            read_only: false,
+                        }],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    },
+                ],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 1);
+    }
+
     // ── SsaBind support (CX-77 Phase 9 sub-packet 2) ─────────────────────────
 
     #[test]


### PR DESCRIPTION
Closes CX-202

## Summary

Cherry-picks the CX-192/CX-198 logical short-circuit determinism tests (4 new tests in `determinism_tests`) and applies the CodeRabbit path-token fix flagged in the review of PR #239 (CX-198).

**Problem (CodeRabbit review on PR #239 — CHANGES_REQUESTED):**
The `jit_determinism_logical_or_lhs_false_rhs_true` test was weak: both `block1` (sc_true) and `block2` (rhs) emitted `I32(1)`, so a wrong-branch execution would still produce exit code 1 and pass silently.

**Fix applied:**
- `block1` (sc_true, should NOT be taken): now emits `TOKEN_TRUE = 42`
- `block2` (rhs, correct path): now emits `TOKEN_RHS = 7`
- `block3` receives the token, compares it to `TOKEN_RHS` via `Compare::Eq` (→ I8), casts `I8 → I32`, and returns the result
- Taking the right branch: `7 == 7 → 1` (exit 1, test passes)
- Taking the wrong branch: `42 == 7 → 0` (exit 0, test fails)
- `assert_deterministic_with_expected(&module, 1)` unchanged

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — 4 new JIT determinism tests; `jit_determinism_logical_or_lhs_false_rhs_true` rewritten with path-token CFG
- `docs/backend/cx_jit_determinism.md` — 4 new coverage table rows (OR row description updated to mention path tokens)

## Tests Run

```
cargo build --features jit   ✓
cargo test --features jit    ✓  338 passed; 0 failed
```

New tests specifically:
```
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_logical_and_lhs_true_rhs_true ... ok
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_logical_and_short_circuit_lhs_false ... ok
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_logical_or_lhs_false_rhs_true ... ok
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_logical_or_short_circuit_lhs_true ... ok
```

## Notes

- CX-198 (PR #239) remains open; this branch supersedes it for the OR test fix.
- The three other tests (AND true/true, AND short-circuit, OR short-circuit) are carried as-is from CX-198 since CodeRabbit only flagged the OR false→rhs test as weak.

## Linear Ticket

CX-202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added JIT determinism tests for short-circuit logical operators (`&&` and `||`) to validate consistent behavior across independent compilations.

* **Documentation**
  * Updated test coverage documentation with four new logical operator determinism test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->