### PR TITLE
CX-209: Rebase CX-117 FloatOps/Cast exit-code parity fixtures onto submain

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -29,8 +29,8 @@ set:
 | Array          | Array literals and array-of-result           | t33, t112 (output-verified); t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit (exit-code-verified, CX-121) |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151, t152, t153 (mixed output/exit-code fixtures; CX-119, CX-187) |
 | Unary          | Unary operators (negation, etc.)             | t96 |
-| Cast           | Explicit type casts                          | t139, t140 |
-| FloatOps       | f64 operations                               | t55, t135–t138 |
+| Cast           | Explicit type casts                          | t139, t140, t157, t158 |
+| FloatOps       | f64 operations                               | t55, t135–t138, t155–t156 |
 | BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
 | LogicalOps     | Logical AND/OR short-circuit operators       | t141, t142 |
 | Other          | Enums, generics, when-blocks, handles, macros, imports, Result/try, string interp, semicolons, copy semantics, and any fixture not matching a named category | t09–t22, t24, t27–t32, t37–t38, t42, t47, t49, t51–t54, t58–t76, t81–t88, t97–t100, t111; exit-code-verified: t143–t145 (CX-113); integration: t154_integration_multifn (CX-182) |
@@ -102,7 +102,7 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-196` (submain as of CX-196 merge window, 2026-05-15).
+Run on branch `stokowski/CX-209` (submain as of CX-209 merge window, 2026-05-16).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
 CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
@@ -113,8 +113,10 @@ CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
 dispatch to cx_printn, CX-187 CompoundAssign DotAccess and Index exit-code
 fixtures (t152_compound_assign_dotaccess_exit, t153_compound_assign_index_exit)
 plus parser support for `arr:[i] op= value` compound assign on array elements,
-and CX-182 integration multi-function PassWithOutput fixture
-(t154_integration_multifn) rebased onto submain via CX-196.
+CX-182 integration multi-function PassWithOutput fixture
+(t154_integration_multifn) rebased onto submain via CX-196, and CX-117/CX-209
+FloatOps/Cast exit-code fixtures (t155_float_arith_mod_exit, t156_float_neg_exit,
+t157_cast_neg_t32_to_f64_exit, t158_cast_t64_to_f64_exit).
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -130,13 +132,13 @@ Struct                    6      5            0
 Array                     3      2            0
 CompoundAssign            4      2            0
 Unary                     0      1            0
-Cast                      0      2            0
-FloatOps                  0      5            0
+Cast                      0      4            0
+FloatOps                  0      7            0
 BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    17     48            0
 ------------------------------------------------
-Total: 158 fixtures, 0 PARITY_FAILs
+Total: 162 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -240,6 +240,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── Cast ─────────────────────────────────────────────────────────────
         "t139_cast_t32_to_f64_exit"
         | "t140_cast_f64_truncate_exit"
+        | "t157_cast_neg_t32_to_f64_exit"
+        | "t158_cast_t64_to_f64_exit"
             => FeatureCategory::Cast,
 
         // ── FloatOps ──────────────────────────────────────────────────────────
@@ -248,6 +250,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t136_float_arith_sub_exit"
         | "t137_float_arith_mul_exit"
         | "t138_float_arith_div_exit"
+        | "t155_float_arith_mod_exit"
+        | "t156_float_neg_exit"
             => FeatureCategory::FloatOps,
 
         // ── BuiltinAssert ─────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t155_float_arith_mod_exit.cx
+++ b/src/tests/verification_matrix/t155_float_arith_mod_exit.cx
@@ -1,0 +1,17 @@
+// CX-209: exit-code-based JIT parity — f64 modulo (remainder).
+// Scaled exact check: multiply remainder by 10 before casting to t32.
+// This catches backend drift hidden by direct truncation (e.g. 1.9 → 1).
+a: f64 = 10.0
+b: f64 = 3.0
+rem: f64 = a % b
+scale: f64 = 10.0
+product: f64 = rem * scale
+n: t32 = product
+assert_eq(n, 10)
+
+x: f64 = 5.5
+y: f64 = 2.0
+rem2: f64 = x % y
+product2: f64 = rem2 * scale
+m: t32 = product2
+assert_eq(m, 15)

--- a/src/tests/verification_matrix/t156_float_neg_exit.cx
+++ b/src/tests/verification_matrix/t156_float_neg_exit.cx
@@ -1,0 +1,12 @@
+// CX-209: exit-code-based JIT parity — unary f64 negation.
+// Negation lowers to ConstFloat(0.0) + Binary(Sub, F64).
+// Results cast to t32 for assert_eq (f64 not yet supported by assert_eq).
+a: f64 = 5.0
+neg: f64 = -a
+n: t32 = neg
+assert_eq(n, -5)
+
+b: f64 = 3.0
+neg2: f64 = -b
+m: t32 = neg2
+assert_eq(m, -3)

--- a/src/tests/verification_matrix/t157_cast_neg_t32_to_f64_exit.cx
+++ b/src/tests/verification_matrix/t157_cast_neg_t32_to_f64_exit.cx
@@ -1,0 +1,11 @@
+// CX-209: exit-code-based JIT parity — negative t32->f64 widening cast.
+// Verifies that sign is preserved when a negative t32 widens to f64.
+a: t32 = -42
+b: f64 = a
+c: t32 = b
+assert_eq(c, -42)
+
+x: t32 = -100
+y: f64 = x
+z: t32 = y
+assert_eq(z, -100)

--- a/src/tests/verification_matrix/t158_cast_t64_to_f64_exit.cx
+++ b/src/tests/verification_matrix/t158_cast_t64_to_f64_exit.cx
@@ -1,0 +1,11 @@
+// CX-209: exit-code-based JIT parity — t64->f64 widening cast.
+// Exercises the I64->F64 conversion path (fcvt_from_sint on a 64-bit value).
+a: t64 = 42
+b: f64 = a
+c: t32 = b
+assert_eq(c, 42)
+
+x: t64 = -100
+y: f64 = x
+z: t32 = y
+assert_eq(z, -100)


### PR DESCRIPTION
Closes CX-209

## Summary

Rebases the CX-117 FloatOps/Cast exit-code parity fixtures onto current submain, renumbering them to the next available slots (t155–t158) since the original numbers (t143–t146) were occupied by when-block and array fixtures that landed concurrently.

- **t155_float_arith_mod_exit** — f64 modulo (BinaryOp::Rem on F64); uses CX-131/CX-132 scaled exact check (multiply remainder by 10.0 before t32 cast) to prevent backend drift hiding behind integer truncation
- **t156_float_neg_exit** — unary f64 negation (lowers to ConstFloat(0.0) + Binary(Sub, F64))
- **t157_cast_neg_t32_to_f64_exit** — negative t32→f64 widening; verifies sign preservation
- **t158_cast_t64_to_f64_exit** — t64→f64 widening (I64→F64 fcvt_from_sint path)

All four fixtures are SKIP in the current JIT (float ops and cast lowering not yet implemented). Zero PARITY_FAILs maintained.

## Files Changed

- `src/tests/verification_matrix/t155_float_arith_mod_exit.cx` (new)
- `src/tests/verification_matrix/t156_float_neg_exit.cx` (new)
- `src/tests/verification_matrix/t157_cast_neg_t32_to_f64_exit.cx` (new)
- `src/tests/verification_matrix/t158_cast_t64_to_f64_exit.cx` (new)
- `src/diff_harness.rs` — feature_of(): Cast arm +t157+t158, FloatOps arm +t155+t156
- `docs/backend/cx_jit_parity_checklist.md` — Section 1 table updated; Section 3 baseline updated (Cast 2→4 SKIP, FloatOps 5→7 SKIP, 158→162 fixtures)

## Validation

```
cargo build --features jit && cargo test --features jit
```

**Result: 342 passed; 0 failed; finished in 1.38s**

## Linear Ticket

CX-209: https://linear.app/cx-lang/issue/CX-209/rebase-cx-117-floatopscast-exit-code-parity-fixtures-onto-current

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added four new verification tests for floating-point operations (modulo, negation) and type casting (t32→f64 and t64→f64 widening casts) to improve JIT parity coverage.

* **Documentation**
  * Updated JIT parity checklist baseline with new fixture data and revised totals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->