### PR TITLE
CX-233: Implement while-in loop source-to-IR lowering

### DIFF
--- a/docs/backend/cx_jit_parity_checklist.md
+++ b/docs/backend/cx_jit_parity_checklist.md
@@ -102,29 +102,11 @@ Captured from:
 cargo build --features jit && cargo test --features jit jit_parity_by_feature -- --nocapture
 ```
 
-Run on branch `train/backend-determinism` (submain as of CX-230 merge window, 2026-05-17).
-Includes exit-code-verified fixtures added in CX-102 (t129–t134), CX-105/CX-107 LogicalOps
-fixtures (t141–t142), the CX-111 bool-variable negation extension to t131,
-CX-113 when-block exit-code fixtures (t143–t145), CX-119 var compound assign
-exit-code fixture (t151_var_compound_assign_exit), CX-121 Array exit-code fixtures
-(t146_array_read_exit, t147_array_write_exit, t148_array_in_func_exit),
-CX-124 ForLoop exit-code fixtures (t149–t150), CX-121 ArrayAlloca JIT emit
-(IrInst::ArrayAlloca Cranelift lowering), CX-136 print/println intrinsic
-dispatch to cx_printn, CX-187 CompoundAssign DotAccess and Index exit-code
-fixtures (t152_compound_assign_dotaccess_exit, t153_compound_assign_index_exit)
-plus parser support for `arr:[i] op= value` compound assign on array elements,
-CX-182 integration multi-function PassWithOutput fixture
-(t154_integration_multifn) rebased onto submain via CX-196,
-CX-117/CX-209 FloatOps/Cast parity fixtures (t155_float_arith_mod_exit,
-t156_float_neg_exit, t157_cast_neg_t32_to_f64_exit, t158_cast_t64_to_f64_exit)
-rebased onto submain via CX-217, CX-152/CX-218 Numeric/Unknown type fallbacks
-in IR lowering (VarRef, Assign, CompoundAssign, and arithmetic binary expressions
-now resolve placeholder types to the stored binding or target-native integer width),
-and CX-228 parity fixture backlog audit adding 19 fixtures (t159–t177): DirectCall
-exit-code (t159–t164), Unary exit-code (t165–t166), InfiniteLoop additional
-(t167–t168), CompoundAssign in-func (t169), BuiltinAssert pass-condition
-(t170–t171), Arithmetic t128 (t172), VariableDecl const/block-scope (t173–t174),
-and Struct/MethodCall SKIP (t175–t177).
+Run on branch `stokowski/CX-233` (submain as of CX-233 merge window, 2026-05-18).
+Includes all prior baselines through CX-230, plus CX-233 while-in source-to-IR
+lowering (`lower_while_in_single` in `src/ir/lower.rs` + `Op::Mul` cursor-deref
+unary support), which moves t34 (while-in exclusive) and t35 (while-in-then)
+from SKIP to PASS.
 
 ```text
 Feature                PASS   SKIP  PARITY_FAIL
@@ -132,7 +114,7 @@ Feature                PASS   SKIP  PARITY_FAIL
 Arithmetic                8     10            0
 VariableDecl              5      5            0
 IfElse                    4      2            0
-WhileLoop                 6      2            0
+WhileLoop                 8      0            0
 ForLoop                   4      0            0
 InfiniteLoop              4      1            0
 DirectCall               12      5            0
@@ -178,13 +160,13 @@ including bool-variable negation added in CX-111). The 4 PASS reflect the
 3 exit-code-verified fixtures plus one print-based original now passing via
 CX-136 print dispatch; the 2 SKIP are the remaining print-based originals.
 
-**WhileLoop parity coverage (CX-102/CX-136/CX-152):** t132 covers basic while loops and
-top-level while at file scope; t133 covers while in a function. The 6 PASS
-reflect the 2 exit-code-verified fixtures (t132, t133) plus 4 print-based originals
-(t23, t105, t107, t108) now passing via CX-136 print dispatch and CX-152 Numeric
-type fallback in Assign/VarRef lowering; the 2 SKIP are t34 (while-in range-based)
-and t35 (while-in-then), which use the `while in arr:...` construct not yet
-lowerable from source through the full IR pipeline.
+**WhileLoop parity coverage (CX-102/CX-136/CX-152/CX-233):** t132 covers basic while
+loops and top-level while at file scope; t133 covers while in a function. CX-233
+added `lower_while_in_single` (5-block CFG with counter param, array load/store, and
+`Op::Mul` cursor-deref unary lowering), which moves t34 (while-in range-based) and
+t35 (while-in-then with `then in` chain) from SKIP to PASS. The 8 PASS reflect the
+2 exit-code-verified fixtures (t132, t133) plus 6 print-based originals (t23, t34,
+t35, t105, t107, t108) now passing. No remaining SKIP in this category.
 
 **WhenBlock parity coverage (CX-113):** t143 mirrors t19 (numeric pattern), t144
 mirrors t20 (TBool three-way), t145 mirrors t21 (range pattern). All 3 are SKIP

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -703,6 +703,10 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 result,
                 pos,
             } => {
+                let (arr_binding, arr_ty) = {
+                    let arr_info = self.lookup_var(arr).ok_or_else(|| sem_err!(*pos, "use of undeclared array '{}'", arr))?;
+                    (arr_info.binding, binding_type(arr_info, &self.current_type_params))
+                };
                 let sem_start = self.analyze_expr(range_start)?;
                 let sem_end = self.analyze_expr(range_end)?;
                 let sem_body = body
@@ -712,6 +716,10 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 let sem_chains = then_chains
                     .iter()
                     .map(|chain| {
+                        let (chain_arr_binding, chain_arr_ty) = {
+                            let info = self.lookup_var(&chain.arr).ok_or_else(|| sem_err!(*pos, "use of undeclared array '{}'", chain.arr))?;
+                            (info.binding, binding_type(info, &self.current_type_params))
+                        };
                         let cs = self.analyze_expr(&chain.range_start)?;
                         let ce = self.analyze_expr(&chain.range_end)?;
                         let cb = chain
@@ -721,6 +729,8 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                             .collect::<Result<Vec<_>, _>>()?;
                         Ok(SemanticWhileInChain {
                             arr: chain.arr.clone(),
+                            arr_binding: chain_arr_binding,
+                            arr_ty: chain_arr_ty,
                             start_slot: chain.start_slot,
                             range_start: cs,
                             range_end: ce,
@@ -735,6 +745,8 @@ Stmt::ExprStmt { expr, _pos } => Ok(SemanticStmt::ExprStmt {
                 };
                 Ok(SemanticStmt::WhileIn {
                     arr: arr.clone(),
+                    arr_binding,
+                    arr_ty,
                     start_slot: *start_slot,
                     range_start: sem_start,
                     range_end: sem_end,

--- a/src/frontend/semantic_types.rs
+++ b/src/frontend/semantic_types.rs
@@ -268,6 +268,8 @@ pub struct SemanticFunction {
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemanticWhileInChain {
     pub arr: String,
+    pub arr_binding: BindingId,
+    pub arr_ty: SemanticType,
     pub start_slot: usize,
     pub range_start: SemanticExpr,
     pub range_end: SemanticExpr,
@@ -354,6 +356,8 @@ ExprStmt {
     },
     WhileIn {
         arr: String,
+        arr_binding: BindingId,
+        arr_ty: SemanticType,
         start_slot: usize,
         range_start: SemanticExpr,
         range_end: SemanticExpr,

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -878,7 +878,40 @@ fn lower_stmt(
         }),
         SemanticStmt::EnumDef { .. } => { unsupported!("EnumDef") },
 SemanticStmt::Block { .. } => { unsupported!("Block") },
-        SemanticStmt::WhileIn { .. } => { unsupported!("WhileIn") },
+        SemanticStmt::WhileIn {
+            arr_binding,
+            arr_ty,
+            start_slot,
+            range_start,
+            range_end,
+            inclusive,
+            body,
+            then_chains,
+            result,
+            ..
+        } => {
+            let mut active = match lower_while_in_single(
+                *arr_binding, arr_ty, *start_slot, range_start, range_end, *inclusive, body,
+                ctx, current, spec, loop_ctx,
+            )? {
+                Some(exit) => exit,
+                None => return Ok(None),
+            };
+            for chain in then_chains {
+                active = match lower_while_in_single(
+                    chain.arr_binding, &chain.arr_ty, chain.start_slot,
+                    &chain.range_start, &chain.range_end, chain.inclusive, &chain.body,
+                    ctx, active, spec, loop_ctx,
+                )? {
+                    Some(exit) => exit,
+                    None => return Ok(None),
+                };
+            }
+            if let Some(result_expr) = result {
+                lower_expr(result_expr, ctx, &mut active)?;
+            }
+            return Ok(Some(active));
+        },
         SemanticStmt::While { cond, body, .. } => {
     return match lower_while(cond, body, ctx, current, spec, loop_ctx)? {
         Some(new_active) => Ok(Some(new_active)),
@@ -1542,6 +1575,212 @@ fn lower_for(
     Ok(Some(exit_block))
 }
 
+fn lower_while_in_single(
+    arr_binding: BindingId,
+    arr_ty: &SemanticType,
+    start_slot: usize,
+    range_start: &SemanticExpr,
+    range_end: &SemanticExpr,
+    inclusive: bool,
+    body: &[SemanticStmt],
+    ctx: &mut LoweringCtx,
+    current: ActiveBlock,
+    spec: &FunctionLoweringSpec,
+    _outer_loop_ctx: Option<&LoopContext>,
+) -> Result<Option<ActiveBlock>, LoweringError> {
+    let mut current = current;
+
+    let start_val = lower_expr(range_start, ctx, &mut current)?;
+    let end_val = lower_expr(range_end, ctx, &mut current)?;
+
+    let (arr_count, elem_sem_ty) = match arr_ty {
+        SemanticType::Array(count, elem_ty) => (*count, elem_ty.as_ref()),
+        _ => {
+            return Err(LoweringError::InternalInvariantViolation {
+                detail: format!("while-in array has non-Array type: {:?}", arr_ty),
+            })
+        }
+    };
+    let elem_ir_ty = if matches!(elem_sem_ty, SemanticType::Numeric | SemanticType::Unknown) {
+        ctx.target.numeric_literal_ir_type()
+    } else {
+        lower_type(elem_sem_ty)?
+    };
+    let layout = compute_array_layout(&elem_ir_ty, arr_count);
+
+    let incoming = current.bindings.clone();
+    let mut ordered_bindings: Vec<_> = incoming.keys().copied().collect();
+    ordered_bindings.sort_by_key(|b| b.0);
+
+    // Synthetic BindingId for the hidden loop counter (for continue/break support).
+    let counter_binding = BindingId(
+        ordered_bindings.iter().map(|b| b.0).max().map_or(0, |m| m + 1),
+    );
+
+    // Header: [counter, ...all_incoming_bindings] as params
+    let mut header_params = Vec::new();
+    let mut header_bindings = HashMap::new();
+    let mut entry_args = Vec::new();
+
+    let counter_param = ctx.fresh_value();
+    header_params.push(BlockParam { value: counter_param, ty: start_val.ty.clone(), read_only: true });
+    entry_args.push(start_val.value);
+
+    for b in &ordered_bindings {
+        let val = incoming.get(b).unwrap();
+        let pv = ctx.fresh_value();
+        header_params.push(BlockParam { value: pv, ty: val.ty.clone(), read_only: false });
+        header_bindings.insert(*b, LoweredValue { value: pv, ty: val.ty.clone() });
+        entry_args.push(val.value);
+    }
+
+    let mut header = ctx.start_block(header_params, header_bindings.clone());
+    let header_id = header.id();
+
+    current.terminate(IrTerminator::Jump { target: header_id, args: entry_args })?;
+    ctx.seal_block(current)?;
+
+    // Increment block: [counter, ...bindings] params; counter+1; back-edge to header
+    let inc_counter_param = ctx.fresh_value();
+    let mut inc_params = vec![BlockParam { value: inc_counter_param, ty: start_val.ty.clone(), read_only: true }];
+    let mut inc_bindings = HashMap::new();
+    for b in &ordered_bindings {
+        let val = incoming.get(b).unwrap();
+        let pv = ctx.fresh_value();
+        inc_params.push(BlockParam { value: pv, ty: val.ty.clone(), read_only: false });
+        inc_bindings.insert(*b, LoweredValue { value: pv, ty: val.ty.clone() });
+    }
+    let mut inc_block = ctx.start_block(inc_params, inc_bindings);
+    let inc_id = inc_block.id();
+
+    let one = ctx.fresh_value();
+    inc_block.emit(IrInst::ConstInt { dst: one, ty: start_val.ty.clone(), value: 1 })?;
+    let next_counter = ctx.fresh_value();
+    inc_block.emit(IrInst::Binary {
+        dst: next_counter,
+        op: BinaryOp::Add,
+        ty: start_val.ty.clone(),
+        lhs: inc_counter_param,
+        rhs: one,
+    })?;
+    let mut inc_jump_args = vec![next_counter];
+    for b in &ordered_bindings {
+        inc_jump_args.push(inc_block.bindings.get(b).unwrap().value);
+    }
+    inc_block.terminate(IrTerminator::Jump { target: header_id, args: inc_jump_args })?;
+    ctx.seal_block(inc_block)?;
+
+    // Compare counter vs end on header
+    let cmp = ctx.fresh_value();
+    header.emit(IrInst::Compare {
+        dst: cmp,
+        op: if inclusive { CompareOp::Le } else { CompareOp::Lt },
+        lhs: counter_param,
+        rhs: end_val.value,
+    })?;
+
+    // Body block: no params; bindings = header_bindings + synthetic counter binding
+    let mut body_bindings = header_bindings.clone();
+    body_bindings.insert(counter_binding, LoweredValue { value: counter_param, ty: start_val.ty.clone() });
+    let mut body_block = ctx.start_block(vec![], body_bindings);
+    let body_id = body_block.id();
+
+    // Exit block: all incoming bindings as params
+    let mut exit_params = Vec::new();
+    let mut exit_bindings = HashMap::new();
+    for b in &ordered_bindings {
+        let val = incoming.get(b).unwrap();
+        let pv = ctx.fresh_value();
+        exit_params.push(BlockParam { value: pv, ty: val.ty.clone(), read_only: false });
+        exit_bindings.insert(*b, LoweredValue { value: pv, ty: val.ty.clone() });
+    }
+    let exit_block = ctx.start_block(exit_params, exit_bindings);
+    let exit_id = exit_block.id();
+
+    let mut else_args = Vec::new();
+    for b in &ordered_bindings {
+        else_args.push(header.bindings.get(b).unwrap().value);
+    }
+    header.terminate(IrTerminator::Branch {
+        cond: cmp,
+        then_block: body_id,
+        then_args: vec![],
+        else_block: exit_id,
+        else_args,
+    })?;
+    ctx.seal_block(header)?;
+
+    // Body: load arr[counter] → store arr[start_slot], then execute body stmts
+    let arr_ptr = body_block.bindings.get(&arr_binding).cloned().ok_or_else(|| {
+        LoweringError::InternalInvariantViolation {
+            detail: format!("while-in: array binding {} not found in body block", arr_binding.0),
+        }
+    })?;
+
+    // Compute byte offset for arr[counter]: cast counter to I64, multiply by stride
+    let idx_i64 = if start_val.ty == IrType::I64 {
+        counter_param
+    } else {
+        let cast_dst = ctx.fresh_value();
+        body_block.emit(IrInst::Cast {
+            dst: cast_dst,
+            from: start_val.ty.clone(),
+            to: IrType::I64,
+            value: counter_param,
+        })?;
+        cast_dst
+    };
+    let stride_val = ctx.fresh_value();
+    body_block.emit(IrInst::ConstInt { dst: stride_val, ty: IrType::I64, value: layout.stride as i128 })?;
+    let byte_offset = ctx.fresh_value();
+    body_block.emit(IrInst::Binary {
+        dst: byte_offset,
+        op: BinaryOp::Mul,
+        ty: IrType::I64,
+        lhs: idx_i64,
+        rhs: stride_val,
+    })?;
+    let elem_ptr = ctx.fresh_value();
+    body_block.emit(IrInst::PtrAdd { dst: elem_ptr, base: arr_ptr.value, offset: byte_offset })?;
+    let loaded = ctx.fresh_value();
+    body_block.emit(IrInst::Load { dst: loaded, ty: elem_ir_ty.clone(), ptr: elem_ptr })?;
+
+    // Store loaded element into arr[start_slot]
+    let slot_ptr = if start_slot == 0 {
+        arr_ptr.value
+    } else {
+        let fp = ctx.fresh_value();
+        body_block.emit(IrInst::PtrOffset {
+            dst: fp,
+            base: arr_ptr.value,
+            offset: start_slot * layout.stride,
+        })?;
+        fp
+    };
+    body_block.emit(IrInst::Store { ptr: slot_ptr, value: loaded })?;
+
+    // LoopContext: continue → increment, break → exit
+    let loop_ctx = LoopContext {
+        header_id,
+        exit_id,
+        ordered_bindings: ordered_bindings.clone(),
+        exit_ordered_bindings: ordered_bindings.clone(),
+    };
+
+    let body_result = lower_stmt_sequence(body.iter(), ctx, Some(body_block), spec, Some(&loop_ctx))?;
+
+    if let Some(mut body_active) = body_result {
+        let mut args = vec![body_active.bindings.get(&counter_binding).map(|v| v.value).unwrap_or(counter_param)];
+        for b in &ordered_bindings {
+            args.push(body_active.bindings.get(b).unwrap().value);
+        }
+        body_active.terminate(IrTerminator::Jump { target: inc_id, args })?;
+        ctx.seal_block(body_active)?;
+    }
+
+    Ok(Some(exit_block))
+}
+
 fn finalize_active_block(
     ctx: &mut LoweringCtx,
     mut active: ActiveBlock,
@@ -1782,6 +2021,23 @@ fn lower_expr(
                 rhs: zero,
             })?;
             Ok(LoweredValue { value: dst, ty: IrType::Bool })
+        }
+        Op::Mul => {
+            // Cursor deref: `*arr` loads arr[0] from the array's base pointer.
+            // The interpreter always returns elems[0] for (Op::Mul, Array(_)).
+            match &expr.ty {
+                SemanticType::Array(_, elem_ty) => {
+                    let elem_ir_ty = if matches!(elem_ty.as_ref(), SemanticType::Numeric | SemanticType::Unknown) {
+                        ctx.target.numeric_literal_ir_type()
+                    } else {
+                        lower_type(elem_ty)?
+                    };
+                    let dst = ctx.fresh_value();
+                    active.emit(IrInst::Load { dst, ty: elem_ir_ty.clone(), ptr: lowered.value })?;
+                    Ok(LoweredValue { value: dst, ty: elem_ir_ty })
+                }
+                _ => Ok(lowered),
+            }
         }
         _ => {
             return Err(LoweringError::UnsupportedSemanticConstruct {
@@ -4117,16 +4373,12 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_statement() {
+        // `When` is still unsupported; use it to verify unsupported-construct
+        // error propagation from a top-level statement.
         let program = SemanticProgram {
-            stmts: vec![SemanticStmt::WhileIn {
-                arr: "arr".to_string(),
-                start_slot: 0,
-                range_start: int_expr(0, SemanticType::I64),
-                range_end: int_expr(10, SemanticType::I64),
-                inclusive: false,
-                body: vec![],
-                then_chains: vec![],
-                result: None,
+            stmts: vec![SemanticStmt::When {
+                expr: bool_expr(true),
+                arms: vec![],
                 pos: 0,
             }],
             enums: vec![],
@@ -4135,27 +4387,22 @@ mod tests {
         assert_eq!(
             lower_program(&program).expect_err("lowering should fail"),
             LoweringError::UnsupportedSemanticConstruct {
-                construct: "WhileIn".to_string()
+                construct: "When".to_string()
             }
         );
     }
 
     #[test]
     fn rejects_unsupported_statement_inside_function() {
+        // `When` is still unsupported; verify propagation from inside a function body.
         let program = SemanticProgram {
             stmts: vec![semantic_function(
                 "bad",
                 vec![],
                 None,
-                vec![SemanticStmt::WhileIn {
-                    arr: "arr".to_string(),
-                    start_slot: 0,
-                    range_start: int_expr(0, SemanticType::I64),
-                    range_end: int_expr(10, SemanticType::I64),
-                    inclusive: false,
-                    body: vec![],
-                    then_chains: vec![],
-                    result: None,
+                vec![SemanticStmt::When {
+                    expr: bool_expr(true),
+                    arms: vec![],
                     pos: 0,
                 }],
                 None,
@@ -4166,7 +4413,7 @@ mod tests {
         assert_eq!(
             lower_program(&program).expect_err("lowering should fail"),
             LoweringError::UnsupportedSemanticConstruct {
-                construct: "WhileIn".to_string()
+                construct: "When".to_string()
             }
         );
     }
@@ -4714,18 +4961,13 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_statement_inside_if_branch() {
+        // `When` is still unsupported; verify propagation from inside an if-branch.
         let program = SemanticProgram {
             stmts: vec![if_stmt(
                 bool_expr(true),
-                vec![SemanticStmt::WhileIn {
-                    arr: "arr".to_string(),
-                    start_slot: 0,
-                    range_start: int_expr(0, SemanticType::I64),
-                    range_end: int_expr(10, SemanticType::I64),
-                    inclusive: false,
-                    body: vec![],
-                    then_chains: vec![],
-                    result: None,
+                vec![SemanticStmt::When {
+                    expr: bool_expr(true),
+                    arms: vec![],
                     pos: 0,
                 }],
                 vec![],
@@ -4737,7 +4979,7 @@ mod tests {
         assert_eq!(
             lower_program(&program).expect_err("lowering should fail"),
             LoweringError::UnsupportedSemanticConstruct {
-                construct: "WhileIn".to_string()
+                construct: "When".to_string()
             }
         );
     }
@@ -5011,6 +5253,7 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_unary_op() {
+        // Op::Div is not a valid unary operator; verify the error path is reached.
         let program = SemanticProgram {
             stmts: vec![SemanticStmt::TypedAssign {
                 binding: BindingId(0),
@@ -5019,7 +5262,7 @@ mod tests {
                 expr: SemanticExpr {
                     ty: SemanticType::I64,
                     kind: SemanticExprKind::Unary {
-                        op: Op::Mul,
+                        op: Op::Div,
                         expr: Box::new(int_expr(5, SemanticType::I64)),
                         pos: 0,
                     },


### PR DESCRIPTION
## Summary

- Add `arr_binding: BindingId` and `arr_ty: SemanticType` to `SemanticStmt::WhileIn` and `SemanticWhileInChain` in `semantic_types.rs`; populate them via `lookup_var` in `semantic.rs`
- Implement `lower_while_in_single` in `src/ir/lower.rs`: 5-block CFG (entry → header → body → increment → exit) with index counter param, array element load via `PtrAdd`/stride multiply, slot store, and correct SSA block params throughout
- Add `Op::Mul` cursor-deref unary lowering (`*arr` loads `arr[0]` from the base pointer)
- Update 3 unit tests that previously relied on `WhileIn` as the unsupported-construct signal to use `When` instead; update `rejects_unsupported_unary_op` to use `Op::Div`
- Update `docs/backend/cx_jit_parity_checklist.md` Section 3 baseline: WhileLoop moves from 6 PASS / 2 SKIP to **8 PASS / 0 SKIP**

## Validation

```
cargo build --features jit    → clean (zero new warnings)
cargo test --features jit     → 399/399 PASS
cargo test --features jit jit_parity_by_feature -- --nocapture
  WhileLoop   8   0   0   ← was 6/2/0; t34 and t35 now PASS
  PARITY_FAIL = 0 across all 16 categories
  Total: 181 fixtures
```

Closes CX-233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * While-in loops are now fully supported and operational
  * Cursor dereference operator now functional for array element access

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->