### PR TITLE
CX-224: Add JIT determinism tests for void function calls

### DIFF
--- a/docs/backend/cx_jit_determinism.md
+++ b/docs/backend/cx_jit_determinism.md
@@ -125,6 +125,10 @@ This is sufficient to verify the guarantee: if the JIT pipeline were non-determi
 | `jit_determinism_while_in_loop_carried_binding` | `sum += arr[0]` across iterations — counter + accumulator threaded as two header block params; exit code 60 |
 | `jit_determinism_call_return_value` | `Call` — value-returning callee; result used as exit code |
 | `jit_determinism_call_void` | `Call` — void callee (no return value); caller returns a constant |
+| `jit_determinism_call_void_with_args` | `Call` — void callee with two `I32` args; exercises arg-passing into a void-return function |
+| `jit_determinism_call_void_multiple` | `Call` — two sequential void calls (`noop_a`, `noop_b`); verifies repeated void-callee declaration stability |
+| `jit_determinism_call_void_in_branch` | `Call` — void callee inside a non-entry branch arm; exercises void-call emission in conditional code |
+| `jit_determinism_void_main` | Void `main` entry point — `return_ty: None`; dispatched as `fn()` → exit 0 |
 | `jit_determinism_call_with_args` | `Call` — callee takes two `I32` arguments; exercises argument passing |
 | `jit_determinism_call_chained` | `Call` — three-function chain; verifies forward-reference resolution |
 | `jit_determinism_call_in_branch` | `Call` inside a non-entry block (branch arm); verifies block-local call emission |

--- a/src/backend/cranelift/host_boundary.rs
+++ b/src/backend/cranelift/host_boundary.rs
@@ -5471,6 +5471,230 @@ mod determinism_tests {
     }
 
     #[test]
+    fn jit_determinism_call_void_with_args() {
+        // Call a void function that takes two I32 arguments; caller returns a constant.
+        // Exercises arg-passing into a void callee where the return value is absent.
+        //
+        // sink(x: I32, y: I32) { return }
+        // main() -> I32 { v0=10; v1=32; call sink(v0, v1); v2=42; return v2 }
+        // Expected: 42
+        let module = IrModule {
+            debug_name: "det_call_void_args".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "sink".to_string(),
+                    params: vec![
+                        IrParam { name: "x".to_string(), ty: IrType::I32 },
+                        IrParam { name: "y".to_string(), ty: IrType::I32 },
+                    ],
+                    return_ty: None,
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![
+                            BlockParam { value: ValueId(0), ty: IrType::I32, read_only: true },
+                            BlockParam { value: ValueId(1), ty: IrType::I32, read_only: true },
+                        ],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: None },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 10 },
+                            IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 32 },
+                            IrInst::Call {
+                                dst: None,
+                                callee: "sink".to_string(),
+                                args: vec![ValueId(0), ValueId(1)],
+                                return_ty: None,
+                            },
+                            IrInst::ConstInt { dst: ValueId(2), ty: IrType::I32, value: 42 },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(2)) },
+                    }],
+                },
+            ],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
+
+    #[test]
+    fn jit_determinism_call_void_multiple() {
+        // Two sequential calls to different void functions; verifies that multiple
+        // void-callee declarations in the same caller are stable across runs.
+        //
+        // noop_a() { return }
+        // noop_b() { return }
+        // main() -> I32 { call noop_a(); call noop_b(); v0=42; return v0 }
+        // Expected: 42
+        let module = IrModule {
+            debug_name: "det_call_void_multi".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "noop_a".to_string(),
+                    params: vec![],
+                    return_ty: None,
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: None },
+                    }],
+                },
+                IrFunction {
+                    name: "noop_b".to_string(),
+                    params: vec![],
+                    return_ty: None,
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: None },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![
+                            IrInst::Call {
+                                dst: None,
+                                callee: "noop_a".to_string(),
+                                args: vec![],
+                                return_ty: None,
+                            },
+                            IrInst::Call {
+                                dst: None,
+                                callee: "noop_b".to_string(),
+                                args: vec![],
+                                return_ty: None,
+                            },
+                            IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 42 },
+                        ],
+                        term: IrTerminator::Return { value: Some(ValueId(0)) },
+                    }],
+                },
+            ],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
+
+    #[test]
+    fn jit_determinism_call_void_in_branch() {
+        // Void call inside a branch arm; verifies void-call emission in a non-entry block.
+        //
+        // side_effect() { return }
+        // main() -> I32 {
+        //   block0: v0=1; v1=1; v2=cmp Eq(v0,v1); branch v2 → block1[], block2[]
+        //   block1: call side_effect(); v3=42; return v3   ← taken (1==1)
+        //   block2: v4=7; return v4
+        // }
+        // Expected: 42
+        let module = IrModule {
+            debug_name: "det_call_void_branch".to_string(),
+            functions: vec![
+                IrFunction {
+                    name: "side_effect".to_string(),
+                    params: vec![],
+                    return_ty: None,
+                    blocks: vec![IrBlock {
+                        id: BlockId(0),
+                        params: vec![],
+                        insts: vec![],
+                        term: IrTerminator::Return { value: None },
+                    }],
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    params: vec![],
+                    return_ty: Some(IrType::I32),
+                    blocks: vec![
+                        IrBlock {
+                            id: BlockId(0),
+                            params: vec![],
+                            insts: vec![
+                                IrInst::ConstInt { dst: ValueId(0), ty: IrType::I32, value: 1 },
+                                IrInst::ConstInt { dst: ValueId(1), ty: IrType::I32, value: 1 },
+                                IrInst::Compare {
+                                    dst: ValueId(2),
+                                    op: CompareOp::Eq,
+                                    lhs: ValueId(0),
+                                    rhs: ValueId(1),
+                                },
+                            ],
+                            term: IrTerminator::Branch {
+                                cond: ValueId(2),
+                                then_block: BlockId(1),
+                                then_args: vec![],
+                                else_block: BlockId(2),
+                                else_args: vec![],
+                            },
+                        },
+                        IrBlock {
+                            id: BlockId(1),
+                            params: vec![],
+                            insts: vec![
+                                IrInst::Call {
+                                    dst: None,
+                                    callee: "side_effect".to_string(),
+                                    args: vec![],
+                                    return_ty: None,
+                                },
+                                IrInst::ConstInt { dst: ValueId(3), ty: IrType::I32, value: 42 },
+                            ],
+                            term: IrTerminator::Return { value: Some(ValueId(3)) },
+                        },
+                        IrBlock {
+                            id: BlockId(2),
+                            params: vec![],
+                            insts: vec![IrInst::ConstInt {
+                                dst: ValueId(4),
+                                ty: IrType::I32,
+                                value: 7,
+                            }],
+                            term: IrTerminator::Return { value: Some(ValueId(4)) },
+                        },
+                    ],
+                },
+            ],
+        };
+        assert_deterministic_with_expected(&module, 42);
+    }
+
+    #[test]
+    fn jit_determinism_void_main() {
+        // Void main entry point: main has return_ty=None and is dispatched as fn().
+        // JitOutcome::success() (exit 0) is returned without reading any register.
+        //
+        // main() { return }
+        // Expected: 0
+        let module = IrModule {
+            debug_name: "det_void_main".to_string(),
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_ty: None,
+                blocks: vec![IrBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    insts: vec![],
+                    term: IrTerminator::Return { value: None },
+                }],
+            }],
+        };
+        assert_deterministic_with_expected(&module, 0);
+    }
+
+    #[test]
     fn jit_determinism_call_with_args() {
         // Call a function that takes two I32 arguments and adds them.
         //


### PR DESCRIPTION
Closes CX-224

## Summary

Adds four new `#[test]` functions to the `determinism_tests` module in `host_boundary.rs`, covering void-function-call scenarios not previously exercised by the single existing `jit_determinism_call_void` test.

- **`jit_determinism_call_void_with_args`** — void callee (`sink`) with two `I32` params; exercises arg-passing where `dst: None` and `return_ty: None`
- **`jit_determinism_call_void_multiple`** — two sequential void calls (`noop_a`, `noop_b`) from the same caller; verifies repeated void-callee `declare_func_in_func` stability
- **`jit_determinism_call_void_in_branch`** — void call (`side_effect`) inside a non-entry branch arm (the true path of `1==1`); exercises void-call emission in conditional code
- **`jit_determinism_void_main`** — void `main` entry point (`return_ty: None`); verifies the `fn()` dispatch path yields exit 0 without reading a stale return register

All four tests use `assert_deterministic_with_expected` to verify both determinism and the expected concrete exit code across two independent JIT runs.

## Files Changed

- `src/backend/cranelift/host_boundary.rs` — 4 new `#[test]` functions in `determinism_tests`, inserted after `jit_determinism_call_void`
- `docs/backend/cx_jit_determinism.md` — 4 new rows in the test coverage table

## Tests Run

```
cargo build --features jit
cargo test --features jit
```

## Validation Results

```
test result: ok. 361 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.35s
```

Previously 357 determinism tests; now 361. All 5 void-call determinism tests (including the pre-existing `jit_determinism_call_void`) pass. `jit_parity_by_feature` gate: 0 PARITY_FAILs.

## Known Limitations

None. All new tests exercise existing IR constructs via the established `assert_deterministic_with_expected` helper.

## Linear Ticket

CX-224