### PR TITLE
daily log 2026-06-28

### DIFF
--- a/daily_log/2026-06-28.md
+++ b/daily_log/2026-06-28.md
@@ -1,0 +1,83 @@
+# Cx Daily Log — 2026-06-28
+
+## Snapshot
+
+Labeled break/continue shipped end-to-end today. Two commits on submain took this from zero to complete: the first added frontend parsing and semantic validation with reject-mode guards on both backends, and the second replaced those guards with real execution on both the interpreter and the JIT. The feature touches the lexer, AST, parser, semantic analyser, IR lowering, and runtime — a full vertical slice through the compiler. A site blog post covering yesterday's Result<T> work also landed. No merge to main; submain is now 26 commits ahead.
+
+## Landed today
+
+- **CONFIRMED** — `f94c6a5` (submain, 2026-06-27 20:41 EDT): **Labeled breaks — frontend parsing + semantic validation.** A new `Label` token in the lexer uses the Rust-style `'ident` syntax (apostrophe + identifier, no closing quote). Logos longest-match ordering ensures `'x'` stays a char literal (3 chars) while `'outer` (2+ chars, no closing quote) lexes as a label. The AST gains an optional label on every loop form (while/for/while-in/loop) and on break/continue. The semantic analyser adds a loop-label scope stack: `break 'L` with no enclosing `'L` loop is rejected, and duplicate labels on overlapping nested loops are rejected. Two new expected-fail fixtures pin these rejections (`t_break_missing_label_reject`, `t_dup_label_reject`). A char literal guard fixture (`t_char_literal_guard`) pins the lexer seam. The execution backends received minimal guards: the interp raises a clean error for labeled jumps, and the JIT SKIPs them. 13 files changed, +208/-39 lines. Gates held: matrix 290/0, parity 231/59/0.
+
+- **CONFIRMED** — `0f56f1e` (submain, 2026-06-28 10:39 EDT): **Labeled breaks — backend execution on interp + JIT.** The temporary refusals from commit (a) are replaced with real execution. In the interpreter, `BreakSignal` and `ContinueSignal` now carry an `Option<label>`. Each loop catches a signal when the label is `None` (innermost, unchanged behavior) or matches its own label; otherwise it re-raises, walking outward to the named loop. In the JIT, `LoopContext` gains a label field and the previously-single context becomes a stack. `break 'L` / `continue 'L` walk the stack via `find_target_loop` to Jump to the named loop's exit or header block, gathering that context's bindings from the live SSA environment. Unlabeled jumps take the top of stack, byte-identical to before. Two new discriminating fixtures: `t_labeled_break_outer` (break from inner loop exits outer — an unlabeled break would loop forever) and `t_labeled_continue_outer` (continue on outer re-iterates it). 10 files changed, +171/-80 lines. Gates: matrix 292/0, parity 233/59/0.
+
+- **CONFIRMED** — `07bef03` (site branch, 2026-06-27 22:42 EDT): **Site blog post for 2026-06-27.** A 35-line MDX post covering the Result<T> packed-i128 representation, the `?` operator lowering, and the design rationale for the memory round-trip over arithmetic packing. Blog-only; no compiler changes.
+
+- **CONFIRMED** — All three commits are branch-local. The two labeled-breaks commits are on submain (not merged to main). The blog post is on the site branch. No merge activity in the 24-hour window. No merge commits detected.
+
+## In progress / uncommitted work
+
+Nothing to report. The working tree is clean. HEAD is detached at main (`2a2e1b2`). No staged, unstaged, or untracked files. The prior daily log mentioned uncommitted example-suite rewrites, but those are not present in this clone.
+
+## Decisions and direction
+
+The labeled break/continue implementation makes several deliberate design choices visible in the commit messages and diffs:
+
+**Lexer token ordering.** The `Label` token regex (`'[_\p{L}][_\p{L}\p{N}]*`) is placed after `LiteralChar` in the logos enum. This relies on logos longest-match: `'x'` (3 chars) beats the 2-char label prefix `'x`, while escape sequences like `'\n'` have a backslash after the quote so they can't match the label regex. The `t_char_literal_guard` fixture explicitly pins this invariant.
+
+**Two-commit split.** Commit (a) lands the frontend with reject-mode guards on the backends. This ensures that a program with labeled breaks parses and validates correctly but doesn't silently mis-break the innermost loop — the interp raises a clear error and the JIT SKIPs. All 11 existing loop fixtures remain unchanged. Commit (b) then replaces the guards with real execution. This separation means the parser/semantic work could be reviewed and tested independently of the backend changes.
+
+**JIT loop-context stack.** The `Option<&LoopContext>` parameter becomes `&[LoopContext]`, threaded through the entire statement-lowering call chain. `find_target_loop` walks the stack in reverse for labeled jumps and takes `.last()` for unlabeled jumps, preserving exact backward compatibility for all existing loop code.
+
+## Roadmap updates
+
+**Checked off:**
+- Labeled break/continue (added as new Phase 11 sub-item, marked complete)
+- Result<T> construct + print (D2.4a, added as Phase 11 sub-item, marked complete)
+- `?`/Try operator on Result (D2.4b, added as Phase 11 sub-item, marked complete)
+- Phase 10 description updated to include labeled break/continue
+
+**Updated numbers:**
+- Phase 15 parity updated from 110/72/0 (182 fixtures) to 233/59/0 (292 fixtures on submain), 230/0 on main
+
+**Added working note:** 2026-06-28 entry documenting today's labeled breaks work, submain state (26 ahead), and current matrix/parity counts.
+
+**Left unchanged:**
+- `when` block lowering (still incomplete)
+- DotAccess in compound forms (still incomplete)
+- Phase 8 Round 2 (still incomplete)
+- All post-0.1 items
+
+**New tasks added:** None. The natural next steps (merge submain to main, dynamic strings, DotAccess) are already covered by existing items.
+
+## What's next
+
+**Yesterday's predictions vs. reality:**
+1. "D2.4c — Result equality routing" — did not happen. The labeled breaks feature took priority instead.
+2. "Commit the example rewrite" — did not happen. No example changes visible.
+3. "Dynamic strings (R6)" — did not happen.
+4. "Merge submain to main" — did not happen. Submain grew from 24 to 26 commits ahead.
+
+None of yesterday's predicted next steps matched today's actual work. The pivot to labeled breaks was not predicted by any recent daily log. It makes sense as a feature that builds on the existing loop lowering infrastructure (Phase 10) and extends control flow before moving to the next type-system frontier.
+
+**Likely next moves:**
+1. **Merge submain to main.** Now 26 commits ahead with zero regressions. The gap since the last merge (PR #295) is approaching 30 days. Every daily log for the past two weeks has flagged this.
+2. **`when` block lowering or structured rejection.** One of the two remaining unchecked Phase 11 items. The labeled breaks work touched `semantic.rs` and `lower.rs` extensively, making `when` lowering the natural next surface-area item.
+3. **DotAccess in compound forms.** The other remaining Phase 11 item. Has been predicted repeatedly but not started.
+4. **Dynamic strings (R6).** Still the next qualitative frontier requiring allocation infrastructure.
+
+---
+
+**Matrix (main):** 230 PASS / 0 FAIL out of 230 total — unchanged from yesterday.
+**Parity (submain, per 0f56f1e):** 233 PASS / 59 SKIP / 0 PARITY_FAIL across 292 fixtures.
+**No reverts detected** in the 24-hour window.
+**No merge commits** in the 24-hour window.
+
+**Evidence sources used:**
+- `git log --all --since="24 hours ago"` — 3 developer commits (labeled-breaks a/b on submain, site blog post), 1 automated daily-log commit
+- `git show` on f94c6a5 and 0f56f1e — full diff review (+208/-39 and +171/-80 lines)
+- `git diff origin/main..origin/submain --stat` — 161 files changed, +3449/-1354 lines, 26 commits ahead
+- `git status` / `git diff` — clean working tree, no uncommitted work
+- `run_matrix.sh` — 230/0 on main
+- Yesterday's daily log (origin/daily-log-2026-06-27-v2) — continuity check
+- `docment/ROADMAP.md` — updated with labeled breaks, Result items, parity numbers
+- `find src/ -newer docment/ROADMAP.md` — confirmed recently modified files align with commit evidence

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-05-18
+Last updated: 2026-06-28
 
 This file is a concise synthesis of the project's roadmap state. Detailed roadmaps live at:
 - Frontend: `docs/frontend/ROADMAP.md` (v5.0)
@@ -38,7 +38,7 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 - [x] Phase 0.5 — Backend trait interface (&IrModule)
 - [x] Phase 7 — IR pretty printer and diagnostics
 - [x] Phase 6 — Function call lowering (direct calls, arity/type validation)
-- [x] Phase 10 — Loop lowering (while, for, break, continue)
+- [x] Phase 10 — Loop lowering (while, for, break, continue, labeled break/continue)
 - [x] Phase 8 Round 1 — ABI (scalars, structs, arrays, enums, calling convention)
 
 ### Active
@@ -55,6 +55,9 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
   - [x] Range structured error (CX-19)
   - [x] MethodCall structured error (CX-21)
   - [x] Method call actual lowering (0ab7e9b — synthesis-and-recurse via Call arm)
+  - [x] Labeled break/continue — frontend parsing, semantic validation, interp + JIT execution (f94c6a5, 0f56f1e)
+  - [x] Result<T> construct + print — packed-i128 representation (71c4160)
+  - [x] `?`/Try operator on Result (a32a242)
   - [ ] `when` block lowering or structured rejection
   - [ ] DotAccess in compound forms
 - [ ] Phase 8 Round 2 — str/strref layout, Handle<T>, TBool calling convention
@@ -66,7 +69,7 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 - [ ] Phase 12 — Differential harness (parity classification CX-69, loop fixtures CX-68, determinism tests CX-55 merged; CX-228 adds t159–t177 parity fixtures; more in flight)
 - [ ] Phase 9 — Runtime intrinsics boundary (assert/assert_eq lowered natively via CX-48; print/println/printn/read/input still pending)
 - [ ] Phase 14 — First executable Cranelift slice (CX-52 float comparison, CX-53 void return, CX-54 debug-trace gating merged)
-- [ ] Phase 15 — Cranelift JIT 0.1 target (CX-74 exit-code propagation merged; print arg widening 08fa2f9; literal-width narrowing complete across 5 operator sites; CX-57/58/60/63/64/66 instruction coverage in flight; 110 PASS / 72 SKIP / 0 PARITY_FAIL across 182 fixtures)
+- [ ] Phase 15 — Cranelift JIT 0.1 target (CX-74 exit-code propagation merged; print arg widening 08fa2f9; literal-width narrowing complete across 5 operator sites; CX-57/58/60/63/64/66 instruction coverage in flight; 233 PASS / 59 SKIP / 0 PARITY_FAIL across 292 fixtures on submain; 230 PASS / 0 FAIL on main)
 
 ### Post-0.1
 - [ ] Cranelift AOT (Phase 16)
@@ -92,6 +95,8 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 ---
 
 ## Working Notes
+
+**2026-06-28:** Labeled break/continue landed end-to-end on submain in two commits (f94c6a5 frontend + 0f56f1e backend). New Label token in lexer, loop-label scope stack in semantic analyser, signal-based interp execution, loop-context-stack JIT lowering. 4 new test fixtures (2 reject, 2 execution). Also a site blog post for 2026-06-27 covering the Result<T> work. Submain 26 commits ahead of main. Matrix 230/0 on main; parity 233/59/0 on submain (292 fixtures).
 
 **2026-05-18:** PR #268 merged `train/backend-determinism` → submain (host_boundary expansion, IR lowering fixes, 23 new parity fixtures including CX-228 t159–t177). CX-233 implements while-in loop source-to-IR lowering on `stokowski/CX-233` (branch-local, not yet merged) — WhileLoop parity moves to 8/0. Submain 171 commits ahead of main.
 


### PR DESCRIPTION
Automated daily log and roadmap update.

## Summary
- Daily development log for 2026-06-28 covering labeled break/continue landing on submain (f94c6a5, 0f56f1e) and site blog post (07bef03)
- ROADMAP.md updated: labeled breaks, Result<T>, and ?/Try operator checked off under Phase 11; parity numbers updated to 233/59/0 (292 fixtures); new working note added

## Matrix
230 PASS / 0 FAIL on main (unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThoonoKrZQyNYpHqnRDWwT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project roadmap with the latest status and progress markers.
  * Expanded completed and active items to reflect support progress for labeled `break`/`continue`, `Result<T>` construction and printing, and the `?`/Try operator.
  * Refreshed coverage and test-status figures in the landed section.
  * Added a new progress note summarizing recent end-to-end landing work and updated parity counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->