### PR TITLE
daily log 2026-08-23

### DIFF
--- a/daily_log/2026-08-23.md
+++ b/daily_log/2026-08-23.md
@@ -1,0 +1,91 @@
+# Cx Daily Log — 2026-08-23
+
+## Snapshot
+
+The five-day quiet streak broke hard. Three substantial commits landed on submain today, all within a two-hour window (17:01–18:58 EDT). The headline is **Model B**: Cx now has a formally stated value semantics for aggregates — plain assignment and parameter passing copy, the receiver is the declared exception. This closes the last silent backend divergence for arrays and structs. The test corpus jumped from 414 to 436 on submain, parity moved from 374/40/0 to 396/40/0, and every pre-existing fixture is byte-identical on both backends. Matrix on main holds at 414/0.
+
+## Landed today
+
+**1. Array and struct assignment copies** (`f291116`, 17:01) — CONFIRMED
+
+Fixed a silent backend divergence: `r: [3: t64] = a` bound `r` to `a`'s storage on the JIT while the interpreter copied the value. Both backends exited 0 with different answers — no existing fixture could observe the aliasing because none assigned one array variable to another and then mutated. The fix introduces `copy_if_memory_resident` in `src/ir/lower.rs`, which allocates fresh storage and copies through it at the single choke point every binding form funnels through. Array and struct literals are exempt (nothing else holds a pointer, so nothing to alias). Structs were fixed by the same change — they alias for the identical reason and `ret_slot_plan` already covers them.
+
+Five new test fixtures: `t_array_assign_is_copy`, `t_array_assign_copy_t8`, `t_array_assign_copy_reverse`, `t_array_assign_copy_reassign`, `t_array_assign_copy_from_call`. Corpus 424 to 429, parity 384/40/0 to 389/40/0.
+
+Deliberately NOT fixed: parameter passing still aliases, because the receiver for impl and phen methods is argument 0, and JIT method mutation depends on that aliasing. That's the setup for commit 2.
+
+**2. Model B — aggregates are values, the receiver is the declared exception** (`4fe3fd2`, 18:18) — CONFIRMED
+
+The big commit. Closes the last backend value-semantics divergence for aggregate parameters. A new `is_receiver` field on `SemanticParam` (`src/frontend/semantic_types.rs`) distinguishes receivers from ordinary parameters, set at the two construction sites: impl-block alias capture and phen-def receiver capture in `src/frontend/semantic.rs`. Lowering in `src/ir/lower.rs` now copies every aggregate parameter that does not carry `is_receiver`.
+
+The design decision: "skip argument 0" would have been wrong, not merely fragile, because `impl (p: Player, w: World)` makes both aliases receivers, and `t177_multi_alias_impl` depends on the second one writing back. The field has no default — a new receiver-producing path that doesn't set it is a compile error at all ten construction sites.
+
+Seven new test fixtures covering parameter array copy, struct copy, multi-aggregate receivers, mutation in branches and loops, and nested aggregates. Corpus 429 to 436. Parity 389/40/0 to 396/40/0 across 436 fixtures. SKIP set unchanged at 40.
+
+Cost: 2 ns/call to 7 ns/call for a 256-byte aggregate, ~36 GB/s, 9 ms over 1.8M calls.
+
+**3. Clippy baseline reconciliation and `.copy.free` deprecation candidate** (`d60e508`, 18:58) — CONFIRMED
+
+Corrected the v0.3.3 tag's recorded clippy count from 110/110 to 111/111 — the 110 was not reproducible; re-measured by building the tag in a worktree against clippy 0.1.96. No code change introduced a lint; the original number was simply wrong. Per-entry deltas in `docs/known_issues.md` are left as written to avoid falsifying the record.
+
+`.copy.free` is recorded in `known_issues.md` §27 as a deprecation candidate: with Model B in place, `.copy.free` has the same semantics as ordinary passing — no program can write code that distinguishes `f(x.copy.free)` from `f(x)`. Not removed yet; the ruling waits for the `.copy`/`.copy.free`/`copy_into` lowering blocker to be addressed.
+
+**4. Site blog post** (`c1d6c39` on `origin/site`, 22:43 Aug 22) — CONFIRMED
+
+Yesterday's dev log published to the project site as `src/content/blog/2026-08-22.mdx`.
+
+**Integration context:** No merge commits in the last 24 hours. All three development commits are on `origin/submain`, now 6 commits ahead of main (3 older + 3 from today). The `site` branch continues as a separate content track.
+
+## In progress / uncommitted work
+
+Nothing to report. The working tree on main is clean. All today's work is committed on submain.
+
+**Pending integration on submain (6 commits ahead of main):**
+- `65736b5` (Aug 16) — array returns via caller-allocated slot
+- `8ae8947` (Aug 16) — docs: correct §26's commit reference
+- `56983eb` (Aug 18) — expression receivers for operator dispatch
+- `f291116` (today) — array and struct assignment copies
+- `4fe3fd2` (today) — Model B: aggregates are values
+- `d60e508` (today) — clippy baseline reconciliation + `.copy.free` deprecation candidate
+
+## Decisions and direction
+
+Today established a significant language-level decision: **Cx aggregates have value semantics.** This is not a backend fix or a lowering gap — it's a deliberate semantic model choice, formally called "Model B" in the commit and in `docs/known_issues.md` §27.
+
+The key design points:
+- Plain assignment copies. `.copy` / `.copy.free` / `copy_into` are the explicit vocabulary; their existence presupposes plain assignment is not aliasing.
+- The receiver is the exception, and the exception is declared, not positional. `is_receiver` is a property of the parameter, not of argument position, because multi-alias `impl` blocks make more than one parameter a receiver.
+- `.copy.free` is now a confirmed no-op spelling under Model B. It's recorded as a deprecation candidate, but the decision to remove it is deferred until the parameter-kinds lowering blocker is addressed.
+
+The `docment/ROADMAP.md` on submain was updated to correct the clippy baseline, remove "array returns" from the remaining lowering blockers (fixed on Aug 16), and add the array-returns fix to the Post-0.3.3 section.
+
+## Roadmap updates
+
+Updates applied to `docment/ROADMAP.md` on the daily-log branch:
+
+- **Updated:** "Post-0.3.0" section header changed to "Post-0.3.3" to match the latest shipped tag.
+- **Added:** Array returns fix, expression receivers, array/struct assignment copies, and Model B to the Post-0.3.3 section as landed-on-submain work.
+- **Removed:** "array returns from methods" from the 0.4 remaining lowering blockers list (fixed on submain Aug 16).
+- **Corrected:** Clippy count from 110/110 to 111/111 at the v0.3.3 tag, with toolchain note.
+- **Corrected:** The `:` collision description to match the accurate shape (subsequent-line parse, not single-line mis-parse).
+- **Added:** Note that `.copy.free` is now a deprecation candidate under Model B.
+- **Updated:** "Last updated" date to 2026-08-23.
+
+## What's next
+
+**Yesterday's predictions vs. today:**
+1. "Merge submain to main" — did not happen, but submain got three major commits instead. The merge is now more valuable (6 commits, including value-semantics and copy-semantics work).
+2. "Next lowering blocker" — partially confirmed. Today's work is directly adjacent to the `.copy`/`.copy.free`/`copy_into` parameter-kinds blocker. Expression receivers (Aug 18) already closed one listed blocker.
+3. "Daily log PR backlog" — did not happen. Backlog continues to accumulate.
+
+**Most likely next moves:**
+1. **Merge submain to main.** Now 6 commits ahead with two substantial semantic/backend changes, tested and clean. The merge would formally close two 0.4 lowering blockers (array returns, expression receivers) and land the value-semantics model on main.
+2. **`.copy` / `.copy.free` / `copy_into` parameter kinds.** Model B makes this the natural next lowering blocker — the value model is settled, and `.copy.free` is already flagged as a deprecation candidate. The lowering work can now proceed with clear semantics.
+3. **Remaining lowering blockers.** After parameter kinds: nested function definitions, `while-in`, function-body `const`, `t128` printing, `char`, non-identifier string interpolation.
+
+---
+
+**Matrix:** 414 PASS / 0 FAIL on main (unchanged since 0.3.3 tag). Submain reports 436/436 in today's commits.
+**Submain divergence:** 6 commits ahead of main (was 3 yesterday).
+**Reverts:** None.
+**Evidence sources:** `git log --all --since="24 hours ago"` (4 commits: 3 on submain, 1 on site), `git show` on each commit, `git diff origin/main..origin/submain` on key files, `git status` (clean on main), `run_matrix.sh` (414/0), `find` scans on `src/` and `docment/` (many files newer than ROADMAP, all committed), yesterday's daily log from `origin/daily-log-2026-08-22-v2`, `docment/ROADMAP.md` on both main and submain.

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-08-16
+Last updated: 2026-08-23
 
 This file is a concise synthesis of the project's roadmap state. Detailed
 0.1-era phase logs live at:
@@ -54,14 +54,44 @@ release notes match the approved changelog. Landed:
   rather than by `run_matrix.sh` alone.
 
 Gate state at the tag: `cargo test` 250/0, `--features jit` 426/0, matrix
-414/414, parity **374 PASS / 40 SKIP / 0 PARITY_FAIL**, clippy 110/110 on both
-feature sets.
+414/414, parity **374 PASS / 40 SKIP / 0 PARITY_FAIL**, clippy **111/111** on
+both feature sets.
+
+*(Clippy corrected 2026-08-23 from the 110/110 originally recorded. Re-measured
+by building the v0.3.3 tag in a worktree: it reports 111, and its lint multiset
+is byte-identical to this HEAD's — same lints, same counts. Clippy counts are
+toolchain-dependent — this figure is clippy 0.1.96.)*
 
 ---
 
-## Post-0.3.0 — landed on `submain`, not yet in a tagged release
+## Post-0.3.3 — landed on `submain`, not yet in a tagged release
 
-**Scalar Handle core (D2.5a/b/c)** — landed `3ea986d`. `Handle<T>` for scalar
+**Array returns via the caller-allocated slot** — `docs/known_issues.md` §26.
+Free functions and impl methods returned a dangling frame pointer and silently
+produced wrong values. The guard that existed covered only phen methods. Fixed
+for all three dispatch paths.
+
+**Expression receivers for operator dispatch** — lifted the named-left-operand
+restriction so `(a + b) + c` works. `receiver_expr` on `SemanticExprKind::MethodCall`
+carries the temporary when the left operand is not a named variable.
+
+**Array and struct assignment copies** — `docs/known_issues.md` §27. Fixed a
+silent backend divergence where `r = a` for arrays/structs aliased on the JIT
+while the interpreter copied. `copy_if_memory_resident` in `src/ir/lower.rs`
+copies through fresh storage at the single choke point every binding form uses.
+
+**Model B — aggregates are values, the receiver is the declared exception** —
+`docs/known_issues.md` §27. All aggregate parameters now copy except declared
+receivers. `SemanticParam.is_receiver` distinguishes receivers from ordinary
+parameters, set at construction. `.copy.free` is now a confirmed no-op spelling
+under Model B and is recorded as a deprecation candidate.
+
+Corpus at submain HEAD: 436/436. Parity: 396 PASS / 40 SKIP / 0 PARITY_FAIL.
+
+---
+
+**Scalar Handle core (D2.5a/b/c)** — shipped in 0.3.1, tagged `3430e4e`; landed
+on `submain` at `3ea986d`. `Handle<T>` for scalar
 `T` (`{I8, I16, I32, I64, Bool}`): construct, read, drop, all checked against
 the interpreter. Generational safety and double-drop non-aliasing empirically
 proven on both backends (interpreter and Cranelift JIT).
@@ -92,13 +122,12 @@ remaining blockers folded into 0.4.
   **design gate** in parallel — see below. The design gate touches no code, so
   it runs alongside 0.4's implementation work rather than queuing behind it.
 
-  **Remaining lowering blockers** — array returns from methods, expression
-  receivers for operator dispatch, `.copy` / `.copy.free` / `copy_into`
-  parameter kinds, nested function definitions, `while-in`, function-body
+  **Remaining lowering blockers** — `.copy` / `.copy.free` / `copy_into`
+  parameter kinds (`.copy.free` is now a deprecation candidate under Model B),
+  nested function definitions, `while-in`, function-body
   `const`, `t128` printing, `char`, and non-identifier string interpolation.
-  Array returns and expression receivers were briefly carried as a prospective
-  0.3.4; they belong here, and inventing a version slot to hold them would
-  recreate the phantom-slot problem the roadmap reconciliation cleaned up. If a
+  Array returns and expression receivers, briefly carried as a prospective
+  0.3.4, are now fixed on submain. If a
   0.3.4 is ever needed, it gets created when something actually justifies it.
 - **0.5** — **Multidimensional arrays landed, or actively completing.**
 - **1.0** — First stable release.
@@ -131,8 +160,12 @@ things:
 - the **type**: `[3: t8]` — size, colon, element type
 - the **index operator**: `a:[2]` — colon *before* the bracket
 
-The colon-before-bracket indexing form was pinned deliberately: bare `a[2]`
-silently mis-parses. That constraint stands, and any multidimensional syntax has
+The colon-before-bracket indexing form was pinned deliberately. The precise
+shape it avoids: an expression followed by `[` on a subsequent line parses as
+two separate statements, because Cx has no statement terminator — `a` is an
+expression statement and `[2]` is an array literal, both discarded, exit 0, no
+error. (`a[2]` on one line is a clean parse error, not a silent mis-parse.)
+That constraint stands, and any multidimensional syntax has
 to live with a `:` that is already carrying two jobs. Nothing downstream can be
 locked until this is settled.
 


### PR DESCRIPTION
Automated daily log and roadmap update for 2026-08-23.

## Summary

- Daily development log capturing three substantial commits on submain: array/struct assignment copy fix, Model B (aggregates are values, receiver is the declared exception), and clippy baseline reconciliation with `.copy.free` deprecation candidate.
- Roadmap updated: Post-0.3.3 section expanded with landed-on-submain work, array returns and expression receivers removed from remaining lowering blockers (fixed), clippy count corrected, `:` collision description corrected.
- Matrix: 414 PASS / 0 FAIL on main. Submain reports 436/436.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSpfihf5dPhpoQ7vEADZUx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the project roadmap with the latest progress and timestamp.
  - Corrected v0.3.3 linting results and added measurement details.
  - Documented newly completed array, expression, aggregate-copy, Model B, and Scalar Handle work.
  - Updated corpus metrics and remaining v0.4 lowering blockers.
  - Clarified multidimensional-array syntax constraints and potential indexing misinterpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->