### PR TITLE
daily log 2026-07-03

### DIFF
--- a/daily_log/2026-07-03.md
+++ b/daily_log/2026-07-03.md
@@ -1,0 +1,113 @@
+# Cx Daily Log — 2026-07-03
+
+## Snapshot
+
+The big merge finally happened. PR #326 integrated submain into main and was tagged v0.3.0 — 26 commits, 148 files changed, 3,441 insertions. This closes a 28-day integration gap that every daily log since mid-June has flagged. After the merge, a single post-audit test was added to submain (Handle+array composition). Matrix stands at 292 PASS / 0 FAIL, up from 230/230 at v0.2.0.
+
+## Landed today
+
+**CONFIRMED** — PR #326 merged submain → main, tagged as v0.3.0 (commit `1654f5b`, merged 2026-07-03T22:23:07Z). This is a release-grade integration of 26 non-merge commits across 148 files. The 26 commits were authored over the preceding weeks on submain; the merge itself landed today. Key content:
+
+- **Correctness hardening (CR#1–4):** Range-check array elements in struct fields and call args (CR#1–2), range-check return values at declared width (CR#3), range-check literals in if/when branch tails (CR#4).
+- **Safety gates:** INT_MIN/-1 division overflow guard (Gate-1a), division/modulo by zero clean trap (Gate-1b), clean trap routing through JIT host exit (Gate-1b0), stored-value width narrowing (Gate-2a), array indexing bounds-check trap (Gate-2b).
+- **IR lowering sprint:**
+  - If-expression lowering via shared branch-value merge (D2.1)
+  - Tag-only enum lowering — construct + match via variant_id (D2.2)
+  - Bool/TBool lowering — unknown construct, condition trap, three-valued Kleene logic (D2.x-A1/A2)
+  - Static string representation — literal construct, cx_print_str, constant-fold len(), literal concat, content equality, print-time interpolation + cx_print_f64 (D2.3a–d)
+  - Result<T> — packed-i128 representation, construct, print (D2.4a); `?`/Try operator on Result (D2.4b)
+- **Labeled loops:** Frontend parse for `'label: loop` syntax + dual-backend execution of labeled break/continue (f94c6a5, 0f56f1e). Duplicate and missing label rejection at compile time.
+- **Refactoring:** Unified when stmt/expr pattern emission (D1.2a). Unified integer-width facts into one frontend-owned table (D1.1). Array element type carry-through in index reads (D1.1b).
+- **Testing:** Pinned JIT divergences for div-zero, INT_MIN, and dual-bool (D1.0). Benchmark suite with wall-time performance baseline (perf-rider).
+
+**CONFIRMED** — Post-merge commit `6e9e41e` on submain (2026-07-03T23:25:27Z): added `t_handle_array_no_drop.cx` test, pinning Handle+array composition as correct behavior. This retracted "Finding 2" from a post-0.3 audit — the original audit used invalid `arr[i]` syntax; Cx's real array-index syntax is `arr:[i]`. With correct syntax, a Handle in an array literal reads back its value correctly. This commit is NOT yet on main.
+
+**CONFIRMED** — v0.3.0 tag created at `1654f5b`.
+
+No reverts detected in the 24-hour window.
+
+## In progress / uncommitted work
+
+Working tree on main is clean — no modified files, no staged changes, no untracked files.
+
+Submain has one commit ahead of main (`6e9e41e`), the Handle+array test. This is minor — a single test file and expected output — with no conflict risk.
+
+17+ daily-log PRs (#308–#324 and counting) remain open against main. Each carries incremental ROADMAP updates that forked from the pre-v0.3.0 main. Now that main has jumped forward via PR #326, these may have merge conflicts in ROADMAP.md.
+
+## Decisions and direction
+
+The v0.3.0 release locks several language decisions documented in the PR body:
+
+- **Labeled loops:** `'label: loop` with colon-terminated labels, duplicate labels in overlapping scope reject at compile time, break/continue to a missing label rejects at compile time.
+- **`?` operator:** Valid only inside a Result-returning function.
+- **Interpreter vs JIT boundary:** The Cranelift JIT lowers a subset; the interpreter (`--backend=interp`, default) is the complete reference. Features like `exit()`, nested functions, `const`, block scopes, `while in`, macros, generics, cross-module imports, Handle, dynamic strings, and `char` are interpreter-only for now.
+- **Benchmarking methodology:** Absolute wall-time ms are not cross-session comparable (thermal/load variance). Regression detection is within-session relative: candidate vs prior binary back-to-back.
+
+A post-0.3 audit was initiated (the Handle+array test is evidence of this), suggesting active quality review of the newly-integrated codebase.
+
+## Roadmap updates
+
+ROADMAP.md was updated from its stale 2026-05-18 state to reflect v0.3.0 reality.
+
+**Checked off:**
+- Phase 11: `when` block lowering (D1.2a unification)
+- Phase 11: if-expression lowering (D2.1)
+- Phase 11: tag-only enum lowering (D2.2)
+- Phase 11: bool/TBool lowering (D2.x-A1/A2)
+- Phase 11: static string lowering (D2.3a–d)
+- Phase 11: Result<T> + `?`/Try operator (D2.4a/b)
+- Phase 11: labeled break/continue
+- Phase 10: labeled break/continue added to description
+- Post-release hardening: CR#1–4, integer-width facts, array element type carry-through
+- JIT Host Boundary: clean trap routing (Gate-1b0)
+
+**Updated descriptions:**
+- Phase 9: noted cx_print_str/cx_print_f64 additions
+- Phase 14: added Gate-1a/1b/2a/2b safety items
+- Phase 15: parity updated from 110/72/0 across 182 → 233/59/0 across 292; benchmark baseline noted
+- Phase 8 Round 2: noted static strings partially cover this
+- Section header: "Landed (integrated to main via v0.3.0 merge)"
+- Frontend header: v0.1.0 → v0.3.0, matrix 182/182 → 292/292
+
+**Left unchanged:**
+- DotAccess in compound forms — still incomplete
+- Phase 8 Round 2 — partially covered but not complete (Handle<T>, strref, TBool calling convention still pending)
+- Phase 12, 14, 15 — significant progress but not fully complete
+- All post-0.1 and Language Features items
+
+**Added:** Working note for 2026-07-03 documenting the merge.
+
+**No new tasks added** — the natural next steps (DotAccess, Phase 8 Round 2, remaining Phase 9 intrinsics) are already tracked.
+
+## What's next
+
+**Yesterday's predictions vs. reality:**
+Yesterday's log predicted: (1) merge submain to main, (2) merge daily-log PRs, (3) DotAccess, (4) Phase 8 Round 2. The submain merge happened — the single most flagged item for weeks. The others did not.
+
+**Likely next moves:**
+1. **Close the post-0.3 audit.** The Handle+array retraction suggests an active quality review. If other findings exist, they need resolution before new feature work.
+2. **Merge the Handle+array test to main.** One commit on submain, trivially clean.
+3. **DotAccess in compound forms.** The last unchecked Phase 11 item.
+4. **Phase 8 Round 2.** Handle<T>, strref layout, TBool calling convention — the next major backend milestone. Static strings are partially in place from D2.3, so this may be partially underway.
+5. **Clean up daily-log PR backlog.** 17+ open PRs with stale ROADMAP forks. Now that main has jumped to v0.3.0, most will conflict.
+
+---
+
+**Matrix (main):** 292 PASS / 0 FAIL out of 292 total — up from 230/230 at v0.2.0.
+**Parity (v0.3.0):** 233 PASS / 59 SKIP / 0 PARITY_FAIL across 292 fixtures.
+**No reverts detected** in the 24-hour window.
+**One merge commit** — PR #326, the v0.3.0 release.
+
+**Evidence sources used:**
+- `git log --all --since="24 hours ago"` — 1 developer commit (6e9e41e on submain), 1 merge (PR #326), 1 automated (daily log)
+- `git log 5981121..1654f5b --no-merges` — 26 commits brought by PR #326
+- `git show 1654f5b --stat` — 148 files, 3441 insertions, 478 deletions
+- GitHub PR #326 metadata — created and merged 2026-07-03, body documents v0.3.0 release notes
+- `git show 6e9e41e` — post-merge Handle+array test commit
+- `git rev-list origin/submain --not origin/main` — 1 unmerged commit
+- `git status` / `git diff` — clean working tree, no uncommitted work
+- `run_matrix.sh` — 292/0 on main
+- `git show origin/daily-log-2026-07-02:daily_log/2026-07-02.md` — yesterday's log for continuity
+- `docment/ROADMAP.md` — updated from stale 2026-05-18 state
+- `bench/BASELINE.md` — confirmed benchmark suite content
+- `git tag` — v0.1.0, v0.2.0, v0.3.0 confirmed

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-05-18
+Last updated: 2026-07-03
 
 This file is a concise synthesis of the project's roadmap state. Detailed roadmaps live at:
 - Frontend: `docs/frontend/ROADMAP.md` (v5.0)
@@ -8,19 +8,22 @@ This file is a concise synthesis of the project's roadmap state. Detailed roadma
 
 ---
 
-## Frontend — v0.1.0 Released
+## Frontend — v0.3.0 Released
 
-All 9 hard blockers resolved. 182/182 matrix tests passing. 8/8 examples passing.
+All 9 hard blockers resolved. 292/292 matrix tests passing. 8/8 examples passing.
 
-**Status:** v0.1.0 released (tagged at 9fc0d24). No known soundness holes. Syntax frozen.
+**Status:** v0.3.0 released (tagged at 1654f5b, PR #326). No known soundness holes. Syntax frozen.
 
 **Known limitations (documented, not blocking):**
 - String arena grows monotonically (interpreter-only)
 - No strref constructor syntax
 - Expression statements still require semicolons
 
-**Post-release hardening (on submain):**
+**Post-release hardening (landed on main via v0.3.0):**
 - [x] Composite literal type-checking — struct field presence/type/unknown-field validation, array element type checking (8169d33)
+- [x] Range-check hardening — array elements in struct fields/call args (CR#1–2), return values at declared width (CR#3), branch tails in if/when (CR#4)
+- [x] Integer-width facts refactoring — unified width table in frontend (D1.1)
+- [x] Array element type carry-through in index reads (D1.1b)
 
 ---
 
@@ -38,7 +41,7 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 - [x] Phase 0.5 — Backend trait interface (&IrModule)
 - [x] Phase 7 — IR pretty printer and diagnostics
 - [x] Phase 6 — Function call lowering (direct calls, arity/type validation)
-- [x] Phase 10 — Loop lowering (while, for, break, continue)
+- [x] Phase 10 — Loop lowering (while, for, break, continue, labeled break/continue)
 - [x] Phase 8 Round 1 — ABI (scalars, structs, arrays, enums, calling convention)
 
 ### Active
@@ -55,18 +58,24 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
   - [x] Range structured error (CX-19)
   - [x] MethodCall structured error (CX-21)
   - [x] Method call actual lowering (0ab7e9b — synthesis-and-recurse via Call arm)
-  - [ ] `when` block lowering or structured rejection
+  - [x] `when` block lowering — when stmt/expr pattern emission unified (D1.2a)
+  - [x] If-expression lowering via branch-value merge (D2.1)
+  - [x] Tag-only enum lowering — construct + match via variant_id (D2.2)
+  - [x] Bool/TBool lowering — unknown construct, condition trap, Kleene logic (D2.x-A1/A2)
+  - [x] Static string lowering — repr, literal construct, len fold, concat, equality, interpolation (D2.3a–d)
+  - [x] Result<T> lowering — packed-i128 repr, construct, print, `?`/Try operator (D2.4a/b)
+  - [x] Labeled break/continue — frontend parse + dual backend execution (f94c6a5, 0f56f1e)
   - [ ] DotAccess in compound forms
-- [ ] Phase 8 Round 2 — str/strref layout, Handle<T>, TBool calling convention
+- [ ] Phase 8 Round 2 — str/strref layout, Handle<T>, TBool calling convention (static strings partially covered by D2.3)
 
-### Landed (integrated to main via v0.1.0 merge)
+### Landed (integrated to main via v0.3.0 merge)
 
 - [x] Phase 13 — Cranelift lowering skeleton (CX-22)
-- [x] JIT Host Boundary (CX-24: process ownership, exit codes, output capture)
-- [ ] Phase 12 — Differential harness (parity classification CX-69, loop fixtures CX-68, determinism tests CX-55 merged; CX-228 adds t159–t177 parity fixtures; more in flight)
-- [ ] Phase 9 — Runtime intrinsics boundary (assert/assert_eq lowered natively via CX-48; print/println/printn/read/input still pending)
-- [ ] Phase 14 — First executable Cranelift slice (CX-52 float comparison, CX-53 void return, CX-54 debug-trace gating merged)
-- [ ] Phase 15 — Cranelift JIT 0.1 target (CX-74 exit-code propagation merged; print arg widening 08fa2f9; literal-width narrowing complete across 5 operator sites; CX-57/58/60/63/64/66 instruction coverage in flight; 110 PASS / 72 SKIP / 0 PARITY_FAIL across 182 fixtures)
+- [x] JIT Host Boundary (CX-24: process ownership, exit codes, output capture, clean trap routing via Gate-1b0)
+- [ ] Phase 12 — Differential harness (parity classification CX-69, loop fixtures CX-68, determinism tests CX-55 merged; CX-228 adds t159–t177 parity fixtures; D1.0 pins div-zero/INT_MIN/dual-bool divergences)
+- [ ] Phase 9 — Runtime intrinsics boundary (assert/assert_eq lowered natively via CX-48; cx_print_str/cx_print_f64 added via D2.3b/D2.3d; read/input still pending)
+- [ ] Phase 14 — First executable Cranelift slice (CX-52 float comparison, CX-53 void return, CX-54 debug-trace gating merged; Gate-1a INT_MIN/-1 guard, Gate-1b div/mod-by-zero trap, Gate-2a width narrowing, Gate-2b array bounds checking)
+- [ ] Phase 15 — Cranelift JIT 0.1 target (233 PASS / 59 SKIP / 0 PARITY_FAIL across 292 fixtures; benchmark baseline added via perf-rider)
 
 ### Post-0.1
 - [ ] Cranelift AOT (Phase 16)
@@ -92,6 +101,8 @@ The backend pipeline converts verified SemanticProgram → IR → machine output
 ---
 
 ## Working Notes
+
+**2026-07-03:** PR #326 merged submain → main, tagged v0.3.0. 26 commits, 148 files changed, 3441 insertions, 478 deletions. Major additions: if-expressions, tag-only enums + when matching, three-state bool, static strings (len/concat/equality/interpolation), Result<T> + `?` operator, labeled break/continue, safety gates (INT_MIN/-1, div/mod-by-zero, array bounds, width narrowing), range-check hardening (CR#1–4), benchmark suite. Matrix: 292/292 on main. Post-merge: submain has 1 additional commit (6e9e41e — Handle+array composition test, retracted audit finding).
 
 **2026-05-18:** PR #268 merged `train/backend-determinism` → submain (host_boundary expansion, IR lowering fixes, 23 new parity fixtures including CX-228 t159–t177). CX-233 implements while-in loop source-to-IR lowering on `stokowski/CX-233` (branch-local, not yet merged) — WhileLoop parity moves to 8/0. Submain 171 commits ahead of main.
 


### PR DESCRIPTION
Automated daily log and roadmap update.

- Daily log for 2026-07-03: documents v0.3.0 release (PR #326 merged submain → main), post-merge Handle+array audit test on submain, matrix 292/0.
- ROADMAP.md updated from stale 2026-05-18 state to reflect v0.3.0 landing: Phase 11 items checked off (when lowering, if-expressions, enums, TBool, strings, Result, labeled break/continue), parity numbers updated (233/59/0 across 292), safety gates and hardening noted, working note added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7AdPTzNqSP9nJgiFni9Tg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap snapshot to reflect the latest release and current project status.
  * Added newly completed frontend hardening items and marked a backend loop-lowering phase as complete.
  * Expanded the list of integrated improvements and refreshed the in-progress work and notes section with the latest merge summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->