### PR TITLE
daily log 2026-07-10

### DIFF
--- a/daily_log/2026-07-10.md
+++ b/daily_log/2026-07-10.md
@@ -1,0 +1,90 @@
+# Cx Daily Log — 2026-07-10
+
+## Snapshot
+
+The v0.3.1 release landed. After five consecutive days where every daily log predicted the submain-to-main merge and it didn't happen, it happened tonight — tagged `3430e4e` at 21:34 EDT on July 9. The release shipped more than originally scoped: Handle core (D2.5), pattern matching first slices (as-v binding and guard clauses), the f64 comparison fix, and the known-issues tracker all merged in a single integration event. The verification matrix jumped from 292 to 321 tests. Submain and main are now at parity.
+
+## Landed today
+
+**v0.3.1 release merge** (`3430e4e`, merge of submain into main) — CONFIRMED. This is the integration event, not new code — the underlying commits span July 3-9 on submain. What it brought to main:
+
+- **Scalar Handle core (D2.5a/b/c)** — `Handle<T>` construct (`f654416`), read/val (`37b71f2`), and drop (`3ea986d`) for scalar payloads. Packed i64 representation with slot+generation fields, host-side registry, generational safety and double-drop non-aliasing empirically proven on both backends. Nine new test fixtures. CONFIRMED.
+
+- **Pattern matching first slices** — `as v` named binding on `when` enum arms (`e7bf778`) and guard clauses on `when` arms (`d4a7373`). Guard clauses reuse the existing unknown-seam and continuation-block machinery. Twenty new test fixtures covering positive behavior, scope-leak rejection, and static/runtime unknown rejection. CONFIRMED.
+
+- **Interpreter float comparison fix** (`c5e8e22`) — four missing `Value::Float` match arms for `<`, `>`, `<=`, `>=` in `src/runtime/ops.rs`. The JIT was already correct; the interpreter was the lagging side, which is the reverse of the usual pattern. Five new f64 comparison fixtures. CONFIRMED.
+
+- **Known-issues tracker** (`cff4e2d` initial, `aadfce6` correction) — `docs/known_issues.md` now catalogs five interpreter/JIT divergences: #1 f64 comparison (fixed), #2 bare builtin in trailing position, #3 explicit return + trailing expression, #4 `print(enum)` divergence, #5 bare I128 printing. CONFIRMED.
+
+- **Roadmap reconciliation** (`10ac2ed`) — corrected version sequence from 0.3.1 through 1.0+, marked 0.1-era docs as historical, fixed stale NullPoint status. CONFIRMED.
+
+- **Handle+array composition test** (`6e9e41e`) — retracted a false finding (original audit used invalid `arr[i]` syntax; real syntax is `arr:[i]`). CONFIRMED.
+
+**Known-issues correction** (`aadfce6`, authored July 9 20:59 EDT) — CONFIRMED. The only new author commit in the 24-hour window. Corrected the understanding of issues #4 and #5:
+
+- Issue #4 (`print(enum)` divergence): sized and confirmed to require building new static infrastructure (per-enum tag-to-name string tables), not a dispatch-arm fix. Deliberately not attempted.
+
+- Issue #5 (bare I128 printing): the previous "fully scoped, ready to build" framing was wrong. A fix was attempted — new `IrType::I128` arm, new `cx_print_i128` host callback — built with zero compile errors, then segfaulted (exit 139) on the JIT reproducer. Root cause: passing a raw `i128` by value across the Cranelift-to-Rust host boundary has never been exercised before. The `enable_llvm_abi_extensions` flag covers internal Cranelift value passing, not external host calls. The fix was reverted in full via `git checkout --` (not a revert commit).
+
+**Submain sync-up merge** (`caab3e1`) — CONFIRMED. After the v0.3.1 merge, submain merged origin/main back into itself. Submain and main are now at parity.
+
+**Site dev log** (`d5944c8`, on the site branch) — CONFIRMED. Yesterday's dev log blog post was published to the site.
+
+## In progress / uncommitted work
+
+Nothing to report. The working tree is clean — no staged, unstaged, or untracked files. HEAD is detached at `3430e4e` (v0.3.1).
+
+## Decisions and direction
+
+The v0.3.1 release absorbed the originally-planned 0.3.2 scope (pattern matching first slices). This was not an explicit decision recorded in any design doc — it's the natural result of the work having already landed on submain before the release happened. The version sequence has been renumbered accordingly: old 0.3.2 becomes part of 0.3.1 (shipped), old 0.3.3 becomes 0.3.2, old 0.3.4 becomes 0.3.3.
+
+The known-issues #5 correction is a significant direction finding: the I128 host-boundary ABI issue means I128 printing can't be fixed with a simple match-arm addition. The suggested direction (pass-by-pointer mirroring the `cx_print_str` pattern) is materially more complex and needs its own sizing pass. This affects any future work that needs to pass wide scalars across the JIT host boundary.
+
+## Roadmap updates
+
+**Checked off:**
+- v0.3.1 added to the Shipped section with full scope documentation
+- "Post-0.3.0" section updated — Handle core is no longer "not yet in a tagged release"
+- Version sequence renumbered to reflect pattern matching landing in 0.3.1
+
+**Left in progress:**
+- gene + phen design pass (now 0.3.2)
+- gene + phen implementation, operator overloading, generics v3 (now 0.3.3)
+- All Future Design Work items unchanged
+
+**New items added:**
+- Working note recording the v0.3.1 release, matrix jump, known-issues #5 ABI finding, and version renumbering
+
+## What's next
+
+**Yesterday's predictions vs. reality:**
+1. "Merge submain -> main" — CONFIRMED after five consecutive misses
+2. "Fix known issue #5 (I128 printing)" — Attempted and failed (segfault); corrected in docs
+3. "Merge at least one daily log PR" — Unknown, not confirmed from evidence
+4. "New feature work on submain" — Did not happen
+
+**Likely next moves:**
+1. **Known issue #5 sizing pass** — the I128 host-boundary ABI issue needs a proper scoping of the pass-by-pointer approach before a second attempt. This is the most concretely documented next technical task.
+2. **Known issue #4 design work** — building per-enum tag-to-name string tables for JIT print parity. Sized but not started.
+3. **Known issue #2 or #3** — the bare-builtin trailing-position and explicit-return-plus-trailing-expression bugs remain open and unsized.
+4. **gene + phen design pass** (0.3.2) — next on the version sequence, but no evidence of imminent work.
+5. **Daily log PR merges** — multiple daily log PRs remain open and unmerged.
+
+---
+
+**Matrix:** 321 PASS / 0 FAIL (up from 292 yesterday — 29 new fixtures from v0.3.1).
+**No revert commits detected.** (Issue #5 fix was reverted via working-tree checkout, not a commit.)
+**No uncommitted work.**
+
+**Evidence sources used:**
+- `git log --all --since="24 hours ago"` — 5 commits total (1 non-merge author commit, 2 merge commits, 1 daily log, 1 site blog post)
+- `git show 3430e4e --stat` — v0.3.1 merge: 72 files changed, 1536 insertions, 153 deletions
+- `git log 1654f5b..3430e4e` — 10 non-merge commits in the release
+- `git diff aadfce6~1..aadfce6` — known_issues.md correction: 63 insertions, 7 deletions
+- `git log origin/main..origin/submain` — empty (parity confirmed)
+- `git status`, `git diff`, `git ls-files --others` — clean working tree confirmed
+- `git show origin/daily-log-2026-07-09:daily_log/2026-07-09.md` — yesterday's log for continuity
+- `docment/ROADMAP.md` — read and updated
+- `docs/known_issues.md` — read in full, 237 lines
+- `run_matrix.sh` — 321/0 confirmed
+- `find` over `src/`, `docment/`, `.claude/worktrees/` — no meaningful in-progress work beyond committed state

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-07-04
+Last updated: 2026-07-10
 
 This file is a concise synthesis of the project's roadmap state. Detailed
 0.1-era phase logs live at:
@@ -33,31 +33,35 @@ release notes match the approved changelog. Landed:
 **Post-release hardening (on submain):**
 - [x] Composite literal type-checking — struct field presence/type/unknown-field validation, array element type checking (8169d33)
 
+**0.3.1** — tagged `3430e4e`, 2026-07-09. Merged submain → main. Shipped more
+than originally scoped for 0.3.1 (Handle core only) — absorbed the 0.3.2
+pattern-matching scope as well. Landed:
+- Scalar Handle core (D2.5a/b/c): `Handle<T>` construct, read, drop for scalar
+  `T` (`{I8, I16, I32, I64, Bool}`), generational safety and double-drop
+  non-aliasing empirically proven on both backends
+- Pattern matching first slices: `as v` named binding on `when` enum arms,
+  guard clauses on `when` arms
+- Interpreter float comparison fix (`<`, `>`, `<=`, `>=`) — reference-side bug,
+  JIT was already correct
+- Known-issues tracker (`docs/known_issues.md`) — 5 cataloged interpreter/JIT
+  divergences, 1 fixed, 4 open
+- Roadmap reconciliation — corrected version sequence, stale items fixed
+- 29 new verification matrix fixtures (292 → 321)
+
 ---
 
-## Post-0.3.0 — landed on `submain`, not yet in a tagged release
-
-**Scalar Handle core (D2.5a/b/c)** — landed `3ea986d`. `Handle<T>` for scalar
-`T` (`{I8, I16, I32, I64, Bool}`): construct, read, drop, all checked against
-the interpreter. Generational safety and double-drop non-aliasing empirically
-proven on both backends (interpreter and Cranelift JIT).
-
----
-
-The sequence below reflects the project's current stated direction as of
-2026-07-04. No prior committed roadmap file contained a 0.2+ version
-sequence — this is the first time it's being formally recorded, not a
-correction to an existing plan.
+The sequence below reflects the project's current stated direction, updated
+2026-07-10 after the 0.3.1 release absorbed the originally-planned 0.3.2
+pattern-matching scope.
 
 ## Corrected Version Sequence
 
-- **0.3.1** — Scalar Handle core (D2.5). *(Already landed on `submain` at
-  `3ea986d` — this slot documents where it lands once tagged, not new work.)*
-- **0.3.2** — Pattern matching (named binding `as v`, guard clauses) — shifted
-  from 0.3.1.
-- **0.3.3** — gene + phen design pass — shifted from 0.3.2.
-- **0.3.4** — gene + phen implementation, operator overloading, generics v3
-  (type bounds) — shifted from 0.3.3.
+- **0.3.1** — Scalar Handle core (D2.5) + pattern matching first slices.
+  *(Tagged `3430e4e`, 2026-07-09.)*
+- **0.3.2** — gene + phen design pass — shifted forward after pattern matching
+  landed in 0.3.1.
+- **0.3.3** — gene + phen implementation, operator overloading, generics v3
+  (type bounds).
 - **0.4** — Stdlib v1, Cranelift AOT / Ricey v0, LLVM AOT, bootstrapping
   begins/completes, math layer. *(Unchanged from prior sequencing.)*
 - **1.0** — First stable release.
@@ -100,6 +104,8 @@ on nested Handles. Needs its own scoping audit before scheduling.
 ---
 
 ## Working Notes
+
+**2026-07-10:** v0.3.1 tagged (`3430e4e`), merging submain → main. Absorbed the originally-planned 0.3.2 pattern-matching scope. Matrix jumped 292 → 321 (29 new fixtures from Handle core, pattern matching, and f64 comparison work). Known-issues #4/#5 corrected — #5 (I128 printing) attempted and segfaulted; root cause is an I128 host-boundary ABI mismatch, not a missing match arm. Submain at parity with main post-merge. Version sequence renumbered: old 0.3.2 → 0.3.1 (shipped), old 0.3.3 → 0.3.2, old 0.3.4 → 0.3.3.
 
 **2026-05-18:** PR #268 merged `train/backend-determinism` → submain (host_boundary expansion, IR lowering fixes, 23 new parity fixtures including CX-228 t159–t177). CX-233 implements while-in loop source-to-IR lowering on `stokowski/CX-233` (branch-local, not yet merged) — WhileLoop parity moves to 8/0. Submain 171 commits ahead of main.
 


### PR DESCRIPTION
Automated daily log and roadmap update.

- Daily log for 2026-07-10 documenting the v0.3.1 release
- Roadmap updated: v0.3.1 marked as shipped, version sequence renumbered (pattern matching absorbed into 0.3.1), working note added
- Matrix: 321 PASS / 0 FAIL (up from 292)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USp2375sRvSxAvtjXRAvFo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to reflect the project status as of July 10, 2026.
  * Clarified the corrected release sequence for versions 0.3.1–0.3.3.
  * Added working notes covering recent scope changes, testing progress, known-issue corrections, and version renumbering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->