### PR TITLE
CX-213: Rebase CX-205 determinism doc coverage rows after latest submain moves

### DIFF
--- a/docs/backend/cx_jit_determinism.md
+++ b/docs/backend/cx_jit_determinism.md
@@ -137,6 +137,12 @@ This is sufficient to verify the guarantee: if the JIT pipeline were non-determi
 | `jit_determinism_logical_or_short_circuit_lhs_true` | OR short-circuit CFG — LHS true, sc_true block taken (RHS unreachable); exit 1 |
 | `jit_determinism_if_else_merge_true_path` | If/else conditional merge — `Compare::Eq` + `Branch`; condition true → then arm → value 42 via `Jump` block param to merge block; exit 42 |
 | `jit_determinism_if_else_merge_false_path` | If/else conditional merge — `Compare::Eq` + `Branch`; condition false → else arm → value 7 via `Jump` block param to merge block; exit 7 |
+| `jit_determinism_unary_neg_int` | `NegInt` lowered as `0 - x` — `ConstInt` zero + `Binary::Sub` on I32; exit 42 |
+| `jit_determinism_unary_neg_float` | `NegFloat` lowered as `0.0 - x` — `ConstFloat` zero + `Binary::Sub` on F64 + `Cast` F64→I32; exit 7 |
+| `jit_determinism_unary_bool_not_true` | `BoolNot` lowered as `x == 0` — `ConstInt(Bool)` + `Compare::Eq` + `Cast` Bool→I32; NOT true → 0; exit 0 |
+| `jit_determinism_unary_bool_not_false` | `BoolNot` lowered as `x == 0` — `ConstInt(Bool)` + `Compare::Eq` + `Cast` Bool→I32; NOT false → 1; exit 1 |
+| `jit_determinism_builtin_assert_pass` | `BuiltinAssert` pass path — `Compare::Eq` + `Branch` to pass/trap blocks; pass block taken (1==1); `Trap` block compiled but unreachable; exit 0 |
+| `jit_determinism_builtin_assert_abort_on_failure` | `BuiltinAssert` abort-on-failure CFG — `ConstInt(Bool 1)` + `Branch`; `Trap` instruction in compiled CFG; forced-true condition keeps Trap unreachable at runtime; exit 0 |
 
 ### Running the Tests
 


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-213/cx-rebase-cx-205-determinism-doc-coverage-rows-after-latest-submain

## Summary

Rebases the CX-205 doc-only change onto current submain. CX-205 added 6 coverage rows (Unary + BuiltinAssert) to the Test Coverage table in `cx_jit_determinism.md`, but was branched before CX-204 merged its 2 if/else rows. This PR applies those same 6 rows after the if/else rows that CX-204 added.

## Files Changed

- `docs/backend/cx_jit_determinism.md` — 6 rows appended to the Test Coverage table

## New rows added

| Test | IR construct covered |
|------|---------------------|
| `jit_determinism_unary_neg_int` | `NegInt` lowered as `0 - x` |
| `jit_determinism_unary_neg_float` | `NegFloat` lowered as `0.0 - x` + `Cast` F64→I32 |
| `jit_determinism_unary_bool_not_true` | `BoolNot` lowered as `x == 0`, NOT true → 0 |
| `jit_determinism_unary_bool_not_false` | `BoolNot` lowered as `x == 0`, NOT false → 1 |
| `jit_determinism_builtin_assert_pass` | `BuiltinAssert` pass path |
| `jit_determinism_builtin_assert_abort_on_failure` | `BuiltinAssert` abort-on-failure CFG |

All 6 corresponding Rust test functions already exist in `src/backend/cranelift/host_boundary.rs` (landed via CX-200 and CX-197).

## Validation

```
cargo build --features jit   → Finished (0 warnings affecting correctness)
cargo test --features jit    → test result: ok. 344 passed; 0 failed; 0 ignored
```

## Linear ticket

CX-213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended determinism verification documentation with additional test case coverage, including verification of unary operations on numeric types, boolean operations, and assertion handling scenarios with passing and failure paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->