### PR TITLE
CX-226: Implement while-in JIT lowering (lower_while_in_single + Op::Mul cursor-deref unary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ The tree-walk interpreter is the reference implementation. All 0.1 language cons
 
 The Cranelift JIT backend compiles Cx programs to native machine code. It is the 0.1 backend target and is in active development.
 
-- 155 fixtures run through the differential harness
+- 158 fixtures run through the differential harness
 - **0 PARITY_FAILs** — every supported construct produces output identical to the interpreter
-- 67 PASS / 88 SKIP across 16 feature categories
+- 71 PASS / 87 SKIP across 16 feature categories
 - ABI and data layout locked for x86-64 (scalar types, struct alignment, calling convention)
 - Determinism tested and guaranteed on valid IR
 
@@ -68,20 +68,20 @@ The Cranelift JIT backend compiles Cx programs to native machine code. It is the
 | Arithmetic     | 8    | 9    | 0           |
 | VariableDecl   | 5    | 3    | 0           |
 | IfElse         | 4    | 2    | 0           |
-| WhileLoop      | 5    | 3    | 0           |
+| WhileLoop      | 7    | 1    | 0           |
 | ForLoop        | 4    | 0    | 0           |
 | InfiniteLoop   | 2    | 1    | 0           |
 | DirectCall     | 7    | 4    | 0           |
 | Struct         | 6    | 5    | 0           |
 | Array          | 3    | 2    | 0           |
-| CompoundAssign | 2    | 2    | 0           |
+| CompoundAssign | 4    | 2    | 0           |
 | Unary          | 0    | 1    | 0           |
 | Cast           | 0    | 2    | 0           |
 | FloatOps       | 0    | 5    | 0           |
 | BuiltinAssert  | 2    | 2    | 0           |
 | LogicalOps     | 2    | 0    | 0           |
-| Other          | 16   | 48   | 0           |
-| **Total**      | **66** | **89** | **0** |
+| Other          | 17   | 48   | 0           |
+| **Total**      | **71** | **87** | **0** |
 
 SKIP means the construct is not yet lowered to JIT codegen — it exits cleanly with an unsupported-construct error rather than producing wrong output. PARITY_FAIL (semantic divergence from the interpreter) is the hard gate: it must stay at zero.
 
@@ -89,7 +89,7 @@ SKIP means the construct is not yet lowered to JIT codegen — it exits cleanly 
 - Integer arithmetic, comparisons, compound assign (`+=`, `-=`, `*=`, `/=`, `%=`)
 - Logical AND/OR with short-circuit
 - Variable declarations, typed and inferred
-- Control flow: `if`/`else`, `while`, `for` ranges (`0..n`, `1..=n`), `loop`/`break`/`continue`
+- Control flow: `if`/`else`, `while`, `for` ranges (`0..n`, `1..=n`), `loop`/`break`/`continue`, `while in arr:[slot], start..end`
 - Direct function calls — arity/type validation, return value handling
 - Struct literals, field read/write, struct-in-function
 - Fixed-size arrays: stack allocation (`ArrayAlloca`), element read/write, array-in-function

--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -102,19 +102,10 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `stokowski/CX-196` (submain as of CX-196 merge window, 2026-05-15).
-Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
-CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
-exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
-(t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
-CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
-dispatch to cx_printn, CX-187 CompoundAssign DotAccess and Index exit-code
-fixtures (t152_compound_assign_dotaccess_exit, t153_compound_assign_index_exit)
-plus parser support for `arr:[i] op= value` compound assign on array elements,
-and CX-182 integration multi-function PassWithOutput fixture
-(t154_integration_multifn) rebased onto submain via CX-196.
+Run on branch `train/backend-while-in` (submain as of CX-226 merge window, 2026-05-17).
+Includes all prior baselines through CX-196, plus CX-226 while-in JIT lowering
+(`lower_while_in_single` in IR lowering + `Op::Mul` cursor-deref unary support),
+which moves t34 (while-in exclusive) and t35 (while-in-then) from SKIP to PASS.
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -122,7 +113,7 @@ Feature                PASS   SKIP  PARITY_FAIL
 Arithmetic                8      9            0
 VariableDecl              5      3            0
 IfElse                    4      2            0
-WhileLoop                 5      3            0
+WhileLoop                 7      1            0
 ForLoop                   4      0            0
 InfiniteLoop              2      1            0
 DirectCall                7      4            0
@@ -167,11 +158,13 @@ including bool-variable negation added in CX-111). The 4 PASS reflect the
 3 exit-code-verified fixtures plus one print-based original now passing via
 CX-136 print dispatch; the 2 SKIP are the remaining print-based originals.
 
-**WhileLoop parity coverage (CX-102/CX-136):** t132 covers basic while loops and
-top-level while at file scope; t133 covers while in a function. The 5 PASS
-reflect the 2 exit-code-verified fixtures plus 3 print-based originals now
-passing via CX-136 print dispatch; the 3 SKIP are while-in/while-in-then
-constructs not yet JIT-lowerable.
+**WhileLoop parity coverage (CX-102/CX-136/CX-226):** t132 covers basic while loops and
+top-level while at file scope; t133 covers while in a function. CX-226 added
+`lower_while_in_single` (5-block CFG with counter param, array load/store, and
+`Op::Mul` cursor-deref unary lowering), which moves t34 (while-in exclusive) and
+t35 (while-in-then with `then in` chain) from SKIP to PASS. The 7 PASS reflect
+the 2 exit-code-verified fixtures plus 5 print-based originals; the 1 remaining
+SKIP is t23 (`let i;` untyped variable — Numeric type not yet JIT-lowerable).
 
 **WhenBlock parity coverage (CX-113):** t143 mirrors t19 (numeric pattern), t144
 mirrors t20 (TBool three-way), t145 mirrors t21 (range pattern). All 3 are SKIP

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -703,6 +703,10 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 result,
                 pos,
             } => {
+                let (arr_binding, arr_ty) = {
+                    let arr_info = self.lookup_var(arr).ok_or_else(|| sem_err!(*pos, "use of undeclared array '{}'", arr))?;
+                    (arr_info.binding, binding_type(arr_info, &self.current_type_params))
+                };
                 let sem_start = self.analyze_expr(range_start)?;
                 let sem_end = self.analyze_expr(range_end)?;
                 let sem_body = body
@@ -712,6 +716,10 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 let sem_chains = then_chains
                     .iter()
                     .map(|chain| {
+                        let (chain_arr_binding, chain_arr_ty) = {
+                            let info = self.lookup_var(&chain.arr).ok_or_else(|| sem_err!(*pos, "use of undeclared array '{}'", chain.arr))?;
+                            (info.binding, binding_type(info, &self.current_type_params))
+                        };
                         let cs = self.analyze_expr(&chain.range_start)?;
                         let ce = self.analyze_expr(&chain.range_end)?;
                         let cb = chain
@@ -721,6 +729,8 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                             .collect::<Result<Vec<_>, _>>()?;
                         Ok(SemanticWhileInChain {
                             arr: chain.arr.clone(),
+                            arr_binding: chain_arr_binding,
+                            arr_ty: chain_arr_ty,
                             start_slot: chain.start_slot,
                             range_start: cs,
                             range_end: ce,
@@ -735,6 +745,8 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 };
                 Ok(SemanticStmt::WhileIn {
                     arr: arr.clone(),
+                    arr_binding,
+                    arr_ty,
                     start_slot: *start_slot,
                     range_start: sem_start,
                     range_end: sem_end,

--- a/src/frontend/semantic_types.rs
+++ b/src/frontend/semantic_types.rs
@@ -268,6 +268,8 @@ pub struct SemanticFunction {
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemanticWhileInChain {
     pub arr: String,
+    pub arr_binding: BindingId,
+    pub arr_ty: SemanticType,
     pub start_slot: usize,
     pub range_start: SemanticExpr,
     pub range_end: SemanticExpr,
@@ -354,6 +356,8 @@ ExprStmt {
     },
     WhileIn {
         arr: String,
+        arr_binding: BindingId,
+        arr_ty: SemanticType,
         start_slot: usize,
         range_start: SemanticExpr,
         range_end: SemanticExpr,

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -866,7 +866,40 @@ fn lower_stmt(
         }),
         SemanticStmt::EnumDef { .. } => { unsupported!("EnumDef") },
 SemanticStmt::Block { .. } => { unsupported!("Block") },
-        SemanticStmt::WhileIn { .. } => { unsupported!("WhileIn") },
+        SemanticStmt::WhileIn {
+            arr_binding,
+            arr_ty,
+            start_slot,
+            range_start,
+            range_end,
+            inclusive,
+            body,
+            then_chains,
+            result,
+            ..
+        } => {
+            let mut active = match lower_while_in_single(
+                *arr_binding, arr_ty, *start_slot, range_start, range_end, *inclusive, body,
+                ctx, current, spec, loop_ctx,
+            )? {
+                Some(exit) => exit,
+                None => return Ok(None),
+            };
+            for chain in then_chains {
+                active = match lower_while_in_single(
+                    chain.arr_binding, &chain.arr_ty, chain.start_slot,
+                    &chain.range_start, &chain.range_end, chain.inclusive, &chain.body,
+                    ctx, active, spec, loop_ctx,
+                )? {
+                    Some(exit) => exit,
+                    None => return Ok(None),
+                };
+            }
+            if let Some(result_expr) = result {
+                lower_expr(result_expr, ctx, &mut active)?;
+            }
+            return Ok(Some(active));
+        },
         SemanticStmt::While { cond, body, .. } => {
     return match lower_while(cond, body, ctx, current, spec, loop_ctx)? {
         Some(new_active) => Ok(Some(new_active)),
@@ -1530,6 +1563,217 @@ fn lower_for(
     Ok(Some(exit_block))
 }
 
+fn lower_while_in_single(
+    arr_binding: BindingId,
+    arr_ty: &SemanticType,
+    start_slot: usize,
+    range_start: &SemanticExpr,
+    range_end: &SemanticExpr,
+    inclusive: bool,
+    body: &[SemanticStmt],
+    ctx: &mut LoweringCtx,
+    current: ActiveBlock,
+    spec: &FunctionLoweringSpec,
+    _outer_loop_ctx: Option<&LoopContext>,
+) -> Result<Option<ActiveBlock>, LoweringError> {
+    let mut current = current;
+
+    let start_val = lower_expr(range_start, ctx, &mut current)?;
+    let end_val = lower_expr(range_end, ctx, &mut current)?;
+
+    let (arr_count, elem_sem_ty) = match arr_ty {
+        SemanticType::Array(count, elem_ty) => (*count, elem_ty.as_ref()),
+        _ => {
+            return Err(LoweringError::InternalInvariantViolation {
+                detail: format!("while-in array has non-Array type: {:?}", arr_ty),
+            })
+        }
+    };
+    let elem_ir_ty = if matches!(elem_sem_ty, SemanticType::Numeric | SemanticType::Unknown) {
+        ctx.target.numeric_literal_ir_type()
+    } else {
+        lower_type(elem_sem_ty)?
+    };
+    let layout = compute_array_layout(&elem_ir_ty, arr_count);
+
+    let incoming = current.bindings.clone();
+    let mut ordered_bindings: Vec<_> = incoming.keys().copied().collect();
+    ordered_bindings.sort_by_key(|b| b.0);
+
+    // Synthetic BindingId for the hidden loop counter (for continue/break support).
+    let counter_binding = BindingId(
+        ordered_bindings.iter().map(|b| b.0).max().map_or(0, |m| m + 1),
+    );
+
+    // Header: [counter, ...all_incoming_bindings] as params
+    let mut header_params = Vec::new();
+    let mut header_bindings = HashMap::new();
+    let mut entry_args = Vec::new();
+
+    let counter_param = ctx.fresh_value();
+    header_params.push(BlockParam { value: counter_param, ty: start_val.ty.clone(), read_only: true });
+    entry_args.push(start_val.value);
+
+    for b in &ordered_bindings {
+        let val = incoming.get(b).unwrap();
+        let pv = ctx.fresh_value();
+        header_params.push(BlockParam { value: pv, ty: val.ty.clone(), read_only: false });
+        header_bindings.insert(*b, LoweredValue { value: pv, ty: val.ty.clone() });
+        entry_args.push(val.value);
+    }
+
+    let mut header = ctx.start_block(header_params, header_bindings.clone());
+    let header_id = header.id();
+
+    current.terminate(IrTerminator::Jump { target: header_id, args: entry_args })?;
+    ctx.seal_block(current)?;
+
+    // Increment block: [counter, ...bindings] params; counter+1; back-edge to header
+    let inc_counter_param = ctx.fresh_value();
+    let mut inc_params = vec![BlockParam { value: inc_counter_param, ty: start_val.ty.clone(), read_only: true }];
+    let mut inc_bindings = HashMap::new();
+    for b in &ordered_bindings {
+        let val = incoming.get(b).unwrap();
+        let pv = ctx.fresh_value();
+        inc_params.push(BlockParam { value: pv, ty: val.ty.clone(), read_only: false });
+        inc_bindings.insert(*b, LoweredValue { value: pv, ty: val.ty.clone() });
+    }
+    let mut inc_block = ctx.start_block(inc_params, inc_bindings);
+    let inc_id = inc_block.id();
+
+    let one = ctx.fresh_value();
+    inc_block.emit(IrInst::ConstInt { dst: one, ty: start_val.ty.clone(), value: 1 })?;
+    let next_counter = ctx.fresh_value();
+    inc_block.emit(IrInst::Binary {
+        dst: next_counter,
+        op: BinaryOp::Add,
+        ty: start_val.ty.clone(),
+        lhs: inc_counter_param,
+        rhs: one,
+    })?;
+    let mut inc_jump_args = vec![next_counter];
+    for b in &ordered_bindings {
+        inc_jump_args.push(inc_block.bindings.get(b).unwrap().value);
+    }
+    inc_block.terminate(IrTerminator::Jump { target: header_id, args: inc_jump_args })?;
+    ctx.seal_block(inc_block)?;
+
+    // Compare counter vs end on header
+    let cmp = ctx.fresh_value();
+    header.emit(IrInst::Compare {
+        dst: cmp,
+        op: if inclusive { CompareOp::Le } else { CompareOp::Lt },
+        lhs: counter_param,
+        rhs: end_val.value,
+    })?;
+
+    // Body block: no params; bindings = header_bindings + synthetic counter binding
+    let mut body_bindings = header_bindings.clone();
+    body_bindings.insert(counter_binding, LoweredValue { value: counter_param, ty: start_val.ty.clone() });
+    let mut body_block = ctx.start_block(vec![], body_bindings);
+    let body_id = body_block.id();
+
+    // Exit block: all incoming bindings as params
+    let mut exit_params = Vec::new();
+    let mut exit_bindings = HashMap::new();
+    for b in &ordered_bindings {
+        let val = incoming.get(b).unwrap();
+        let pv = ctx.fresh_value();
+        exit_params.push(BlockParam { value: pv, ty: val.ty.clone(), read_only: false });
+        exit_bindings.insert(*b, LoweredValue { value: pv, ty: val.ty.clone() });
+    }
+    let exit_block = ctx.start_block(exit_params, exit_bindings);
+    let exit_id = exit_block.id();
+
+    let mut else_args = Vec::new();
+    for b in &ordered_bindings {
+        else_args.push(header.bindings.get(b).unwrap().value);
+    }
+    header.terminate(IrTerminator::Branch {
+        cond: cmp,
+        then_block: body_id,
+        then_args: vec![],
+        else_block: exit_id,
+        else_args,
+    })?;
+    ctx.seal_block(header)?;
+
+    // Body: load arr[counter] → store arr[start_slot], then execute body stmts
+    let arr_ptr = body_block.bindings.get(&arr_binding).cloned().ok_or_else(|| {
+        LoweringError::InternalInvariantViolation {
+            detail: format!("while-in: array binding {} not found in body block", arr_binding.0),
+        }
+    })?;
+
+    // Compute byte offset for arr[counter]: cast counter to I64, multiply by stride
+    let idx_i64 = if start_val.ty == IrType::I64 {
+        counter_param
+    } else {
+        let cast_dst = ctx.fresh_value();
+        body_block.emit(IrInst::Cast {
+            dst: cast_dst,
+            from: start_val.ty.clone(),
+            to: IrType::I64,
+            value: counter_param,
+        })?;
+        cast_dst
+    };
+    let stride_val = ctx.fresh_value();
+    body_block.emit(IrInst::ConstInt { dst: stride_val, ty: IrType::I64, value: layout.stride as i128 })?;
+    let byte_offset = ctx.fresh_value();
+    body_block.emit(IrInst::Binary {
+        dst: byte_offset,
+        op: BinaryOp::Mul,
+        ty: IrType::I64,
+        lhs: idx_i64,
+        rhs: stride_val,
+    })?;
+    let elem_ptr = ctx.fresh_value();
+    body_block.emit(IrInst::PtrAdd { dst: elem_ptr, base: arr_ptr.value, offset: byte_offset })?;
+    let loaded = ctx.fresh_value();
+    body_block.emit(IrInst::Load { dst: loaded, ty: elem_ir_ty, ptr: elem_ptr })?;
+
+    // Store loaded element into arr[start_slot]
+    let slot_ptr = if start_slot == 0 {
+        arr_ptr.value
+    } else {
+        let fp = ctx.fresh_value();
+        body_block.emit(IrInst::PtrOffset {
+            dst: fp,
+            base: arr_ptr.value,
+            offset: start_slot * layout.stride,
+        })?;
+        fp
+    };
+    body_block.emit(IrInst::Store { ptr: slot_ptr, value: loaded })?;
+
+    // LoopContext: continue → increment, break → exit
+    let loop_context = LoopContext {
+        header_id: inc_id,
+        exit_id,
+        ordered_bindings: {
+            let mut v = vec![counter_binding];
+            v.extend(ordered_bindings.iter().copied());
+            v
+        },
+        exit_ordered_bindings: ordered_bindings.clone(),
+    };
+
+    let body_result = lower_stmt_sequence(body.iter(), ctx, Some(body_block), spec, Some(&loop_context))?;
+
+    if let Some(mut body_active) = body_result {
+        // Natural fallthrough: jump to increment with [counter, ...bindings]
+        let mut args = vec![body_active.bindings.get(&counter_binding).unwrap().value];
+        for b in &ordered_bindings {
+            args.push(body_active.bindings.get(b).unwrap().value);
+        }
+        body_active.terminate(IrTerminator::Jump { target: inc_id, args })?;
+        ctx.seal_block(body_active)?;
+    }
+
+    Ok(Some(exit_block))
+}
+
 fn finalize_active_block(
     ctx: &mut LoweringCtx,
     mut active: ActiveBlock,
@@ -1764,6 +2008,23 @@ fn lower_expr(
                 rhs: zero,
             })?;
             Ok(LoweredValue { value: dst, ty: IrType::Bool })
+        }
+        Op::Mul => {
+            // Cursor deref: `*arr` loads arr[0] from the array's base pointer.
+            // The interpreter always returns elems[0] for (Op::Mul, Array(_)).
+            match &expr.ty {
+                SemanticType::Array(_, elem_ty) => {
+                    let elem_ir_ty = if matches!(elem_ty.as_ref(), SemanticType::Numeric | SemanticType::Unknown) {
+                        ctx.target.numeric_literal_ir_type()
+                    } else {
+                        lower_type(elem_ty)?
+                    };
+                    let dst = ctx.fresh_value();
+                    active.emit(IrInst::Load { dst, ty: elem_ir_ty.clone(), ptr: lowered.value })?;
+                    Ok(LoweredValue { value: dst, ty: elem_ir_ty })
+                }
+                _ => Ok(lowered),
+            }
         }
         _ => {
             return Err(LoweringError::UnsupportedSemanticConstruct {
@@ -4032,16 +4293,12 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_statement() {
+        // `When` is still unsupported; use it to verify unsupported-construct
+        // error propagation from a top-level statement.
         let program = SemanticProgram {
-            stmts: vec![SemanticStmt::WhileIn {
-                arr: "arr".to_string(),
-                start_slot: 0,
-                range_start: int_expr(0, SemanticType::I64),
-                range_end: int_expr(10, SemanticType::I64),
-                inclusive: false,
-                body: vec![],
-                then_chains: vec![],
-                result: None,
+            stmts: vec![SemanticStmt::When {
+                expr: bool_expr(true),
+                arms: vec![],
                 pos: 0,
             }],
             enums: vec![],
@@ -4050,27 +4307,22 @@ mod tests {
         assert_eq!(
             lower_program(&program).expect_err("lowering should fail"),
             LoweringError::UnsupportedSemanticConstruct {
-                construct: "WhileIn".to_string()
+                construct: "When".to_string()
             }
         );
     }
 
     #[test]
     fn rejects_unsupported_statement_inside_function() {
+        // `When` is still unsupported; verify propagation from inside a function body.
         let program = SemanticProgram {
             stmts: vec![semantic_function(
                 "bad",
                 vec![],
                 None,
-                vec![SemanticStmt::WhileIn {
-                    arr: "arr".to_string(),
-                    start_slot: 0,
-                    range_start: int_expr(0, SemanticType::I64),
-                    range_end: int_expr(10, SemanticType::I64),
-                    inclusive: false,
-                    body: vec![],
-                    then_chains: vec![],
-                    result: None,
+                vec![SemanticStmt::When {
+                    expr: bool_expr(true),
+                    arms: vec![],
                     pos: 0,
                 }],
                 None,
@@ -4081,7 +4333,7 @@ mod tests {
         assert_eq!(
             lower_program(&program).expect_err("lowering should fail"),
             LoweringError::UnsupportedSemanticConstruct {
-                construct: "WhileIn".to_string()
+                construct: "When".to_string()
             }
         );
     }
@@ -4629,18 +4881,13 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_statement_inside_if_branch() {
+        // `When` is still unsupported; verify propagation from inside an if-branch.
         let program = SemanticProgram {
             stmts: vec![if_stmt(
                 bool_expr(true),
-                vec![SemanticStmt::WhileIn {
-                    arr: "arr".to_string(),
-                    start_slot: 0,
-                    range_start: int_expr(0, SemanticType::I64),
-                    range_end: int_expr(10, SemanticType::I64),
-                    inclusive: false,
-                    body: vec![],
-                    then_chains: vec![],
-                    result: None,
+                vec![SemanticStmt::When {
+                    expr: bool_expr(true),
+                    arms: vec![],
                     pos: 0,
                 }],
                 vec![],
@@ -4652,7 +4899,7 @@ mod tests {
         assert_eq!(
             lower_program(&program).expect_err("lowering should fail"),
             LoweringError::UnsupportedSemanticConstruct {
-                construct: "WhileIn".to_string()
+                construct: "When".to_string()
             }
         );
     }
@@ -4926,6 +5173,7 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_unary_op() {
+        // Op::Div is not a valid unary operator; verify the error path is reached.
         let program = SemanticProgram {
             stmts: vec![SemanticStmt::TypedAssign {
                 binding: BindingId(0),
@@ -4934,7 +5182,7 @@ mod tests {
                 expr: SemanticExpr {
                     ty: SemanticType::I64,
                     kind: SemanticExprKind::Unary {
-                        op: Op::Mul,
+                        op: Op::Div,
                         expr: Box::new(int_expr(5, SemanticType::I64)),
                         pos: 0,
                     },


### PR DESCRIPTION
## Summary

- Implements `lower_while_in_single` in `src/ir/lower.rs` — 5-block CFG (entry→header→body|exit, body→increment→header) for `while in arr:[slot], start..end { body }` and sequential `then in` chains
- Adds `arr_binding: BindingId` and `arr_ty: SemanticType` to `SemanticStmt::WhileIn` and `SemanticWhileInChain` in `semantic_types.rs`; populated in `semantic.rs` via scoped `lookup_var` borrows
- Adds `Op::Mul` unary handling in the JIT expression lowering path: `*arr` (cursor-deref) emits `IrInst::Load` from the array base pointer

## Parity delta

| Category   | Before       | After        |
|------------|--------------|--------------|
| WhileLoop  | 5 PASS 3 SKIP| 7 PASS 1 SKIP|
| **Total**  | 66 PASS 89 SKIP | 71 PASS 87 SKIP |

t34 (while-in exclusive range) and t35 (while-in-then with `then in` chain) move from SKIP to PASS. PARITY_FAIL stays 0 across all 16 categories.

## Test plan

- [ ] `cargo build --features jit` — clean build
- [ ] `cargo test --features jit` — 357 passed, 0 failed
- [ ] `cargo test --features jit jit_parity_by_feature -- --nocapture` — WhileLoop 7 PASS 1 SKIP, 0 PARITY_FAILs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for "while-in" loop constructs with improved array element handling and iteration.

* **Bug Fixes**
  * Improved JIT backend test parity metrics (71 PASS / 87 SKIP, up from 67 PASS / 88 SKIP).

* **Documentation**
  * Updated README and parity checklist with Phase 12 baseline results reflecting enhanced while-in construct coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->