### PR TITLE
CX-217: Rebase CX-209 FloatOps/Cast parity fixtures after latest submain moves

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -29,8 +29,8 @@ set:
 | Array          | Array literals and array-of-result           | t33, t112 (output-verified); t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit (exit-code-verified, CX-121) |
 | CompoundAssign | Compound assignment operators (+=, etc.)     | t26, t41, t128, t151, t152, t153 (mixed output/exit-code fixtures; CX-119, CX-187) |
 | Unary          | Unary operators (negation, etc.)             | t96 |
-| Cast           | Explicit type casts                          | t139, t140 |
-| FloatOps       | f64 operations                               | t55, t135–t138 |
+| Cast           | Explicit type casts                          | t139, t140, t157, t158 |
+| FloatOps       | f64 operations                               | t55, t135–t138, t155–t156 |
 | BuiltinAssert  | `assert` and `assert_eq` builtins            | t77–t80 |
 | LogicalOps     | Logical AND/OR short-circuit operators       | t141, t142 |
 | Other          | Enums, generics, when-blocks, handles, macros, imports, Result/try, string interp, semicolons, copy semantics, and any fixture not matching a named category | t09–t22, t24, t27–t32, t37–t38, t42, t47, t49, t51–t54, t58–t76, t81–t88, t97–t100, t111; exit-code-verified: t143–t145 (CX-113); integration: t154_integration_multifn (CX-182) |
@@ -102,7 +102,7 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-196` (submain as of CX-196 merge window, 2026-05-15).
+Run on branch `stokowski/CX-217` (submain as of CX-217 merge window, 2026-05-16).
 Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
 fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
 CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
@@ -113,8 +113,11 @@ CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
 dispatch to cx_printn, CX-187 CompoundAssign DotAccess and Index exit-code
 fixtures (t152_compound_assign_dotaccess_exit, t153_compound_assign_index_exit)
 plus parser support for `arr:[i] op= value` compound assign on array elements,
-and CX-182 integration multi-function PassWithOutput fixture
-(t154_integration_multifn) rebased onto submain via CX-196.
+CX-182 integration multi-function PassWithOutput fixture
+(t154_integration_multifn) rebased onto submain via CX-196,
+and CX-117/CX-209 FloatOps/Cast parity fixtures (t155_float_arith_mod_exit,
+t156_float_neg_exit, t157_cast_neg_t32_to_f64_exit, t158_cast_t64_to_f64_exit)
+rebased onto submain via CX-217.
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -130,13 +133,13 @@ Struct                    6      5            0
 Array                     3      2            0
 CompoundAssign            4      2            0
 Unary                     0      1            0
-Cast                      0      2            0
-FloatOps                  0      5            0
+Cast                      0      4            0
+FloatOps                  0      7            0
 BuiltinAssert             2      2            0
 LogicalOps                2      0            0
 Other                    17     48            0
 ------------------------------------------------
-Total: 158 fixtures, 0 PARITY_FAILs
+Total: 162 fixtures, 0 PARITY_FAILs
 ```
 
 ### Interpretation
@@ -201,6 +204,15 @@ element read/write, and array passing through function calls. The 3 PASS reflect
 fixtures passing via the CX-121 ArrayAlloca JIT emit (`IrInst::ArrayAlloca` lowered to
 Cranelift via `compute_array_layout`). The 2 SKIP are t33 and t112 (print-based originals
 that remain SKIP).
+
+**FloatOps/Cast parity fixtures (CX-117/CX-209, rebased CX-217):** t155_float_arith_mod_exit
+exercises f64 modulo, scaling the remainder by 10.0 and casting to t32 to avoid rounding drift.
+t156_float_neg_exit exercises unary f64 negation (lowered in IR as `ConstFloat(0.0) + Binary(Sub,
+F64)`), casting the result to t32. t157_cast_neg_t32_to_f64_exit exercises negative t32→f64
+widening, verifying sign preservation through the round-trip t32→f64→t32. t158_cast_t64_to_f64_exit
+exercises t64→f64 widening (the `fcvt` path for 64-bit integers), including negative values.
+All four are SKIP (float ops and cast constructs not yet JIT-lowerable; exits 127). Cast SKIP count
+rises from 2 to 4; FloatOps SKIP count rises from 5 to 7; total fixture count rises from 158 to 162.
 
 **Integration fixture (CX-182, rebased CX-196):** t154_integration_multifn is a
 PassWithOutput fixture exercising two user-defined functions (`sum_up_to` using a while loop,

--- a/src/diff_harness.rs
+++ b/src/diff_harness.rs
@@ -240,6 +240,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         // ── Cast ─────────────────────────────────────────────────────────────
         "t139_cast_t32_to_f64_exit"
         | "t140_cast_f64_truncate_exit"
+        | "t157_cast_neg_t32_to_f64_exit"
+        | "t158_cast_t64_to_f64_exit"
             => FeatureCategory::Cast,
 
         // ── FloatOps ──────────────────────────────────────────────────────────
@@ -248,6 +250,8 @@ pub fn feature_of(fixture_name: &str) -> FeatureCategory {
         | "t136_float_arith_sub_exit"
         | "t137_float_arith_mul_exit"
         | "t138_float_arith_div_exit"
+        | "t155_float_arith_mod_exit"
+        | "t156_float_neg_exit"
             => FeatureCategory::FloatOps,
 
         // ── BuiltinAssert ─────────────────────────────────────────────────────

--- a/src/tests/verification_matrix/t155_float_arith_mod_exit.cx
+++ b/src/tests/verification_matrix/t155_float_arith_mod_exit.cx
@@ -1,0 +1,16 @@
+// CX-117/CX-209: exit-code-based JIT parity — f64 modulo (remainder).
+// Results scaled by 10.0 and cast to t32 to avoid floating-point rounding
+// drift in JIT backends (e.g. 1.9 → 1 vs 2 due to precision).
+a: f64 = 10.0
+b: f64 = 3.0
+rem: f64 = a % b
+scaled: f64 = rem * 10.0
+n: t32 = scaled
+assert_eq(n, 10)
+
+x: f64 = 5.5
+y: f64 = 2.0
+rem2: f64 = x % y
+scaled2: f64 = rem2 * 10.0
+m: t32 = scaled2
+assert_eq(m, 15)

--- a/src/tests/verification_matrix/t156_float_neg_exit.cx
+++ b/src/tests/verification_matrix/t156_float_neg_exit.cx
@@ -1,0 +1,11 @@
+// CX-117/CX-209: exit-code-based JIT parity — unary f64 negation.
+// Negation is lowered in the IR as ConstFloat(0.0) + Binary(Sub, F64).
+a: f64 = 5.0
+neg_a: f64 = -a
+n: t32 = neg_a
+assert_eq(n, -5)
+
+b: f64 = 3.0
+neg_b: f64 = -b
+m: t32 = neg_b
+assert_eq(m, -3)

--- a/src/tests/verification_matrix/t157_cast_neg_t32_to_f64_exit.cx
+++ b/src/tests/verification_matrix/t157_cast_neg_t32_to_f64_exit.cx
@@ -1,0 +1,12 @@
+// CX-117/CX-209: exit-code-based JIT parity — negative t32→f64 widening cast.
+// Verifies sign preservation when a negative t32 value widens to f64,
+// then narrows back to t32 for assert_eq verification.
+a: t32 = -42
+b: f64 = a
+c: t32 = b
+assert_eq(c, -42)
+
+x: t32 = -100
+y: f64 = x
+z: t32 = y
+assert_eq(z, -100)

--- a/src/tests/verification_matrix/t158_cast_t64_to_f64_exit.cx
+++ b/src/tests/verification_matrix/t158_cast_t64_to_f64_exit.cx
@@ -1,0 +1,12 @@
+// CX-117/CX-209: exit-code-based JIT parity — t64→f64 widening cast (fcvt path).
+// Exercises 64-bit integer to float conversion, then narrows back to t32
+// for assert_eq verification.
+a: t64 = 42
+b: f64 = a
+c: t32 = b
+assert_eq(c, 42)
+
+x: t64 = -100
+y: f64 = x
+z: t32 = y
+assert_eq(z, -100)


### PR DESCRIPTION
Closes https://linear.app/cx-lang/issue/CX-217/cx-rebase-cx-209-floatopscast-parity-fixtures-after-latest-submain

## Summary

- Adds four exit-code-verified JIT parity fixtures from CX-117/CX-209 (t155–t158) to the verification matrix
- Registers t155/t156 as FloatOps and t157/t158 as Cast in `feature_of()` in `src/diff_harness.rs`
- Updates parity checklist: Cast SKIP 2→4, FloatOps SKIP 5→7, total 158→162 fixtures, 0 PARITY_FAILs

## Fixtures Added

| File | Category | What it tests |
|------|----------|---------------|
| `t155_float_arith_mod_exit.cx` | FloatOps | f64 modulo; result scaled ×10 and cast to t32 to avoid rounding drift |
| `t156_float_neg_exit.cx` | FloatOps | Unary f64 negation (IR: `ConstFloat(0.0) + Binary(Sub, F64)`), result cast to t32 |
| `t157_cast_neg_t32_to_f64_exit.cx` | Cast | Negative t32→f64 widening; verifies sign preservation via t32→f64→t32 round-trip |
| `t158_cast_t64_to_f64_exit.cx` | Cast | t64→f64 widening (fcvt path); positive and negative values |

All four are SKIP (exit 127) in JIT — float ops and cast constructs are not yet JIT-lowerable. Zero PARITY_FAILs maintained.

## Files Changed

- `src/tests/verification_matrix/t155_float_arith_mod_exit.cx` — new
- `src/tests/verification_matrix/t156_float_neg_exit.cx` — new
- `src/tests/verification_matrix/t157_cast_neg_t32_to_f64_exit.cx` — new
- `src/tests/verification_matrix/t158_cast_t64_to_f64_exit.cx` — new
- `src/diff_harness.rs` — t155/t156 added to FloatOps arm; t157/t158 added to Cast arm
- `docs/backend/cx_jit_parity_checklist.md` — Section 1 fixture lists updated; Section 3 baseline table and provenance note updated

## Validation

```
cargo build --features jit && cargo test --features jit
```

Result: **344 passed; 0 failed** — `interpreter_baseline_all` and `jit_parity_by_feature` both green.

## Linear

CX-217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added 4 new JIT parity verification tests covering f64 modulo and negation operations, and casting conversions between t32/t64 and f64 types

* **Documentation**
  * Updated JIT parity checklist with Phase 12 baseline results, including revised fixture counts (162 total) and rebase details for parity fixtures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->