### PR TITLE
CX-221: Rebase CX-212 F64 call-boundary determinism tests after latest submain moves

### DIFF
--- a/docs/backend/cx_jit_determinism.md
+++ b/docs/backend/cx_jit_determinism.md
@@ -156,6 +156,8 @@ This is sufficient to verify the guarantee: if the JIT pipeline were non-determi
 | `jit_determinism_f64_binary_mul` | F64 `Binary::Mul` — 3.5 × 2.0 = 7.0 → exit 7 |
 | `jit_determinism_f64_binary_div` | F64 `Binary::Div` — 21.0 ÷ 3.0 = 7.0 → exit 7 |
 | `jit_determinism_f64_binary_rem` | F64 `Binary::Rem` — 10.0 % 3.0 = 1.0 via fmod libcall → exit 1 |
+| `jit_determinism_call_f64_return_value` | F64 call boundary — no-arg callee returns F64 42.0; main casts F64→I32; exit 42 |
+| `jit_determinism_call_f64_with_args` | F64 call boundary — callee takes two F64 params (20.0, 22.0), adds them, returns F64; main casts F64→I32; exit 42 |
 
 ### Running the Tests
 

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -7328,4 +7328,121 @@ mod determinism_tests {
         };
         assert_deterministic_with_expected(&module, 1);
     }
+
+    // ── F64 function argument and return value passing ────────────────────────
+
+    #[test]
+    fn jit_determinism_call_f64_return_value() {
+        // Call a no-arg function that returns an F64 constant; cast to I32 for exit code.
+        //
+        // get_float() -> F64 { v0=42.0f64; return v0 }
+        // main() -> I32 { v0=call get_float() -> F64; v1=cast F64→I32 v0; return v1 }
+        // Expected: 42
+        let module = IrModule {
+            debug_name: "det_call_f64_ret".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "get_float".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::F64),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstFloat { dst: ValueId(0), value: 42.0 }],
+                        term: IrTerminator::Return { value: Some(ValueId(0)) },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::Call {
+                                dst: Some(ValueId(0)),
+                                callee: "get_float".to_string(),
+                                args: vec![],
+                                return_ty: Some(IrType::F64),
+                            },
+                            IrInst::Cast {
+                                dst: ValueId(1),
+                                from: IrType::F64,
+                                to: IrType::I32,
+                                value: ValueId(0),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(1)) },
+                    }],
+                },
+            ],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
+
+    #[test]
+    fn jit_determinism_call_f64_with_args() {
+        // Call a function that takes two F64 arguments and adds them; cast result to I32.
+        //
+        // add_floats(a: F64, b: F64) -> F64 { v2=v0+v1; return v2 }
+        // main() -> I32 { v0=20.0f64; v1=22.0f64; v2=call add_floats(v0,v1) -> F64;
+        //                 v3=cast F64→I32 v2; return v3 }
+        // Expected: 42
+        let module = IrModule {
+            debug_name: "det_call_f64_args".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "add_floats".to_string(),
+                    params: vec![
+                        IrParam { name: "a".to_string(), ty: IrType::F64 },
+                        IrParam { name: "b".to_string(), ty: IrType::F64 },
+                    ],
+                    return_ty: Some(IrType::F64),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![
+                            BlockParam { value: ValueId(0), ty: IrType::F64, read_only: true },
+                            BlockParam { value: ValueId(1), ty: IrType::F64, read_only: true },
+                        ],
+                        insts: vec![IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Add,
+                            ty: IrType::F64,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(2)) },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstFloat { dst: ValueId(0), value: 20.0 },
+                            IrInst::ConstFloat { dst: ValueId(1), value: 22.0 },
+                            IrInst::Call {
+                                dst: Some(ValueId(2)),
+                                callee: "add_floats".to_string(),
+                                args: vec![ValueId(0), ValueId(1)],
+                                return_ty: Some(IrType::F64),
+                            },
+                            IrInst::Cast {
+                                dst: ValueId(3),
+                                from: IrType::F64,
+                                to: IrType::I32,
+                                value: ValueId(2),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    }],
+                },
+            ],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
 }


### PR DESCRIPTION
Closes CX-221

Rebases the two F64 call-boundary determinism tests from CX-212 onto the current submain (which moved forward with CX-204, CX-213, and CX-214 since CX-212 was authored).

## Changes

### src/backend/cranelift/host_boundary.rs
Two new `#[test]` functions appended after `jit_determinism_f64_binary_rem` at the end of the F64 section in `mod determinism_tests`:

- **`jit_determinism_call_f64_return_value`** — a no-arg callee returns F64 42.0; main calls it, casts F64→I32, and returns the result. Expected exit: 42.
- **`jit_determinism_call_f64_with_args`** — a callee takes two F64 params (20.0, 22.0), adds them, returns F64; main casts F64→I32. Expected exit: 42.

Both tests run the module through two independent `HostBoundary` instances and assert identical exit codes via `assert_deterministic_with_expected`.

### docs/backend/cx_jit_determinism.md
Two coverage rows added to the test table after `jit_determinism_f64_binary_rem`.

## Validation

```
cargo build --features jit   ✓  (warnings only, no errors)
cargo test --features jit determinism
```

```
running 75 tests
...
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_call_f64_return_value ... ok
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_call_f64_with_args ... ok
...
test result: ok. 75 passed; 0 failed; 0 ignored; 0 measured; 284 filtered out; finished in 0.05s
```

## Linear ticket
CX-221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new determinism tests for floating-point calling conventions across function boundaries

* **Documentation**
  * Updated determinism test coverage documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->