### PR TITLE
daily log 2026-06-17

### DIFF
--- a/daily_log/2026-06-17.md
+++ b/daily_log/2026-06-17.md
@@ -1,0 +1,79 @@
+# Cx Daily Log — 2026-06-17
+
+## Snapshot
+
+If-expression lowering landed on submain today (tracker D2.1), the first real feature commit since the JIT memory-safety gate closed. The `lower.rs` stub that was `unsupported!("If")` is now a fully working two-branch value-producing lowering path that shares merge machinery with the existing when-expression infrastructure. Parity climbed from 192/94/0 to 199/87/0, converting 7 fixtures. Main remains untouched — submain is now 15 commits ahead and carries 286 matrix fixtures at 0 failures.
+
+## Landed today
+
+- **CONFIRMED — `a42f001` on submain:** `feat(ir): lower if-expressions via shared branch-value merge (tracker D2.1)`. This is the day's real work. The commit:
+  - Extracted the per-arm body-value lowering from `lower_when_expr` into a shared free function `lower_branch_value()` that handles leading statements via the void path, trailing ExprStmt as the branch value, and Jump to merge with `ensure_type_match`. The `when`-expr closure is now a thin wrapper delegating to it — emitted IR is byte-identical for all 12 existing when-exercising fixtures.
+  - Added `lower_if_expr()`: lowers the condition, emits `Branch(cond, then_block, else_block)`, each branch produces a value via `lower_branch_value` into one merge block parameter. Else-if chains are nested If nodes in `else_body`, handled by recursion. Decision block is sealed first (seal-order rule).
+  - Fixed a latent Numeric-placeholder bug in both `lower_if_expr` and `lower_when_expr`: bare integer literals in branch tails type the expression as the unresolved `Numeric` placeholder — `lower_type(Numeric)` errored. Both now resolve Numeric to the target's default integer width (I64 on 64-bit), the same rule `lower_binary` uses.
+  - Converted 7 fixtures from SKIP to PASS (the 6 target if-expr fixtures plus `t59_when_value`, a clean side-effect of the Numeric fix in `lower_when_expr`). Zero PARITY_FAIL.
+  - Updated `bench/bench_if_expr.cx` to run on both backends; first JIT baseline recorded in `BASELINE.md` — interp median 817ms vs JIT median 19ms on 700k iterations.
+  - Gates all green: cargo test 243/0, --features jit 418/0, matrix 286/0, parity 199/87/0, clippy 0 errors.
+  - Files changed: `src/ir/lower.rs` (+160/-63), `bench/bench_if_expr.cx` (+6/-6), `bench/BASELINE.md` (+12/-1).
+
+- **CONFIRMED — `70bcd29` on origin/site:** Backfill blog post for 2026-05-18 dev log. Automated content, not developer work.
+
+- **CONFIRMED — `aef30f5` on origin/daily-log-2026-06-16:** Yesterday's daily log and roadmap update. Still open as an unmerged PR.
+
+No merge commits in the last 24 hours. No reverts detected.
+
+## In progress / uncommitted work
+
+Nothing to report. The working tree on the current checkout (main) is clean — no modified files, staged changes, or untracked files.
+
+The substantive in-progress context is that submain's 15-commit integration gap with main continues to grow. The D2.1 commit today adds to the body of work (CR#1-4 range-check fixes, D1.0-D1.2a audit and refactors, Gate-1a/1b0/1b/2a/2b arithmetic and memory safety, and now D2.1 if-expression lowering) that is fully tested but not yet merged to main.
+
+## Decisions and direction
+
+The D2.1 commit represents a concrete architectural decision: **if-expressions and when-expressions share the same merge machinery**. Rather than implementing if-expression lowering as a separate code path, the commit extracted `lower_branch_value()` as a shared free function and made `lower_when_expr` delegate to it. This means the two control-flow value-producing constructs in Cx emit structurally identical IR for their branch bodies, and any future fix to one automatically applies to the other.
+
+The Numeric-placeholder fix is also notable — it surfaced as a latent bug in `lower_when_expr` that was only exposed because the D2.1 test fixture `t_return_if_when_in_range` contains both an if-expr and a when-expr with bare integer literal arms. Fixing the bug in both places simultaneously prevented a PARITY_FAIL that would have appeared if only `lower_if_expr` had the fix.
+
+The commit message explicitly defers two items: #026 unknown-condition lowering (unknown values SKIP at `lower_value` before reaching any if) and #044-B (unknown-arm path). These wait for the step that lowers unknown values generally.
+
+## Roadmap updates
+
+Updated `docment/ROADMAP.md`:
+- **Checked off:** `when` block lowering under Phase 11 — the when-expr path was already working and D2.1 confirms the when stmt/expr pattern emission is unified and stable.
+- **Updated:** Phase 15 parity numbers to 199/87/0 across 286 fixtures (submain).
+- **Added:** D2.1 if-expression lowering note under Working Notes for 2026-06-17.
+- **Updated:** Last-updated date to 2026-06-17.
+
+No new roadmap tasks added — the existing items (DotAccess in compound forms, Phase 8 Round 2, Phase 12) already cover the obvious next steps.
+
+## What's next
+
+**Yesterday's predictions vs. reality:**
+1. "Merge submain to main" — DID NOT HAPPEN. Gap grew from 14 to 15 commits.
+2. "Resume Phase 11 — when block lowering and DotAccess" — PARTIALLY CONFIRMED. D2.1 is closely related — if-expression lowering is the natural next step after when-expression lowering was unified in D1.2a. The `when` block lowering item in the roadmap is now effectively done (stmt + expr both lower), though DotAccess in compound forms remains open.
+3. "Phase 8 Round 2 — str/strref layout" — DID NOT HAPPEN.
+4. "Merge daily-log PR backlog" — DID NOT HAPPEN. Backlog is now 11 open PRs.
+
+**Likely next moves based on current state:**
+1. **DotAccess in compound forms** — the last unchecked Phase 11 item. With if-expression lowering done, this is the natural next surface area reduction target.
+2. **Merge submain to main.** 15 commits, all stable, zero regressions. This has been predicted for multiple days and keeps not happening.
+3. **Unknown value lowering.** The D2.1 commit explicitly defers #026 and #044-B pending this. It would unlock the remaining SKIP fixtures that involve unknown-valued conditions.
+4. **Phase 8 Round 2 — str/strref layout.** Still unchecked. Would unblock `bench_str_concat` JIT and the read/input builtins.
+
+---
+
+**Matrix (main):** 230 PASS / 0 FAIL out of 230 total — unchanged from yesterday.
+**Matrix (submain, per commit gates):** 286 PASS / 0 FAIL out of 286 total.
+**Parity (submain):** 199 PASS / 87 SKIP / 0 PARITY_FAIL (up from 192/94/0 yesterday).
+
+**Reverts:** None detected.
+
+**Evidence sources:**
+- `git log --all --since="24 hours ago"` — 3 commits (1 developer, 2 automated)
+- `git log origin/main..origin/submain` — 15 unmerged commits
+- `git show a42f001` — full commit message and diff for D2.1
+- `git diff 51e4e24..a42f001 -- src/ir/lower.rs` — 223-line diff confirming the implementation
+- `git show a42f001:bench/bench_if_expr.cx` — bench program contents
+- `git show a42f001:bench/BASELINE.md` — JIT baseline results
+- `run_matrix.sh` — 230/0 on main
+- Yesterday's daily log (origin/daily-log-2026-06-16) — continuity check
+- `git status` — clean working tree on main

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-05-18
+Last updated: 2026-06-17
 
 This file is a concise synthesis of the project's roadmap state. Detailed roadmaps live at:
 - Frontend: `docs/frontend/ROADMAP.md` (v5.0)
@@ -55,7 +55,7 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
   - [x] Range structured error (CX-19)
   - [x] MethodCall structured error (CX-21)
   - [x] Method call actual lowering (0ab7e9b — synthesis-and-recurse via Call arm)
-  - [ ] `when` block lowering or structured rejection
+  - [x] `when` block lowering (D1.2a unified stmt/expr emission; D2.1 shared branch-value merge)
   - [ ] DotAccess in compound forms
 - [ ] Phase 8 Round 2 — str/strref layout, Handle<T>, TBool calling convention
 
@@ -66,7 +66,7 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 - [ ] Phase 12 — Differential harness (parity classification CX-69, loop fixtures CX-68, determinism tests CX-55 merged; CX-228 adds t159–t177 parity fixtures; more in flight)
 - [ ] Phase 9 — Runtime intrinsics boundary (assert/assert_eq lowered natively via CX-48; print/println/printn/read/input still pending)
 - [ ] Phase 14 — First executable Cranelift slice (CX-52 float comparison, CX-53 void return, CX-54 debug-trace gating merged)
-- [ ] Phase 15 — Cranelift JIT 0.1 target (CX-74 exit-code propagation merged; print arg widening 08fa2f9; literal-width narrowing complete across 5 operator sites; CX-57/58/60/63/64/66 instruction coverage in flight; 110 PASS / 72 SKIP / 0 PARITY_FAIL across 182 fixtures)
+- [ ] Phase 15 — Cranelift JIT 0.1 target (CX-74 exit-code propagation merged; print arg widening 08fa2f9; literal-width narrowing complete across 5 operator sites; CX-57/58/60/63/64/66 instruction coverage in flight; if-expression lowering D2.1 landed; 199 PASS / 87 SKIP / 0 PARITY_FAIL across 286 fixtures on submain)
 
 ### Post-0.1
 - [ ] Cranelift AOT (Phase 16)
@@ -92,6 +92,8 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 ---
 
 ## Working Notes
+
+**2026-06-17:** D2.1 if-expression lowering landed on submain (`a42f001`). Shared `lower_branch_value()` extracted from when-expr, reused for if-expr. Parity 199/87/0 across 286. 15 commits ahead of main.
 
 **2026-05-18:** PR #268 merged `train/backend-determinism` → submain (host_boundary expansion, IR lowering fixes, 23 new parity fixtures including CX-228 t159–t177). CX-233 implements while-in loop source-to-IR lowering on `stokowski/CX-233` (branch-local, not yet merged) — WhileLoop parity moves to 8/0. Submain 171 commits ahead of main.
 


### PR DESCRIPTION
Automated daily log and roadmap update.

## Summary
- Daily dev log for 2026-06-17 covering D2.1 if-expression lowering on submain
- ROADMAP.md updated: checked off `when` block lowering, updated Phase 15 parity numbers to 199/87/0 across 286 fixtures, added working notes for 2026-06-17

## Changes
- `daily_log/2026-06-17.md` — new daily log
- `docment/ROADMAP.md` — conservative updates reflecting landed work

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3WQ8WsxDA6ZSbTK7CwWg4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap with current development progress and milestones
  * Documented completion of when block lowering with improved statement/expression emission
  * Added latest JIT testing progress metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->