### PR TITLE
ci: call run_matrix.sh directly (verification for audit finding 3.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,57 +36,7 @@ jobs:
         run: cargo build
 
       - name: Run verification matrix
-        run: |
-          set +e
-          PASS=0
-          FAIL=0
-          ERRORS=()
-
-          for f in src/tests/verification_matrix/t*.cx; do
-            test_name=$(basename "$f")
-            expected_fail=false
-
-            if [ -f "${f}.expected_fail" ]; then
-              expected_fail=true
-            fi
-
-            cargo run --quiet -- "$f" > /dev/null 2>&1
-            exit_code=$?
-
-            if $expected_fail; then
-              if [ $exit_code -ne 0 ]; then
-                echo "PASS (expected fail): $test_name"
-                PASS=$((PASS + 1))
-              else
-                echo "FAIL (should have errored): $test_name"
-                FAIL=$((FAIL + 1))
-                ERRORS+=("$test_name")
-              fi
-            else
-              if [ $exit_code -eq 0 ]; then
-                echo "PASS: $test_name"
-                PASS=$((PASS + 1))
-              else
-                echo "FAIL: $test_name"
-                output=$(cargo run --quiet -- "$f" 2>&1)
-                echo "  Output: $output"
-                FAIL=$((FAIL + 1))
-                ERRORS+=("$test_name")
-              fi
-            fi
-          done
-
-          echo ""
-          echo "Matrix: $PASS passed, $FAIL failed out of $((PASS + FAIL)) total"
-
-          if [ ${#ERRORS[@]} -gt 0 ]; then
-            echo ""
-            echo "Failed tests:"
-            for e in "${ERRORS[@]}"; do
-              echo "  - $e"
-            done
-            exit 1
-          fi
+        run: bash src/tests/run_matrix.sh
 
   backend:
     name: Backend Build + Tests


### PR DESCRIPTION
## Summary
Throwaway verification PR for audit finding 3.4 — confirms the CI fix (replacing the inline matrix reimplementation with a direct call to `bash src/tests/run_matrix.sh`) actually runs live and reports the correct 336/0 result.

Will be closed without merging once CI confirms; the real commit lands directly on submain per this session's established workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automated verification matrix execution in the frontend build process.
  * Improved consistency by centralizing matrix test handling in a dedicated command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->