### PR TITLE
CX-218: Fix JIT arithmetic parity SKIP — resolve Numeric type in assert_eq argument lowering (t117–t121)

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -102,24 +102,15 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-196` (submain as of CX-196 merge window, 2026-05-15).
-Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
-CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
-exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
-(t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
-CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
-dispatch to cx_printn, CX-187 CompoundAssign DotAccess and Index exit-code
-fixtures (t152_compound_assign_dotaccess_exit, t153_compound_assign_index_exit)
-plus parser support for `arr:[i] op= value` compound assign on array elements,
-and CX-182 integration multi-function PassWithOutput fixture
-(t154_integration_multifn) rebased onto submain via CX-196.
+Run on branch `stokowski/CX-218` (submain as of CX-218 merge window, 2026-05-16).
+Includes all baselines from CX-196 plus CX-218 Numeric type resolution in
+`lower_binary` for arithmetic operators, which converts t117–t121
+(assert_eq-based arithmetic parity fixtures) from SKIP to PASS.
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
 ------------------------------------------------
-Arithmetic                8      9            0
+Arithmetic               13      4            0
 VariableDecl              5      3            0
 IfElse                    4      2            0
 WhileLoop                 5      3            0
@@ -160,6 +151,16 @@ handles, and other Phase 14+ constructs). As subsequent phases land, SKIP
 counts will continue to decrease and PASS counts will increase.
 
 **PARITY_FAIL = 0** across all 16 categories. The gate holds.
+
+**Arithmetic parity coverage (CX-218):** t117–t121 are exit-code-verified fixtures
+for the five integer arithmetic operators (+, -, *, /, %). They were previously SKIP
+because `lower_binary` called `lower_type(SemanticType::Numeric)` for the result type
+of unresolved numeric expressions, which returned an `UnsupportedSemanticType` error.
+CX-218 fixes this by resolving `SemanticType::Numeric` to the target's native integer
+width (I64 on 64-bit) in `lower_binary`, matching the existing behaviour in `lower_value`.
+The 13 PASS reflect t01, t89–t95 (print-based originals), t103 (expected-fail),
+t114–t116 (eval-order fixtures), and t117–t121 (arithmetic exit-code fixtures).
+The 4 remaining SKIP are print-based originals not yet supported by the JIT.
 
 **IfElse parity coverage (CX-102/CX-111/CX-136):** t129 mirrors t44 (basic if/else),
 t130 mirrors t45 (if/else in function), t131 mirrors t46 (negated conditions,

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1986,7 +1986,16 @@ fn lower_binary(
 
     match op {
         Op::Plus | Op::Minus | Op::Mul | Op::Div | Op::Mod => {
-            let ty = lower_type(result_ty)?;
+            // SemanticType::Numeric is an unresolved placeholder for integer
+            // literals without an explicit type annotation.  Resolve it to the
+            // target's native integer width (I64 on 64-bit) so that expressions
+            // like `0 + 0` or `3 * 4` lower successfully instead of returning
+            // an UnsupportedSemanticType error (which propagates as JIT SKIP).
+            let ty = if *result_ty == SemanticType::Numeric {
+                ctx.target.numeric_literal_ir_type()
+            } else {
+                lower_type(result_ty)?
+            };
             ensure_type_match("binary lhs", ty.clone(), lhs.ty)?;
             ensure_type_match("binary rhs", ty.clone(), rhs.ty)?;
             let op = match op {
@@ -6197,6 +6206,53 @@ mod tests {
             "expected InternalInvariantViolation for wrong assert_eq arity, got: {:?}",
             err
         );
+    }
+
+    #[test]
+    fn assert_eq_with_numeric_binary_lhs_lowers_correctly() {
+        // assert_eq(1 + 1, 2) — both args have SemanticType::Numeric.
+        // Prior to CX-218 this returned UnsupportedSemanticType("Numeric")
+        // because lower_binary called lower_type(Numeric) for arithmetic ops.
+        // After the fix, Numeric resolves to I64 (on 64-bit targets) and the
+        // entire assert_eq lowers to Compare(Eq) + Branch/Trap.
+        let add_expr = SemanticExpr {
+            ty: SemanticType::Numeric,
+            kind: SemanticExprKind::Binary {
+                lhs: Box::new(int_expr(1, SemanticType::Numeric)),
+                op: Op::Plus,
+                pos: 0,
+                rhs: Box::new(int_expr(1, SemanticType::Numeric)),
+            },
+        };
+        let program = SemanticProgram {
+            stmts: vec![builtin_stmt(
+                "assert_eq",
+                vec![
+                    SemanticCallArg::Expr(add_expr),
+                    SemanticCallArg::Expr(int_expr(2, SemanticType::Numeric)),
+                ],
+            )],
+            enums: vec![],
+        };
+        let module = lower_and_validate(&program);
+        let all_insts: Vec<_> = module.functions[0]
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .collect();
+        let has_add = all_insts
+            .iter()
+            .any(|i| matches!(i, IrInst::Binary { op: BinaryOp::Add, ty: IrType::I64, .. }));
+        assert!(has_add, "expected Binary(Add, I64) for Numeric 1+1");
+        let has_eq = all_insts
+            .iter()
+            .any(|i| matches!(i, IrInst::Compare { op: CompareOp::Eq, .. }));
+        assert!(has_eq, "expected Compare(Eq) for assert_eq");
+        let has_trap = module.functions[0]
+            .blocks
+            .iter()
+            .any(|b| matches!(b.term, IrTerminator::Trap));
+        assert!(has_trap, "expected Trap block for failing assert_eq path");
     }
 
     #[test]


### PR DESCRIPTION
Closes CX-218

## Summary

- `lower_binary` called `lower_type(result_ty)` for arithmetic operators (`+`, `-`, `*`, `/`, `%`). When the result type is `SemanticType::Numeric` (the placeholder for unresolved integer literal expressions), `lower_type` returns `UnsupportedSemanticType("Numeric")`, propagating as JIT exit code 127 (SKIP).
- Fix: resolve `SemanticType::Numeric` to `ctx.target.numeric_literal_ir_type()` (I64 on 64-bit targets) in the arithmetic arm of `lower_binary`, mirroring the existing logic in `lower_value`.
- Tests t117–t121 (add/sub/mul/div/mod exit-code fixtures using `assert_eq`) now PASS instead of SKIP.

## Files Changed

- `src/ir/lower.rs` — arithmetic arm of `lower_binary` now handles `SemanticType::Numeric`; new unit test `assert_eq_with_numeric_binary_lhs_lowers_correctly`
- `docs/backend/cx_jit_parity_checklist.md` — baseline updated: Arithmetic 8 PASS/9 SKIP → 13 PASS/4 SKIP

## Validation

```
cargo build --features jit   ✓
cargo test --features jit    ✓  345 passed; 0 failed
```

- `ir::lower::tests::assert_eq_with_numeric_binary_lhs_lowers_correctly` — ok (new test)
- `diff_harness::tests::jit_parity_by_feature` — ok (gate holds, PARITY_FAIL = 0)
- `diff_harness::tests::interpreter_baseline_all` — ok

## Linear Ticket

CX-218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed numeric type resolution in arithmetic operations, enabling expressions like `0 + 0` and `3 * 4` to lower successfully.

* **Tests**
  * Added regression test for assertion lowering with arithmetic expressions.
  * Improved parity coverage: five arithmetic test cases transitioned from SKIP to PASS status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->