### PR TITLE
CX-205: Add Unary and BuiltinAssert coverage rows to cx_jit_determinism.md

### DIFF
--- a/docs/backend/cx_jit_determinism.md
+++ b/docs/backend/cx_jit_determinism.md
@@ -135,6 +135,12 @@ This is sufficient to verify the guarantee: if the JIT pipeline were non-determi
 | `jit_determinism_logical_and_short_circuit_lhs_false` | AND short-circuit CFG — LHS false, sc_false block taken (RHS unreachable); exit 0 |
 | `jit_determinism_logical_or_lhs_false_rhs_true` | OR short-circuit CFG — LHS false, RHS block taken; path tokens (TOKEN_TRUE=42, TOKEN_RHS=7) + `Compare::Eq` + `Cast` I8→I32 verify branch identity; exit 1 |
 | `jit_determinism_logical_or_short_circuit_lhs_true` | OR short-circuit CFG — LHS true, sc_true block taken (RHS unreachable); exit 1 |
+| `jit_determinism_unary_neg_int` | `NegInt` lowered as `0 - x` — `ConstInt` zero + `Binary::Sub` on I32; exit 42 |
+| `jit_determinism_unary_neg_float` | `NegFloat` lowered as `0.0 - x` — `ConstFloat` zero + `Binary::Sub` on F64 + `Cast` F64→I32; exit 7 |
+| `jit_determinism_unary_bool_not_true` | `BoolNot` lowered as `x == 0` — `ConstInt(Bool)` + `Compare::Eq` + `Cast` Bool→I32; NOT true → 0; exit 0 |
+| `jit_determinism_unary_bool_not_false` | `BoolNot` lowered as `x == 0` — `ConstInt(Bool)` + `Compare::Eq` + `Cast` Bool→I32; NOT false → 1; exit 1 |
+| `jit_determinism_builtin_assert_pass` | `BuiltinAssert` pass path — `Compare::Eq` + `Branch` to pass/trap blocks; pass block taken (1==1); `Trap` block compiled but unreachable; exit 0 |
+| `jit_determinism_builtin_assert_abort_on_failure` | `BuiltinAssert` abort-on-failure CFG — `ConstInt(Bool 1)` + `Branch`; `Trap` instruction in compiled CFG; forced-true condition keeps Trap unreachable at runtime; exit 0 |
 
 ### Running the Tests
 


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-205/update-cx-jit-determinismmd-add-coverage-table-rows-for-unary-and

## Summary

- Added 4 coverage table rows for Unary determinism tests (`NegInt`, `NegFloat`, `BoolNot` true path, `BoolNot` false path)
- Added 2 coverage table rows for BuiltinAssert determinism tests (pass path and abort-on-failure CFG structure)

## Files Changed

- `docs/backend/cx_jit_determinism.md` — 6 new rows appended to the Test Coverage table

## Tests Run

```
cargo build --features jit
cargo test --features jit determinism
```

## Validation Results

```
test result: ok. 58 passed; 0 failed; 0 ignored; 0 measured; 284 filtered out
```

All 58 determinism tests pass, including all 6 newly documented tests.

## Linear Ticket

CX-205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended JIT determinism test coverage documentation with new test cases for unary operations (negation, boolean NOT) and built-in assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->