### PR TITLE
CX-208: Add JIT determinism tests for F64 comparison (fcmp)

### DIFF
--- a/docs/backend/cx_jit_determinism.md
+++ b/docs/backend/cx_jit_determinism.md
@@ -1,5 +1,5 @@
 # Cx JIT Determinism Guarantee
-v1.2 — 2026-05-09
+v1.3 — 2026-05-16
 
 ---
 
@@ -135,6 +135,20 @@ This is sufficient to verify the guarantee: if the JIT pipeline were non-determi
 | `jit_determinism_logical_and_short_circuit_lhs_false` | AND short-circuit CFG — LHS false, sc_false block taken (RHS unreachable); exit 0 |
 | `jit_determinism_logical_or_lhs_false_rhs_true` | OR short-circuit CFG — LHS false, RHS block taken; path tokens (TOKEN_TRUE=42, TOKEN_RHS=7) + `Compare::Eq` + `Cast` I8→I32 verify branch identity; exit 1 |
 | `jit_determinism_logical_or_short_circuit_lhs_true` | OR short-circuit CFG — LHS true, sc_true block taken (RHS unreachable); exit 1 |
+| `jit_determinism_fcmp_eq_true` | `fcmp` `Equal` — 1.5 == 1.5 → true path; exit 1 |
+| `jit_determinism_fcmp_eq_false` | `fcmp` `Equal` — 1.5 == 2.5 → false path; exit 0 |
+| `jit_determinism_fcmp_ne_true` | `fcmp` `NotEqual` — 1.5 != 2.5 → true path; exit 1 |
+| `jit_determinism_fcmp_ne_false` | `fcmp` `NotEqual` — 2.5 != 2.5 → false path; exit 0 |
+| `jit_determinism_fcmp_lt_true` | `fcmp` `LessThan` — 1.5 < 2.5 → true path; exit 1 |
+| `jit_determinism_fcmp_lt_false` | `fcmp` `LessThan` — 2.5 < 1.5 → false path; exit 0 |
+| `jit_determinism_fcmp_le_true` | `fcmp` `LessThanOrEqual` — 1.5 <= 2.5 (strict-less) → true path; exit 1 |
+| `jit_determinism_fcmp_le_equal` | `fcmp` `LessThanOrEqual` — 1.5 <= 1.5 (equal boundary) → true path; exit 1 |
+| `jit_determinism_fcmp_le_false` | `fcmp` `LessThanOrEqual` — 2.5 <= 1.5 → false path; exit 0 |
+| `jit_determinism_fcmp_gt_true` | `fcmp` `GreaterThan` — 2.5 > 1.5 → true path; exit 1 |
+| `jit_determinism_fcmp_gt_false` | `fcmp` `GreaterThan` — 1.5 > 2.5 → false path; exit 0 |
+| `jit_determinism_fcmp_ge_true` | `fcmp` `GreaterThanOrEqual` — 2.5 >= 1.5 (strict-greater) → true path; exit 1 |
+| `jit_determinism_fcmp_ge_equal` | `fcmp` `GreaterThanOrEqual` — 1.5 >= 1.5 (equal boundary) → true path; exit 1 |
+| `jit_determinism_fcmp_ge_false` | `fcmp` `GreaterThanOrEqual` — 1.5 >= 2.5 → false path; exit 0 |
 
 ### Running the Tests
 

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -3085,6 +3085,83 @@ mod determinism_tests {
         );
     }
 
+    /// Build a two-block if/else module that compares two F64 constants via fcmp.
+    ///
+    /// ```text
+    /// main() -> I32 {
+    ///   block0:
+    ///     v0 = const lhs : F64
+    ///     v1 = const rhs : F64
+    ///     v2 = compare op(v0, v1)   // I8 via fcmp (ordered)
+    ///     branch v2, block1[], block2[]
+    ///   block1:          // true path
+    ///     v3 = const true_val : I32
+    ///     return v3
+    ///   block2:          // false path
+    ///     v4 = const false_val : I32
+    ///     return v4
+    /// }
+    /// ```
+    fn float_compare_branch_module(
+        lhs: f64,
+        rhs: f64,
+        op: CompareOp,
+        true_val: i128,
+        false_val: i128,
+    ) -> IrModule {
+        IrModule {
+            debug_name: "det_fcmp_branch".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstFloat { dst: ValueId(0), value: lhs },
+                            IrInst::ConstFloat { dst: ValueId(1), value: rhs },
+                            IrInst::Compare {
+                                dst: ValueId(2),
+                                op,
+                                lhs: ValueId(0),
+                                rhs: ValueId(1),
+                            },
+                        ],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(2),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(3),
+                            ty: IrType::I32,
+                            value: true_val,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(4),
+                            ty: IrType::I32,
+                            value: false_val,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(4)) },
+                    },
+                ],
+            }],
+        }
+    }
+
     // ── ConstInt + Return ─────────────────────────────────────────────────────
 
     #[test]
@@ -6687,5 +6764,105 @@ mod determinism_tests {
             }],
         };
         assert_deterministic_with_expected(&module, 30);
+    }
+
+    // ── F64 comparison (fcmp) determinism ─────────────────────────────────────
+
+    #[test]
+    fn jit_determinism_fcmp_eq_true() {
+        // 1.5 == 1.5 → ordered Equal → true path → exit 1
+        let m = float_compare_branch_module(1.5, 1.5, CompareOp::Eq, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_eq_false() {
+        // 1.5 == 2.5 → ordered Equal → false path → exit 0
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Eq, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ne_true() {
+        // 1.5 != 2.5 → ordered NotEqual → true path → exit 1
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Ne, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ne_false() {
+        // 2.5 != 2.5 → ordered NotEqual → false path → exit 0
+        let m = float_compare_branch_module(2.5, 2.5, CompareOp::Ne, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_lt_true() {
+        // 1.5 < 2.5 → ordered LessThan → true path → exit 1
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Lt, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_lt_false() {
+        // 2.5 < 1.5 → ordered LessThan → false path → exit 0
+        let m = float_compare_branch_module(2.5, 1.5, CompareOp::Lt, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_le_true() {
+        // 1.5 <= 2.5 → ordered LessThanOrEqual (strict-less case) → true path → exit 1
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Le, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_le_equal() {
+        // 1.5 <= 1.5 → ordered LessThanOrEqual (equal boundary) → true path → exit 1
+        let m = float_compare_branch_module(1.5, 1.5, CompareOp::Le, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_le_false() {
+        // 2.5 <= 1.5 → ordered LessThanOrEqual → false path → exit 0
+        let m = float_compare_branch_module(2.5, 1.5, CompareOp::Le, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_gt_true() {
+        // 2.5 > 1.5 → ordered GreaterThan → true path → exit 1
+        let m = float_compare_branch_module(2.5, 1.5, CompareOp::Gt, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_gt_false() {
+        // 1.5 > 2.5 → ordered GreaterThan → false path → exit 0
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Gt, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ge_true() {
+        // 2.5 >= 1.5 → ordered GreaterThanOrEqual (strict-greater case) → true path → exit 1
+        let m = float_compare_branch_module(2.5, 1.5, CompareOp::Ge, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ge_equal() {
+        // 1.5 >= 1.5 → ordered GreaterThanOrEqual (equal boundary) → true path → exit 1
+        let m = float_compare_branch_module(1.5, 1.5, CompareOp::Ge, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ge_false() {
+        // 1.5 >= 2.5 → ordered GreaterThanOrEqual → false path → exit 0
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Ge, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
     }
 }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-208/cx-208-add-jit-determinism-tests-for-f64-comparison-fcmp-and-update-cx

## Summary

- Adds 14 `jit_determinism_fcmp_*` tests in `determinism_tests` module covering all six ordered fcmp operators (Eq, Ne, Lt, Le, Gt, Ge), each with a true-branch and a false-branch case; Le and Ge also include an equality-boundary case
- Adds a local `float_compare_branch_module` helper inside `determinism_tests` (mirrors the one in `jit_tests` — the two are sibling modules and cannot share helpers)
- Updates `docs/backend/cx_jit_determinism.md` to v1.3 with the 14 new rows in the Test Coverage table

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — helper + 14 tests appended to `determinism_tests`
- `docs/backend/cx_jit_determinism.md` — version bumped to v1.3, coverage table extended

## Validation

```
cargo build --features jit   ✓ (warnings pre-existing, no new ones)
cargo test --features jit    ✓ 356 passed; 0 failed
```

New tests isolated:
```
cargo test --features jit -- jit_determinism_fcmp
running 14 tests
... all ok
```

## Linear Ticket

CX-208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded determinism test suite with new tests for floating-point comparison operations, covering equality, ordering, and boundary cases.

* **Documentation**
  * Updated Cx JIT determinism specification document with new floating-point comparison test entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->