### PR TITLE
CX-216: Rebase CX-208 F64 comparison determinism tests after latest submain moves

### DIFF
--- a/docs/backend/cx_jit_determinism.md
+++ b/docs/backend/cx_jit_determinism.md
@@ -1,5 +1,5 @@
 # Cx JIT Determinism Guarantee
-v1.2 — 2026-05-09
+v1.3 — 2026-05-16
 
 ---
 
@@ -143,6 +143,20 @@ This is sufficient to verify the guarantee: if the JIT pipeline were non-determi
 | `jit_determinism_unary_bool_not_false` | `BoolNot` lowered as `x == 0` — `ConstInt(Bool)` + `Compare::Eq` + `Cast` Bool→I32; NOT false → 1; exit 1 |
 | `jit_determinism_builtin_assert_pass` | `BuiltinAssert` pass path — `Compare::Eq` + `Branch` to pass/trap blocks; pass block taken (1==1); `Trap` block compiled but unreachable; exit 0 |
 | `jit_determinism_builtin_assert_abort_on_failure` | `BuiltinAssert` abort-on-failure CFG — `ConstInt(Bool 1)` + `Branch`; `Trap` instruction in compiled CFG; forced-true condition keeps Trap unreachable at runtime; exit 0 |
+| `jit_determinism_fcmp_eq_true` | `fcmp` `Equal` — 1.5 == 1.5 → true path; exit 1 |
+| `jit_determinism_fcmp_eq_false` | `fcmp` `Equal` — 1.5 == 2.5 → false path; exit 0 |
+| `jit_determinism_fcmp_ne_true` | `fcmp` `NotEqual` — 1.5 != 2.5 → true path; exit 1 |
+| `jit_determinism_fcmp_ne_false` | `fcmp` `NotEqual` — 2.5 != 2.5 → false path; exit 0 |
+| `jit_determinism_fcmp_lt_true` | `fcmp` `LessThan` — 1.5 < 2.5 → true path; exit 1 |
+| `jit_determinism_fcmp_lt_false` | `fcmp` `LessThan` — 2.5 < 1.5 → false path; exit 0 |
+| `jit_determinism_fcmp_le_true` | `fcmp` `LessThanOrEqual` — 1.5 <= 2.5 (strict-less) → true path; exit 1 |
+| `jit_determinism_fcmp_le_equal` | `fcmp` `LessThanOrEqual` — 1.5 <= 1.5 (equal boundary) → true path; exit 1 |
+| `jit_determinism_fcmp_le_false` | `fcmp` `LessThanOrEqual` — 2.5 <= 1.5 → false path; exit 0 |
+| `jit_determinism_fcmp_gt_true` | `fcmp` `GreaterThan` — 2.5 > 1.5 → true path; exit 1 |
+| `jit_determinism_fcmp_gt_false` | `fcmp` `GreaterThan` — 1.5 > 2.5 → false path; exit 0 |
+| `jit_determinism_fcmp_ge_true` | `fcmp` `GreaterThanOrEqual` — 2.5 >= 1.5 (strict-greater) → true path; exit 1 |
+| `jit_determinism_fcmp_ge_equal` | `fcmp` `GreaterThanOrEqual` — 1.5 >= 1.5 (equal boundary) → true path; exit 1 |
+| `jit_determinism_fcmp_ge_false` | `fcmp` `GreaterThanOrEqual` — 1.5 >= 2.5 → false path; exit 0 |
 
 ### Running the Tests
 

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -3085,6 +3085,83 @@ mod determinism_tests {
         );
     }
 
+    /// Build a two-block if/else module that compares two F64 constants via fcmp.
+    ///
+    /// ```text
+    /// main() -> I32 {
+    ///   block0:
+    ///     v0 = const lhs : F64
+    ///     v1 = const rhs : F64
+    ///     v2 = compare op(v0, v1)   // I8 via fcmp (ordered)
+    ///     branch v2, block1[], block2[]
+    ///   block1:          // true path
+    ///     v3 = const true_val : I32
+    ///     return v3
+    ///   block2:          // false path
+    ///     v4 = const false_val : I32
+    ///     return v4
+    /// }
+    /// ```
+    fn float_compare_branch_module(
+        lhs: f64,
+        rhs: f64,
+        op: CompareOp,
+        true_val: i128,
+        false_val: i128,
+    ) -> IrModule {
+        IrModule {
+            debug_name: "det_fcmp_branch".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: Some(IrType::I32),
+                blocks: vec![
+                    IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstFloat { dst: ValueId(0), value: lhs },
+                            IrInst::ConstFloat { dst: ValueId(1), value: rhs },
+                            IrInst::Compare {
+                                dst: ValueId(2),
+                                op,
+                                lhs: ValueId(0),
+                                rhs: ValueId(1),
+                            },
+                        ],
+                        term: IrTerminator::Branch {
+                            cond: ValueId(2),
+                            then_block: BlockId(1),
+                            then_args: vec![],
+                            else_block: BlockId(2),
+                            else_args: vec![],
+                        },
+                    },
+                    IrBlock {
+                        id: BlockId(1),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(3),
+                            ty: IrType::I32,
+                            value: true_val,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    },
+                    IrBlock {
+                        id: BlockId(2),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(4),
+                            ty: IrType::I32,
+                            value: false_val,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(4)) },
+                    },
+                ],
+            }],
+        }
+    }
+
     // ── ConstInt + Return ─────────────────────────────────────────────────────
 
     #[test]
@@ -6853,5 +6930,105 @@ mod determinism_tests {
             }],
         };
         assert_deterministic_with_expected(&module, 30);
+    }
+
+    // ── F64 comparison (fcmp) determinism ─────────────────────────────────────
+
+    #[test]
+    fn jit_determinism_fcmp_eq_true() {
+        // 1.5 == 1.5 → ordered Equal → true path → exit 1
+        let m = float_compare_branch_module(1.5, 1.5, CompareOp::Eq, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_eq_false() {
+        // 1.5 == 2.5 → ordered Equal → false path → exit 0
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Eq, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ne_true() {
+        // 1.5 != 2.5 → ordered NotEqual → true path → exit 1
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Ne, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ne_false() {
+        // 2.5 != 2.5 → ordered NotEqual → false path → exit 0
+        let m = float_compare_branch_module(2.5, 2.5, CompareOp::Ne, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_lt_true() {
+        // 1.5 < 2.5 → ordered LessThan → true path → exit 1
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Lt, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_lt_false() {
+        // 2.5 < 1.5 → ordered LessThan → false path → exit 0
+        let m = float_compare_branch_module(2.5, 1.5, CompareOp::Lt, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_le_true() {
+        // 1.5 <= 2.5 → ordered LessThanOrEqual (strict-less case) → true path → exit 1
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Le, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_le_equal() {
+        // 1.5 <= 1.5 → ordered LessThanOrEqual (equal boundary) → true path → exit 1
+        let m = float_compare_branch_module(1.5, 1.5, CompareOp::Le, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_le_false() {
+        // 2.5 <= 1.5 → ordered LessThanOrEqual → false path → exit 0
+        let m = float_compare_branch_module(2.5, 1.5, CompareOp::Le, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_gt_true() {
+        // 2.5 > 1.5 → ordered GreaterThan → true path → exit 1
+        let m = float_compare_branch_module(2.5, 1.5, CompareOp::Gt, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_gt_false() {
+        // 1.5 > 2.5 → ordered GreaterThan → false path → exit 0
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Gt, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ge_true() {
+        // 2.5 >= 1.5 → ordered GreaterThanOrEqual (strict-greater case) → true path → exit 1
+        let m = float_compare_branch_module(2.5, 1.5, CompareOp::Ge, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ge_equal() {
+        // 1.5 >= 1.5 → ordered GreaterThanOrEqual (equal boundary) → true path → exit 1
+        let m = float_compare_branch_module(1.5, 1.5, CompareOp::Ge, 1, 0);
+        assert_deterministic_with_expected(&m, 1);
+    }
+
+    #[test]
+    fn jit_determinism_fcmp_ge_false() {
+        // 1.5 >= 2.5 → ordered GreaterThanOrEqual → false path → exit 0
+        let m = float_compare_branch_module(1.5, 2.5, CompareOp::Ge, 1, 0);
+        assert_deterministic_with_expected(&m, 0);
     }
 }


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-216/cx-rebase-cx-208-f64-comparison-determinism-tests-after-latest-submain

## Summary

- Ports 14 `jit_determinism_fcmp_*` tests from the CX-208 branch onto current submain (which had CX-204 and CX-213 merged since CX-208 branched)
- Adds a `float_compare_branch_module` helper inside `determinism_tests` (scoped separately from the existing one in `jit_tests`)
- Covers all six fcmp operators: `Eq`, `Ne`, `Lt`, `Le`, `Gt`, `Ge` with true/false paths and equality boundary cases for `Le` and `Ge`
- Updates `cx_jit_determinism.md` to v1.3 with 14 new coverage table rows

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — `float_compare_branch_module` helper + 14 determinism tests added to `determinism_tests` module
- `docs/backend/cx_jit_determinism.md` — bumped to v1.3, added 14 fcmp coverage rows

## Validation

```
cargo build --features jit   ✓ (warnings are pre-existing)
cargo test --features jit    ✓ 358 passed; 0 failed
```

All 14 new `jit_determinism_fcmp_*` tests passed:
- `jit_determinism_fcmp_eq_true/false`
- `jit_determinism_fcmp_ne_true/false`
- `jit_determinism_fcmp_lt_true/false`
- `jit_determinism_fcmp_le_true/equal/false`
- `jit_determinism_fcmp_gt_true/false`
- `jit_determinism_fcmp_ge_true/equal/false`

## Linear Ticket

CX-216 — https://linear.app/cx-lang/issue/CX-216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes and test coverage documentation for floating-point operations.

* **Tests**
  * Added comprehensive determinism tests for floating-point comparison operations, covering equality, inequality, and relational comparisons to ensure consistent results across independent execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->