### PR TITLE
CX-212: Add JIT determinism tests for F64 function argument and return value passing

### DIFF
--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -5741,6 +5741,123 @@ mod determinism_tests {
         assert_deterministic(&module);
     }
 
+    // ── F64 function argument and return value passing ────────────────────────
+
+    #[test]
+    fn jit_determinism_call_f64_return_value() {
+        // Call a no-arg function that returns an F64 constant; cast to I32 for exit code.
+        //
+        // get_float() -> F64 { v0=42.0f64; return v0 }
+        // main() -> I32 { v0=call get_float() -> F64; v1=cast F64→I32 v0; return v1 }
+        // Expected: 42
+        let module = IrModule {
+            debug_name: "det_call_f64_ret".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "get_float".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::F64),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstFloat { dst: ValueId(0), value: 42.0 }],
+                        term: IrTerminator::Return { value: Some(ValueId(0)) },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::Call {
+                                dst: Some(ValueId(0)),
+                                callee: "get_float".to_string(),
+                                args: vec![],
+                                return_ty: Some(IrType::F64),
+                            },
+                            IrInst::Cast {
+                                dst: ValueId(1),
+                                from: IrType::F64,
+                                to: IrType::I32,
+                                value: ValueId(0),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(1)) },
+                    }],
+                },
+            ],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
+
+    #[test]
+    fn jit_determinism_call_f64_with_args() {
+        // Call a function that takes two F64 arguments and adds them; cast result to I32.
+        //
+        // add_floats(a: F64, b: F64) -> F64 { v2=v0+v1; return v2 }
+        // main() -> I32 { v0=20.0f64; v1=22.0f64; v2=call add_floats(v0,v1) -> F64;
+        //                 v3=cast F64→I32 v2; return v3 }
+        // Expected: 42
+        let module = IrModule {
+            debug_name: "det_call_f64_args".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "add_floats".to_string(),
+                    params: vec![
+                        IrParam { name: "a".to_string(), ty: IrType::F64 },
+                        IrParam { name: "b".to_string(), ty: IrType::F64 },
+                    ],
+                    return_ty: Some(IrType::F64),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![
+                            BlockParam { value: ValueId(0), ty: IrType::F64, read_only: true },
+                            BlockParam { value: ValueId(1), ty: IrType::F64, read_only: true },
+                        ],
+                        insts: vec![IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Add,
+                            ty: IrType::F64,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(2)) },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstFloat { dst: ValueId(0), value: 20.0 },
+                            IrInst::ConstFloat { dst: ValueId(1), value: 22.0 },
+                            IrInst::Call {
+                                dst: Some(ValueId(2)),
+                                callee: "add_floats".to_string(),
+                                args: vec![ValueId(0), ValueId(1)],
+                                return_ty: Some(IrType::F64),
+                            },
+                            IrInst::Cast {
+                                dst: ValueId(3),
+                                from: IrType::F64,
+                                to: IrType::I32,
+                                value: ValueId(2),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    }],
+                },
+            ],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
+
     // ── Logical AND/OR short-circuit (CX-192) ────────────────────────────────
     //
     // Each test models the canonical 4-block short-circuit CFG that lower_logical


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-212/add-jit-determinism-tests-for-f64-function-argument-and-return-value

## Summary

- Adds `jit_determinism_call_f64_return_value`: a no-arg callee returns F64 `42.0`; main calls it, casts `F64→I32`, and returns the result. Verifies that F64 return values flow correctly across the JIT call boundary.
- Adds `jit_determinism_call_f64_with_args`: a callee takes two F64 params (`20.0`, `22.0`), adds them, and returns F64; main casts to I32 (→42). Verifies that F64 arguments are passed correctly through the JIT ABI.

Both tests use `assert_deterministic_with_expected` to confirm that two independent `HostBoundary` executions produce identical exit codes and the expected value.

## Files changed

- `src/backend/cranelift/host_boundary.rs` — two new `#[test]` functions in `mod determinism_tests`

## Validation

```
cargo build --features jit   ✓ (0 errors, pre-existing warnings only)
cargo test --features jit    ✓ 344 passed; 0 failed
```

New tests:
```
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_call_f64_return_value ... ok
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_call_f64_with_args ... ok
```

## Linear ticket

CX-212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added determinism integration tests for Cranelift F64 calling-convention behavior to verify consistent JIT compilation results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->