### PR TITLE
daily log 2026-06-19

### DIFF
--- a/daily_log/2026-06-19.md
+++ b/daily_log/2026-06-19.md
@@ -1,0 +1,85 @@
+# Cx Daily Log — 2026-06-19
+
+## Snapshot
+
+Tag-only enum lowering landed on submain — the D2.2 milestone. `src/ir/lower.rs` gained 72 lines across four sites: type erasure (Enum → I8), value construction (EnumVariant → ConstInt of variant_id), pattern matching in `when` arms (tag compare + branch, reusing D1.2a machinery), and EnumDef no-op (like StructDef). Six enum fixtures converted from SKIP to PASS, moving parity from 199/87/0 to 205/81/0 across 286 fixtures. This also completes the `when` block lowering item in Phase 11 — stmt/expr emission (D1.2a), if-expression merge (D2.1), and now enum construct+match (D2.2) are all done. Submain is 16 commits ahead of main with zero regressions.
+
+## Landed today
+
+- **CONFIRMED** — `d12d161` on submain: `feat(ir): lower tag-only enums (construct + match via variant_id) (tracker D2.2)`. The commit modifies `src/ir/lower.rs` (+72/−12 lines) at four sites:
+  1. `lower_type(Enum)` → `IrType::I8` — tag-only enums erase to their u8 tag width, no enum IR type needed.
+  2. `lower_value(EnumVariant)` → `ConstInt(I8, variant_id)` — constructing an enum value is just emitting the tag constant.
+  3. `emit_when_arm_match(EnumVariant)` → ConstInt + Compare(Eq) + Branch — matching mirrors the Literal arm, reusing D1.2a's pattern emission helper.
+  4. `SemanticStmt::EnumDef` → no-op at both top-level and lower_stmt — enum declarations carry no runtime data.
+
+  The variant_id is the globally-monotonic declaration-order tag from `fresh_enum_variant()`, shared between construct and match sites. This means the scrutinee's tag and the pattern's tag compare equal for the same variant by construction.
+
+  Per the commit message, fixtures verified directly:
+  - t22_enum_basic, t27_enum_grouped, t28_super_group: interp == jit
+  - t_enum_param, t_enum_return, t_enum_state_machine: jit == .expected_output
+
+  Parity moved from 199/87/0 to 205/81/0 — exactly +6 PASS (the 6 enum fixtures). The 7th candidate (t47_edge_mix) stays SKIP because it also uses unknown values (`?`), which are deferred to a separate D2.x path.
+
+  Gates reported: cargo test 243/0, --features jit 418/0, matrix 286/0, parity 205/81/0, clippy clean.
+
+- No merge commits in the last 24 hours. The D2.2 commit is branch-local on submain, not yet integrated to main.
+
+## In progress / uncommitted work
+
+Nothing to report. The working tree on the current checkout (detached HEAD at main) is clean — no modified files, no staged changes, no untracked files.
+
+The `find` scan of `src/` and `docment/` shows many files with recent modification times, but these are checkout artifacts from the clone, not uncommitted work. No `.claude/worktrees/` activity detected.
+
+## Decisions and direction
+
+The D2.2 commit makes an explicit architectural choice: tag-only enums erase entirely to I8 constants. There is no enum IR type, no enum table, no runtime representation beyond the tag value. The variant_id is a program-global monotonic counter, which means the ceiling is 256 total enum variants across the entire program (u8). The commit message documents this as "fine for 0.3's small enums; a spec footnote if enums grow."
+
+This is a deliberate simplification: exhaustiveness is enforced at semantic time (the frontend's required `_` catchall in #027), so the IR doesn't need an exhaustiveness check or trap path. Value-producing enum-match routes through D2.1's `lower_branch_value` — the if-expression merge machinery handles it automatically.
+
+The D2.2 commit also clarifies that t47_edge_mix is not a pure enum fixture but an enum+unknown hybrid. This means unknown-value lowering (the deferred D2.x path) is the actual blocker for that fixture, not enum support.
+
+## Roadmap updates
+
+Updated `docment/ROADMAP.md`:
+
+- **Checked off:** `when` block lowering in Phase 11 — now complete across D1.2a (stmt/expr unification), D2.1 (if-expression merge), and D2.2 (enum construct+match).
+- **Added to post-release hardening:** CR#1-4 range-check fixes and Gate-1a/1b0/1b/2a/2b JIT arithmetic safety gates (all confirmed on submain from prior commits).
+- **Updated Phase 15 parity numbers:** 205/81/0 across 286 fixtures (up from stale 110/72/0 across 182).
+- **Updated matrix count:** 230/230 on main (was 182/182).
+- **Added working note** for 2026-06-19 documenting D2.2 landing and current state.
+- **Updated last-updated date** to 2026-06-19.
+
+No new roadmap tasks added — the existing items (DotAccess in compound forms, Phase 8 Round 2, unknown-value lowering) already cover the natural next steps.
+
+## What's next
+
+**Yesterday's predictions vs. reality:**
+1. "DotAccess in compound forms" — did not happen. Still the last unchecked Phase 11 sub-item.
+2. "Merge submain to main (15 commits)" — did not happen. Gap grew to 16 commits with D2.2.
+3. "Unknown value lowering" — did not happen. D2.2 commit explicitly notes this as the blocker for t47_edge_mix.
+4. "Daily-log PR backlog" — no change. Still 20+ open daily-log PRs unmerged.
+
+**Likely next moves:**
+1. **DotAccess in compound forms** — last unchecked item in Phase 11. With `when` block lowering complete, this is the natural surface area target.
+2. **Unknown-value lowering** — the D2.x deferred path. Would unlock t47_edge_mix and other fixtures that combine known constructs with `?` values. Explicitly called out in D2.2's commit notes.
+3. **Merge submain to main.** 16 commits, all stable, zero regressions. This gap has been growing since June 5 (last submain merge was PR #295).
+4. **Phase 8 Round 2** — str/strref layout, Handle<T>, TBool calling convention. Blocked behind Phase 11 completion.
+
+---
+
+**Matrix (main):** 230 PASS / 0 FAIL out of 230 total — unchanged from yesterday.
+**Matrix (submain, per commit gates):** 286 PASS / 0 FAIL out of 286 total.
+**Parity (submain):** 205 PASS / 81 SKIP / 0 PARITY_FAIL.
+
+**Reverts:** None detected in the 24-hour window.
+
+**Evidence sources used:**
+- `git log --all --since="24 hours ago"` — 2 commits (D2.2 on submain, automated daily log on daily-log-2026-06-18)
+- `git show d12d161` — full diff of D2.2 commit (+72/−12 in lower.rs)
+- `git log origin/main..origin/submain` — 16 unmerged commits
+- `git status` — clean working tree
+- `git diff` / `git diff --cached` — no changes
+- `find src/ -mtime -1` / `find docment/ -mtime -1` — filesystem scan
+- `run_matrix.sh` — 230/0 on main
+- Yesterday's daily log (origin/daily-log-2026-06-18) — continuity check
+- `docment/ROADMAP.md` — roadmap state before update

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-05-18
+Last updated: 2026-06-19
 
 This file is a concise synthesis of the project's roadmap state. Detailed roadmaps live at:
 - Frontend: `docs/frontend/ROADMAP.md` (v5.0)
@@ -10,7 +10,7 @@ This file is a concise synthesis of the project's roadmap state. Detailed roadma
 
 ## Frontend — v0.1.0 Released
 
-All 9 hard blockers resolved. 182/182 matrix tests passing. 8/8 examples passing.
+All 9 hard blockers resolved. 230/230 matrix tests passing (main). 8/8 examples passing.
 
 **Status:** v0.1.0 released (tagged at 9fc0d24). No known soundness holes. Syntax frozen.
 
@@ -21,6 +21,8 @@ All 9 hard blockers resolved. 182/182 matrix tests passing. 8/8 examples passing
 
 **Post-release hardening (on submain):**
 - [x] Composite literal type-checking — struct field presence/type/unknown-field validation, array element type checking (8169d33)
+- [x] CR#1-4 range-check fixes — generic type args, array elements, return values, if/when branch tails (b8e92fb..cbba042)
+- [x] Gate-1a/1b0/1b/2a/2b — JIT arithmetic safety (INT_MIN/-1, div-zero trap, host-exit, width-narrowing, array bounds-check)
 
 ---
 
@@ -55,7 +57,7 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
   - [x] Range structured error (CX-19)
   - [x] MethodCall structured error (CX-21)
   - [x] Method call actual lowering (0ab7e9b — synthesis-and-recurse via Call arm)
-  - [ ] `when` block lowering or structured rejection
+  - [x] `when` block lowering — unified stmt/expr emission (D1.2a), if-expression shared branch-value merge (D2.1), tag-only enum construct+match (D2.2)
   - [ ] DotAccess in compound forms
 - [ ] Phase 8 Round 2 — str/strref layout, Handle<T>, TBool calling convention
 
@@ -66,7 +68,7 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 - [ ] Phase 12 — Differential harness (parity classification CX-69, loop fixtures CX-68, determinism tests CX-55 merged; CX-228 adds t159–t177 parity fixtures; more in flight)
 - [ ] Phase 9 — Runtime intrinsics boundary (assert/assert_eq lowered natively via CX-48; print/println/printn/read/input still pending)
 - [ ] Phase 14 — First executable Cranelift slice (CX-52 float comparison, CX-53 void return, CX-54 debug-trace gating merged)
-- [ ] Phase 15 — Cranelift JIT 0.1 target (CX-74 exit-code propagation merged; print arg widening 08fa2f9; literal-width narrowing complete across 5 operator sites; CX-57/58/60/63/64/66 instruction coverage in flight; 110 PASS / 72 SKIP / 0 PARITY_FAIL across 182 fixtures)
+- [ ] Phase 15 — Cranelift JIT 0.1 target (CX-74 exit-code propagation merged; print arg widening 08fa2f9; literal-width narrowing complete across 5 operator sites; CX-57/58/60/63/64/66 instruction coverage in flight; 205 PASS / 81 SKIP / 0 PARITY_FAIL across 286 fixtures on submain)
 
 ### Post-0.1
 - [ ] Cranelift AOT (Phase 16)
@@ -92,6 +94,8 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 ---
 
 ## Working Notes
+
+**2026-06-19:** D2.2 enum lowering landed on submain (d12d161). Tag-only enums now construct and match via variant_id — 4 sites in lower.rs. Parity: 205/81/0 across 286 fixtures. Submain 16 commits ahead of main. `when` block lowering checked off in Phase 11.
 
 **2026-05-18:** PR #268 merged `train/backend-determinism` → submain (host_boundary expansion, IR lowering fixes, 23 new parity fixtures including CX-228 t159–t177). CX-233 implements while-in loop source-to-IR lowering on `stokowski/CX-233` (branch-local, not yet merged) — WhileLoop parity moves to 8/0. Submain 171 commits ahead of main.
 


### PR DESCRIPTION
Automated daily log and roadmap update.

## Summary
- Daily dev log for 2026-06-19: D2.2 tag-only enum lowering landed on submain (d12d161)
- Roadmap updated: `when` block lowering checked off in Phase 11, parity numbers updated to 205/81/0, post-release hardening items added
- Matrix: 230/0 on main, 286/0 on submain

---
_Generated by [Claude Code](https://claude.ai/code/session_0156MYThhwCuVFQu8GyaSUTe)_