### PR TITLE
daily log 2026-06-07

### DIFF
--- a/daily_log/2026-06-07.md
+++ b/daily_log/2026-06-07.md
@@ -1,0 +1,64 @@
+# Cx Daily Log — 2026-06-07
+
+## Snapshot
+
+A quiet day. No developer-authored feature commits landed anywhere in the last 24 hours. The only git activity was publication of yesterday's daily log (on `daily-log-2026-06-06-v2`) and a site blog post summarizing the v0.2.0 merge and CR#1-3 work. The working tree is clean. Main remains at the v0.2.0 merge (`5981121`); submain remains 3 commits ahead with CR#1-3 unmerged. Matrix holds steady at 230/0 on main.
+
+## Landed today
+
+- **Daily log 2026-06-06** (`c9c76d5`, `origin/daily-log-2026-06-06-v2`, 23:39 UTC Jun 6) — CONFIRMED. Documentation only. PR #298 opened against main, not yet merged.
+
+- **Site blog post** (`2c4f231`, `origin/site`, 00:10 UTC Jun 7) — CONFIRMED. Published `src/content/blog/2026-06-06.mdx` — a public-facing dev log summarizing the v0.2.0 merge and CR#1-3 range-check fixes. Documentation only.
+
+No feature work, no bug fixes, no new test fixtures in the last 24 hours.
+
+## In progress / uncommitted work
+
+Nothing to report. The working tree on main is clean. No staged changes, no unstaged changes, no untracked files.
+
+The submain branch still carries 3 unmerged commits (CR#1-3) and 22 new verification matrix fixtures that are not yet on main. This is carried forward from yesterday — no new work was added today.
+
+## Decisions and direction
+
+Nothing to report. No design decisions or direction changes are evidenced by today's activity.
+
+The open questions from yesterday remain open:
+- CR#4 (range-check literals inside if/when branches) is the last identified gap in the #028/#037 rule
+- The Cranelift negative-element struct array segfault (surfaced by CR#2) is documented but unfixed
+- Implicit non-literal narrowing awaits cast syntax as a prerequisite
+
+## Roadmap updates
+
+**Checked off:** Nothing new. The roadmap already reflects the v0.2.0 release status from yesterday's update on the `daily-log-2026-06-06-v2` branch (PR #298, not yet merged to main).
+
+**Updated today:** The roadmap on main is brought current — reflecting v0.2.0 release, CR#1-3 on submain, `when` block lowering checked off, Phase 15 parity numbers updated, and a 2026-06-07 working note. This catches main's roadmap up to reality since PR #298 has not yet merged.
+
+**Not changed:**
+- Phase 11 DotAccess in compound forms — no new evidence
+- Phase 8 Round 2 — no backend feature work
+- Post-0.1 language features — unchanged
+
+## What's next
+
+**Yesterday's predictions vs. today:**
+1. *"Merge CR#1-3 from submain to main"* — NOT DONE. Submain is still 3 commits ahead.
+2. *"CR#4: range-check literals inside if/when branches"* — NOT DONE.
+3. *"Commit the example suite overhaul"* — NOT DONE.
+4. *"Address the Cranelift negative-element segfault"* — NOT DONE.
+
+None of yesterday's predicted next steps materialized. This appears to have been a rest day or focus was elsewhere.
+
+**Likely next moves:**
+1. **Merge CR#1-3 from submain to main.** Still the most obvious immediate task — 3 commits, clean merge, correctness fixes that should reach main.
+2. **Merge PR #298 (daily log 2026-06-06).** Currently open, no conflicts expected.
+3. **CR#4: range-check literals inside if/when branches.** The last identified gap in the #028/#037 sweep. Explicitly tracked in the CR#3 commit message.
+4. **Backend work or Cranelift segfault investigation.** The frontend semantic analysis layer is now quite mature; the primary remaining frontier is backend JIT coverage.
+
+---
+
+**Matrix (main):** 230 PASS / 0 FAIL out of 230 total — unchanged from yesterday.
+**Matrix (submain, per CR#3 commit):** 252 PASS / 0 FAIL — unchanged from yesterday.
+
+**Reverts:** None in the last 24 hours.
+
+**Evidence sources:** `git log --all --since="24 hours ago"` (2 commits: 1 daily-log, 1 site blog post — both documentation), `git status` (clean working tree), `git diff origin/main..origin/submain --stat` (59 files, CR#1-3 still unmerged), `run_matrix.sh` (230/0 on main), PR #298 status (open, not merged), yesterday's daily log from `origin/daily-log-2026-06-06-v2`.

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-05-18
+Last updated: 2026-06-07
 
 This file is a concise synthesis of the project's roadmap state. Detailed roadmaps live at:
 - Frontend: `docs/frontend/ROADMAP.md` (v5.0)
@@ -8,11 +8,11 @@ This file is a concise synthesis of the project's roadmap state. Detailed roadma
 
 ---
 
-## Frontend — v0.1.0 Released
+## Frontend — v0.2.0 Released
 
-All 9 hard blockers resolved. 182/182 matrix tests passing. 8/8 examples passing.
+All 9 hard blockers resolved. 230/230 matrix tests passing on main. 10/10 examples passing.
 
-**Status:** v0.1.0 released (tagged at 9fc0d24). No known soundness holes. Syntax frozen.
+**Status:** v0.2.0 released (tagged at 5981121, merged to main via PR #295). No known soundness holes. Syntax frozen. Post-release range-check sweep (CR#1-3) on submain closes all known #028/#037 gaps except branch-nested literals (CR#4).
 
 **Known limitations (documented, not blocking):**
 - String arena grows monotonically (interpreter-only)
@@ -21,6 +21,9 @@ All 9 hard blockers resolved. 182/182 matrix tests passing. 8/8 examples passing
 
 **Post-release hardening (on submain):**
 - [x] Composite literal type-checking — struct field presence/type/unknown-field validation, array element type checking (8169d33)
+- [x] CR#1 — range-check fields through explicit generic type args (b8e92fb)
+- [x] CR#2 — range-check array elements in struct fields and call args (7337b61)
+- [x] CR#3 — range-check return values at declared width (79a1bbd)
 
 ---
 
@@ -55,18 +58,18 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
   - [x] Range structured error (CX-19)
   - [x] MethodCall structured error (CX-21)
   - [x] Method call actual lowering (0ab7e9b — synthesis-and-recurse via Call arm)
-  - [ ] `when` block lowering or structured rejection
+  - [x] `when` block lowering — Literal/Range/Bool/Catchall + TBool wire-value (bed71c1, landed on main via v0.2.0 merge)
   - [ ] DotAccess in compound forms
 - [ ] Phase 8 Round 2 — str/strref layout, Handle<T>, TBool calling convention
 
-### Landed (integrated to main via v0.1.0 merge)
+### Landed (integrated to main via v0.2.0 merge)
 
 - [x] Phase 13 — Cranelift lowering skeleton (CX-22)
 - [x] JIT Host Boundary (CX-24: process ownership, exit codes, output capture)
 - [ ] Phase 12 — Differential harness (parity classification CX-69, loop fixtures CX-68, determinism tests CX-55 merged; CX-228 adds t159–t177 parity fixtures; more in flight)
 - [ ] Phase 9 — Runtime intrinsics boundary (assert/assert_eq lowered natively via CX-48; print/println/printn/read/input still pending)
 - [ ] Phase 14 — First executable Cranelift slice (CX-52 float comparison, CX-53 void return, CX-54 debug-trace gating merged)
-- [ ] Phase 15 — Cranelift JIT 0.1 target (CX-74 exit-code propagation merged; print arg widening 08fa2f9; literal-width narrowing complete across 5 operator sites; CX-57/58/60/63/64/66 instruction coverage in flight; 110 PASS / 72 SKIP / 0 PARITY_FAIL across 182 fixtures)
+- [ ] Phase 15 — Cranelift JIT 0.1 target (CX-74 exit-code propagation merged; print arg widening 08fa2f9; literal-width narrowing complete across 5 operator sites; CX-57/58/60/63/64/66 instruction coverage in flight; 156 PASS / 96 SKIP / 0 PARITY_FAIL across 252 fixtures on submain)
 
 ### Post-0.1
 - [ ] Cranelift AOT (Phase 16)
@@ -92,6 +95,10 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 ---
 
 ## Working Notes
+
+**2026-06-07:** Quiet day. No feature commits. Submain CR#1-3 still awaiting merge to main. Matrix 230/0 on main, 252/0 on submain — both unchanged. PR #298 (daily log 2026-06-06) open, not yet merged.
+
+**2026-06-06:** v0.2.0 merged to main (PR #295, tagged). Three post-release range-check fixes landed on submain (CR#1 generic fields, CR#2 array elements in struct fields/call args, CR#3 return values) — all found by CodeRabbit, all in `semantic.rs`. Matrix grew from 230 to 252 fixtures on submain, 0 failures. Submain now 3 commits ahead of main. CR#2 surfaced a pre-existing Cranelift segfault with negative struct array elements (marked `.jit_known_unsound`).
 
 **2026-05-18:** PR #268 merged `train/backend-determinism` → submain (host_boundary expansion, IR lowering fixes, 23 new parity fixtures including CX-228 t159–t177). CX-233 implements while-in loop source-to-IR lowering on `stokowski/CX-233` (branch-local, not yet merged) — WhileLoop parity moves to 8/0. Submain 171 commits ahead of main.
 


### PR DESCRIPTION
Automated daily log and roadmap update.

## Summary
- Daily development log for 2026-06-07 (quiet day — no developer-authored feature commits)
- Roadmap updated on main: v0.2.0 release status, CR#1-3 checked off in post-release hardening, `when` block lowering checked off, Phase 15 parity numbers updated, working notes entries added for 2026-06-06 and 2026-06-07
- Matrix: 230 PASS / 0 FAIL on main (unchanged)

## Changes
- `daily_log/2026-06-07.md` — new daily log
- `docment/ROADMAP.md` — catches main's roadmap up to current reality (v0.2.0 release, CR#1-3, when lowering)

https://claude.ai/code/session_01YFC9MeZ23Mkn3agCBQUTMk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFC9MeZ23Mkn3agCBQUTMk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap to reflect progress toward v0.2.0 release, including updated status for frontend and backend features, post-release hardening items, and recent test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->