### PR TITLE
CX-222: Add JIT determinism tests for direct function calls with I32/I64 integer argument and return value passing

### DIFF
--- a/docs/backend/cx_jit_determinism.md
+++ b/docs/backend/cx_jit_determinism.md
@@ -129,6 +129,8 @@ This is sufficient to verify the guarantee: if the JIT pipeline were non-determi
 | `jit_determinism_call_chained` | `Call` — three-function chain; verifies forward-reference resolution |
 | `jit_determinism_call_in_branch` | `Call` inside a non-entry block (branch arm); verifies block-local call emission |
 | `jit_determinism_call_multiple` | Two calls to the same callee; verifies repeated `declare_func_in_func` stability |
+| `jit_determinism_call_i64_return_value` | `Call` — no-arg callee returns `I64` constant; result `ireduce`d to `I32` for exit code |
+| `jit_determinism_call_i64_with_args` | `Call` — callee takes two `I64` arguments and adds them; `ireduce` result to `I32` for exit code |
 | `jit_determinism_compound_assign_dot_access` | `CompoundAssign` DotAccess lvalue — `PtrOffset` + `Load` + `Binary::Add` + `Store` on a non-first struct field |
 | `jit_determinism_compound_assign_index` | `CompoundAssign` Index lvalue — `ArrayAlloca` + `PtrAdd` + `Load` + `Binary::Add` + `Store` on an array element |
 | `jit_determinism_logical_and_lhs_true_rhs_true` | AND short-circuit CFG — LHS true, RHS block taken; `ConstInt(Bool)` + `Branch` + `Jump` with block param; exit 1 |

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -5741,6 +5741,124 @@ mod determinism_tests {
         assert_deterministic(&module);
     }
 
+    #[test]
+    fn jit_determinism_call_i64_return_value() {
+        // Call a no-arg function that returns an I64 constant; cast to I32 for exit code.
+        //
+        // get_i64() -> I64 { v0=42i64; return v0 }
+        // main()    -> I32 { v0=call get_i64() -> I64; v1=ireduce I64→I32 v0; return v1 }
+        // Expected: 42
+        let module = IrModule {
+            debug_name: "det_call_i64_ret".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "get_i64".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I64),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![IrInst::ConstInt {
+                            dst: ValueId(0),
+                            ty: IrType::I64,
+                            value: 42,
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(0)) },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::Call {
+                                dst: Some(ValueId(0)),
+                                callee: "get_i64".to_string(),
+                                args: vec![],
+                                return_ty: Some(IrType::I64),
+                            },
+                            IrInst::Cast {
+                                dst: ValueId(1),
+                                from: IrType::I64,
+                                to: IrType::I32,
+                                value: ValueId(0),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(1)) },
+                    }],
+                },
+            ],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
+
+    #[test]
+    fn jit_determinism_call_i64_with_args() {
+        // Call a function that takes two I64 arguments and adds them; cast result to I32.
+        //
+        // add64(a: I64, b: I64) -> I64 { v2=v0+v1; return v2 }
+        // main() -> I32 { v0=20i64; v1=22i64; v2=call add64(v0,v1) -> I64; v3=ireduce I64→I32 v2; return v3 }
+        // Expected: 42
+        let module = IrModule {
+            debug_name: "det_call_i64_args".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "add64".to_string(),
+                    params: vec![
+                        IrParam { name: "a".to_string(), ty: IrType::I64 },
+                        IrParam { name: "b".to_string(), ty: IrType::I64 },
+                    ],
+                    return_ty: Some(IrType::I64),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![
+                            BlockParam { value: ValueId(0), ty: IrType::I64, read_only: true },
+                            BlockParam { value: ValueId(1), ty: IrType::I64, read_only: true },
+                        ],
+                        insts: vec![IrInst::Binary {
+                            dst: ValueId(2),
+                            op: BinaryOp::Add,
+                            ty: IrType::I64,
+                            lhs: ValueId(0),
+                            rhs: ValueId(1),
+                        }],
+                        term: IrTerminator::Return { value: Some(ValueId(2)) },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstInt { dst: ValueId(0), ty: IrType::I64, value: 20 },
+                            IrInst::ConstInt { dst: ValueId(1), ty: IrType::I64, value: 22 },
+                            IrInst::Call {
+                                dst: Some(ValueId(2)),
+                                callee: "add64".to_string(),
+                                args: vec![ValueId(0), ValueId(1)],
+                                return_ty: Some(IrType::I64),
+                            },
+                            IrInst::Cast {
+                                dst: ValueId(3),
+                                from: IrType::I64,
+                                to: IrType::I32,
+                                value: ValueId(2),
+                            },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(3)) },
+                    }],
+                },
+            ],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
+
     // ── Logical AND/OR short-circuit (CX-192) ────────────────────────────────
     //
     // Each test models the canonical 4-block short-circuit CFG that lower_logical


### PR DESCRIPTION
Closes CX-222

## Summary

- Added `jit_determinism_call_i64_return_value`: a no-arg callee returns an I64 constant (42); `main` calls it, ireduces the result I64→I32, and returns. Verifies that I64 return-type in `Call` is stable across two independent JIT runs.
- Added `jit_determinism_call_i64_with_args`: callee `add64(a: I64, b: I64) -> I64` takes two I64 block params, performs `Binary::Add` on I64, returns I64; `main` passes 20i64 and 22i64, ireduces the I64 result to I32 for the exit code. Verifies I64 argument passing stability.
- Updated `docs/backend/cx_jit_determinism.md` coverage table with one row for each new test.

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — two new `#[test]` functions in `determinism_tests`
- `docs/backend/cx_jit_determinism.md` — two new coverage table rows

## Validation

```
cargo build --features jit   → ok (20 pre-existing warnings, 0 errors)
cargo test --features jit    → test result: ok. 359 passed; 0 failed; 0 ignored
```

Both new tests confirmed passing individually:
```
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_call_i64_return_value ... ok
test backend::cranelift::host_boundary::determinism_tests::jit_determinism_call_i64_with_args ... ok
```

## Notes

`IrType::I64` maps directly to Cranelift `types::I64` via `ir_type_to_cranelift`. The `Call` lowering in `compile_ir_function` is type-agnostic (reads results from `builder.inst_results`). The `Cast { from: I64, to: I32 }` ireduce path was already exercised by `jit_determinism_cast_ireduce_i64_to_i32`. No new backend code was required.

Linear ticket: CX-222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced JIT determinism documentation with additional test coverage details.

* **Tests**
  * Added test cases verifying deterministic behavior for JIT-compiled functions with `I64` return types and multi-argument function calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->