### PR TITLE
CX-210: Add jit_eval_order_* unit tests for evaluation order structural guarantee

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -3026,6 +3026,269 @@ mod jit_tests {
         assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
         assert_eq!(result.unwrap().exit_code.raw(), 1); // 10 > 3 = true
     }
+
+    #[test]
+    fn jit_eval_order_div_lhs_is_dividend() {
+        // Binary{Div, lhs=20, rhs=4} must yield 20/4=5, not 4/20=0.
+        // A backend that swaps lhs/rhs would compute 4/20=0 (integer division).
+        let module = IrModule {
+            debug_name: "test_eval_order_div".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 20 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 4 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Div,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 5); // 20 / 4
+    }
+
+    #[test]
+    fn jit_eval_order_rem_lhs_is_dividend() {
+        // Binary{Rem, lhs=10, rhs=3} must yield 10%3=1, not 3%10=3.
+        // A backend that swaps lhs/rhs would compute 3%10=3.
+        let module = IrModule {
+            debug_name: "test_eval_order_rem".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 10 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 3 },
+                        IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Rem,
+                            ty: IrType::I32,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(2)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 1); // 10 % 3
+    }
+
+    #[test]
+    fn jit_eval_order_compare_lt_lhs_is_left_operand() {
+        // Compare{Lt, lhs=3, rhs=10} must yield 1 (3 < 10 = true).
+        // A backend that swaps lhs/rhs would compute 10 < 3 = false → 0.
+        use crate::ir::instr::CompareOp;
+        let module = IrModule {
+            debug_name: "test_eval_order_compare_lt".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 3 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 10 },
+                        IrInst::Compare {
+                            dst: ValueId(2),
+                            op: CompareOp::Lt,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Cast {
+                            dst: ValueId(3),
+                            from: IrType::I8,
+                            to: IrType::I32,
+                            value: ValueId(2),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 1); // 3 < 10 = true
+    }
+
+    #[test]
+    fn jit_eval_order_compare_le_lhs_is_left_operand() {
+        // Compare{Le, lhs=3, rhs=10} must yield 1 (3 <= 10 = true).
+        // A backend that swaps lhs/rhs would compute 10 <= 3 = false → 0.
+        use crate::ir::instr::CompareOp;
+        let module = IrModule {
+            debug_name: "test_eval_order_compare_le".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 3 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 10 },
+                        IrInst::Compare {
+                            dst: ValueId(2),
+                            op: CompareOp::Le,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Cast {
+                            dst: ValueId(3),
+                            from: IrType::I8,
+                            to: IrType::I32,
+                            value: ValueId(2),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 1); // 3 <= 10 = true
+    }
+
+    #[test]
+    fn jit_eval_order_compare_ge_lhs_is_left_operand() {
+        // Compare{Ge, lhs=10, rhs=3} must yield 1 (10 >= 3 = true).
+        // A backend that swaps lhs/rhs would compute 3 >= 10 = false → 0.
+        use crate::ir::instr::CompareOp;
+        let module = IrModule {
+            debug_name: "test_eval_order_compare_ge".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 10 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 3 },
+                        IrInst::Compare {
+                            dst: ValueId(2),
+                            op: CompareOp::Ge,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Cast {
+                            dst: ValueId(3),
+                            from: IrType::I8,
+                            to: IrType::I32,
+                            value: ValueId(2),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 1); // 10 >= 3 = true
+    }
+
+    #[test]
+    fn jit_eval_order_compare_ne_lhs_rhs_unequal() {
+        // Compare{Ne, lhs=5, rhs=10} must yield 1 (5 != 10 = true).
+        // Ne is symmetric so operand swap cannot be detected via result;
+        // this test verifies that Ne semantics are implemented correctly.
+        use crate::ir::instr::CompareOp;
+        let module = IrModule {
+            debug_name: "test_eval_order_compare_ne".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 5 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 10 },
+                        IrInst::Compare {
+                            dst: ValueId(2),
+                            op: CompareOp::Ne,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Cast {
+                            dst: ValueId(3),
+                            from: IrType::I8,
+                            to: IrType::I32,
+                            value: ValueId(2),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 1); // 5 != 10 = true
+    }
+
+    #[test]
+    fn jit_eval_order_compare_eq_lhs_rhs_equal() {
+        // Compare{Eq, lhs=7, rhs=7} must yield 1 (7 == 7 = true).
+        // Eq is symmetric so operand swap cannot be detected via result;
+        // this test verifies that Eq semantics are implemented correctly.
+        use crate::ir::instr::CompareOp;
+        let module = IrModule {
+            debug_name: "test_eval_order_compare_eq".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![
+                        IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 7 },
+                        IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 7 },
+                        IrInst::Compare {
+                            dst: ValueId(2),
+                            op: CompareOp::Eq,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        },
+                        IrInst::Cast {
+                            dst: ValueId(3),
+                            from: IrType::I8,
+                            to: IrType::I32,
+                            value: ValueId(2),
+                        },
+                    ],
+                    term: IrTerminator::Return { value: Some(ValueId(3)) },
+                }],
+            }],
+        };
+        let result = HostBoundary::new().execute(&module);
+        assert!(result.is_ok(), "JIT failed: {:?}", result.unwrap_err());
+        assert_eq!(result.unwrap().exit_code.raw(), 1); // 7 == 7 = true
+    }
 }
 
 // ── JIT determinism tests (require the `jit` feature) ────────────────────────


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-210/add-jit-eval-order-unit-tests-for-evaluation-order-structural

## Summary

- Added 7 new `jit_eval_order_*` unit tests to `mod jit_tests` in `src/backend/cranelift/host_boundary.rs`
- Extends the existing 3 eval-order tests (Sub, nested-Sub, Gt) to cover all remaining non-commutative operations and the full `CompareOp` variant set

## New Tests

| Test | Op | Verifies |
|------|----|----------|
| `jit_eval_order_div_lhs_is_dividend` | `Div` | `Div{lhs=20, rhs=4}` → 5, not 0 (swapped: 4÷20=0) |
| `jit_eval_order_rem_lhs_is_dividend` | `Rem` | `Rem{lhs=10, rhs=3}` → 1, not 3 (swapped: 3%10=3) |
| `jit_eval_order_compare_lt_lhs_is_left_operand` | `Lt` | `Lt{lhs=3, rhs=10}` → 1, not 0 (swapped: 10<3=false) |
| `jit_eval_order_compare_le_lhs_is_left_operand` | `Le` | `Le{lhs=3, rhs=10}` → 1, not 0 (swapped: 10<=3=false) |
| `jit_eval_order_compare_ge_lhs_is_left_operand` | `Ge` | `Ge{lhs=10, rhs=3}` → 1, not 0 (swapped: 3>=10=false) |
| `jit_eval_order_compare_ne_lhs_rhs_unequal` | `Ne` | `Ne{lhs=5, rhs=10}` → 1 (verifies Ne semantics; symmetric op) |
| `jit_eval_order_compare_eq_lhs_rhs_equal` | `Eq` | `Eq{lhs=7, rhs=7}` → 1 (verifies Eq semantics; symmetric op) |

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — 263 insertions inside `mod jit_tests`

## Validation

```
cargo build --features jit   ✓  (warnings pre-existing, no new warnings)
cargo test --features jit    ✓  349 passed; 0 failed
```

All 10 `jit_eval_order_*` tests pass (3 pre-existing + 7 new).

## Notes

- `Mul` and `Add` are commutative — operand swap is undetectable via result; not tested here (consistent with prior art)
- `Ne` and `Eq` are symmetric — the new tests verify correct semantics rather than operand-order detectability, with comments explaining why
- Linear ticket: CX-210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added JIT integration tests validating operand-order semantics for arithmetic and comparison operations to ensure correct execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->