### PR TITLE
refactor(frontend): add Type::Void AST variant

### DIFF
--- a/src/frontend/ast.rs
+++ b/src/frontend/ast.rs
@@ -45,6 +45,7 @@ pub enum Type {
     StrRef,
     Container,
     Char,
+    Void,
     Enum(String),
     Unknown,
     Handle(Box<Type>),

--- a/src/frontend/lexer.rs
+++ b/src/frontend/lexer.rs
@@ -155,6 +155,9 @@ pub enum Token {
     #[token("char")]
     TypeChar,
 
+    #[token("void")]
+    TypeVoid,
+
     // ── Literals ─────────────────────────────────
     #[regex(r#""([^"\\]|\\.)*""#, |lex| {
         let s = lex.slice();

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -47,6 +47,7 @@ where
             Token::TypeStr    => Type::Str,
             Token::TypeStrRef => Type::StrRef,
             Token::TypeChar   => Type::Char,
+            Token::TypeVoid   => Type::Void,
         };
 
         let named_type = select! { Token::Identifier(s) => Type::Struct(s) };

--- a/src/frontend/semantic.rs
+++ b/src/frontend/semantic.rs
@@ -1952,6 +1952,7 @@ fn semantic_type_from_decl(ty: Type, type_params: &[String]) -> SemanticType {
         Type::StrRef => SemanticType::StrRef,
         Type::Container => SemanticType::Container,
         Type::Char => SemanticType::Char,
+        Type::Void => SemanticType::Void,
         Type::Enum(name) => SemanticType::Enum(name),
         Type::Unknown => SemanticType::Unknown,
         Type::Handle(inner) => SemanticType::Handle(Box::new(semantic_type_from_decl(*inner, type_params))),
@@ -2510,5 +2511,73 @@ mod tests {
 
         let errors = analyze_program(&program).expect_err("analysis should fail");
         assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    fn void_returning_function_allows_trailing_void_call() {
+        // Guards `fnc: void main() { print("hi") }`. The lexer emits
+        // Token::TypeVoid, the parser maps it to Type::Void, and the
+        // semantic mapper lowers that to SemanticType::Void — so the
+        // trailing print() (typed Void) matches the declared return type.
+        let program = Program {
+            stmts: vec![Stmt::FuncDef {
+                name: "main".to_string(),
+                type_params: vec![],
+                params: vec![],
+                ret_ty: Some(Type::Void),
+                body: vec![],
+                ret_expr: Some(Expr::Call(
+                    "print".to_string(),
+                    vec![CallArg::Expr(Expr::Val(AstValue::Str("hi".to_string())))],
+                    0,
+                )),
+                pos: 0,
+                is_pub: false,
+                macros: vec![],
+            }],
+        };
+
+        let semantic = analyze_program(&program).expect("void main with trailing print should analyse");
+        match &semantic.stmts[0] {
+            SemanticStmt::FuncDef(func) => {
+                assert_eq!(func.return_ty, Some(SemanticType::Void));
+                let ret_expr = func.ret_expr.as_ref().expect("trailing expr preserved");
+                assert_eq!(ret_expr.ty, SemanticType::Void);
+            }
+            other => panic!("unexpected stmt: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parser_emits_type_void_for_void_keyword() {
+        use crate::frontend::lexer::Token;
+        use crate::frontend::parser;
+        use chumsky::input::Stream;
+        use chumsky::prelude::*;
+        use logos::Logos;
+
+        let source = "fnc: void main() {}";
+        let mut tokens = Vec::new();
+        let mut lex = Token::lexer(source);
+        while let Some(tok_result) = lex.next() {
+            let span = lex.span();
+            if let Ok(token) = tok_result {
+                tokens.push((token, (span.start..span.end).into()));
+            }
+        }
+        let eoi: SimpleSpan = (source.len()..source.len()).into();
+        let input = Stream::from_iter(tokens).map(eoi, |(token, span): (_, _)| (token, span));
+        let program = parser::program_parser()
+            .parse(input)
+            .into_result()
+            .expect("source should parse");
+
+        match &program.stmts[0] {
+            Stmt::FuncDef { name, ret_ty, .. } => {
+                assert_eq!(name, "main");
+                assert_eq!(ret_ty, &Some(Type::Void));
+            }
+            other => panic!("unexpected stmt: {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Replaces the previous string-match band-aid in `semantic_type_from_decl` with a structural fix for the spurious `"return type mismatch: expected void, got void"` error reported on `fnc: void main() { print("Hello from Linux!") }`.

Root cause: the AST `Type` enum had no `Void` variant, so the parser's `named_type` rule mapped the bare identifier `void` to `Type::Struct("void")`. The semantic mapper produced `SemanticType::Struct("void")` from that, which then failed `types_compatible(...)` against `SemanticType::Void` returned by the `print` builtin. Both rendered as `"void"` via `type_name`, producing the misleading diagnostic.

## What changed

- **`src/frontend/ast.rs`** — added `Type::Void` in the primitive cluster (after `Char`).
- **`src/frontend/lexer.rs`** — added `#[token("void")] TypeVoid` alongside the existing `Token::TypeT8`…`Token::TypeChar`. `void` is now a reserved type keyword.
- **`src/frontend/parser.rs`** — added `Token::TypeVoid => Type::Void` to the `scalar` `select!` block in `type_parser`. `named_type` no longer needs to handle `void` because the lexer claims it first.
- **`src/frontend/semantic.rs`** — removed the `if name == "void" { SemanticType::Void }` band-aid arm; added `Type::Void => SemanticType::Void` in the primitive cluster of `semantic_type_from_decl`.
- **Tests** — updated the existing `void_returning_function_allows_trailing_void_call` semantic test to use `Type::Void`, and added `parser_emits_type_void_for_void_keyword` which parses `fnc: void main() {}` and asserts `ret_ty == Some(Type::Void)`.

## Behavior changes for reviewers

- `void` is now a reserved type keyword. Using it as a binding name (e.g. `let void: t32 = 5`) is now a parse error. (The error wording from the parser layer is generic — pre-existing diagnostic-quality issue, not addressed here.)
- All existing usages of the `void` return type continue to work; the lexer/parser/semantic pipeline now produces `SemanticType::Void` consistently.

## Audit

Phase-1 grep of `Type::Struct` usages outside `semantic_type_from_decl` confirmed no other site inspects the inner string for `"void"` — backend/IR matches on `SemanticType::Struct`, never on AST `Type::Struct("void")`. No additional updates required.

## Test plan

- [x] `cargo build` — clean (only the two pre-existing warnings on `IrType` import and `ArrayLayout` dead fields).
- [x] `cargo test` — 241 passed; 0 failed (one more than before — the new parser test).
- [x] `cargo run -- hello.cx` with body `fnc: void main() { print("Hello from Linux!") }` — exit 0, no semantic error.
- [x] `grep '"void"' src/frontend/semantic.rs` — only the `type_name` display string remains; band-aid arm gone.
- [x] Sanity check: `let void: t32 = 5` now produces a `PARSE ERROR (line 2): ... found: Some(TypeVoid)` — confirms the reservation took effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `void` return type, enabling functions to be declared and type-checked with `void` as their return type. Functions can now have trailing expression statements that properly type-check as void.

* **Tests**
  * Added comprehensive test coverage for void function declarations and semantic type checking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/COMMENTERTHE9/Cx_lang/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->