### PR TITLE
daily log 2026-08-25

### DIFF
--- a/daily_log/2026-08-25.md
+++ b/daily_log/2026-08-25.md
@@ -1,0 +1,88 @@
+# Cx Daily Log — 2026-08-25
+
+## Snapshot
+
+Two commits landed on submain in the last 24 hours, both targeting the same seam: assignment targets. The first unified the parser's assignment grammar so that a single `target := ident ('.' ident)? (':' '[' expr ']')*` production handles all write shapes — plain, field-rooted, indexed, chained — in every statement position. The second deleted `AssignTarget` entirely, widening `CompoundAssign` to carry an `Expr` target, which closes the last remaining parse gap for compound assignment at arbitrary depth. Together they moved the corpus from 444 to 453 and parity from 404 to 413, all on submain. Main holds at 414/0 on the matrix. No merges, no reverts, no uncommitted work.
+
+## Landed today
+
+**1. Unified assignment-target grammar** (`e943103`, submain, 19:35 Aug 24) — CONFIRMED
+
+The parser carried two near-identical productions: `index_assign` for indexed writes and `assign` for plain and field writes. The function body's statement list included `assign` and `index_compound_assign` but not `index_assign`, which is why `r:[0] = 9` inside a function body was a parse error while working at the top level. Field-rooted writes like `g.cells:[0] = 9` failed for the same reason — `index_assign` rooted at a bare identifier.
+
+Both collapsed into one production. The optional dot-field and repeated index suffixes are now in a single rule, so `x = v`, `x.f = v`, `x:[i] = v`, `x.f:[i] = v` and `x:[i]:[j] = v` share one grammar path. The duplicate `index_assign` production was deleted, the function body now folds the unified rule, and clippy dropped from 111 to 110 — one fewer clone on a Copy combinator.
+
+Downstream needed no widening. The semantic layer's `Expr::Index` assignment arm already called `analyze_expr` on its target. The JIT's `resolve_array_element_ptr` already lowered any Ptr-producing expression. Only the interpreter's `exec.rs` and `scope.rs` needed work: root descent now starts at a variable or one of its fields, sharing the existing index walk.
+
+Four new test fixtures: `t_place_body_write`, `t_place_field_rooted_write`, `t_place_field_rooted_single`, `t_place_three_deep_write`.
+
+Corpus 444 to 448. Parity 404/40/0 to 408/40/0. Clippy 111 to 110.
+
+**2. Delete AssignTarget — compound assignment carries a place** (`eb54b36`, submain, 20:17 Aug 24) — CONFIRMED
+
+`AssignTarget` was a three-variant enum of names (`Var`, `Field`, `Index`) introduced in March 2026 when the writable set was narrow. It could not describe `a:[i]:[j]` or `g.cells:[0]` and never reached either backend — the semantic layer already converted it to `SemanticLValue`, which is why its index arm had to reconstruct `Expr::Ident(arr_name)` just to analyse it.
+
+`CompoundAssign` now carries `target: Expr`, and both statements parse through the same target grammar. A new `resolve_place` method in `semantic.rs` is the single `Expr` to `SemanticLValue` conversion, shared by both `Assign` and `CompoundAssign`. The const and loop-variable guards fire through `assign_target_base_name`, which is now required rather than opportunistic.
+
+The JIT needed zero changes — all five new fixtures passed on Cranelift the moment the parser produced the wider tree. The interpreter did need a change: its compound arm still matched for a VarRef root with a single index. `resolve_index_place` in `exec.rs` now resolves root and index path once, and both statements share it.
+
+Single evaluation is structural: the JIT holds one SSA pointer named by both Load and Store; the interpreter holds one `(root, field, path)` used by both read and write. `t_place_compound_eval_once` discriminates against the expanded form by counting side-effect markers.
+
+New documentation: `docs/backend/cx_eval_order.md` extended with the compound-assignment single-resolution rule and the rule that a compound assignment does not see writes made by its own operand (confirmed on interpreter, JIT claim rests on instruction order since the program does not lower there yet).
+
+Five new test fixtures: `t_place_compound_chained`, `t_place_compound_eval_once`, `t_place_compound_field_rooted`, `t_place_compound_rank1`, `t_place_compound_three_deep`.
+
+Corpus 448 to 453. Parity 408/40/0 to 413/40/0. Clippy back to 110/110.
+
+**Integration context:** Both commits are on `origin/submain`, now 9 commits ahead of main. No merge activity in the last 24 hours.
+
+## In progress / uncommitted work
+
+Nothing to report. The working tree on main is clean. All work from the last 24 hours is committed on submain.
+
+**Pending integration on submain (9 commits ahead of main):**
+- `65736b5` (Aug 16) — array returns via caller-allocated slot
+- `8ae8947` (Aug 16) — docs: correct §26's commit reference
+- `56983eb` (Aug 18) — expression receivers for operator dispatch
+- `f291116` (Aug 23) — array and struct assignment copies
+- `4fe3fd2` (Aug 23) — Model B: aggregates are values
+- `d60e508` (Aug 23) — clippy baseline reconciliation + `.copy.free` deprecation candidate
+- `332a46a` (Aug 23) — Model A: contiguous multidimensional arrays
+- `e943103` (Aug 24) — unified assignment-target grammar
+- `eb54b36` (Aug 24) — delete AssignTarget, compound assignment carries a place
+
+## Decisions and direction
+
+The two commits together complete the assignment-target unification that Model A made visible as a gap. Before today, there were three representations of "the thing being written to": the grammar had `assign` and `index_assign` as separate productions, `CompoundAssign` carried `AssignTarget` (an enum of names that predated first-class arrays), and the semantic layer used `SemanticLValue`. Now there are two: the parser produces an `Expr` tree that is the same tree the reader builds for the same text, and `resolve_place` converts it to `SemanticLValue` once for both statement kinds.
+
+The compound-assignment single-evaluation rule is now documented and tested. The rule that `a:[f()]:[g()] += 1` evaluates each index once is structural in both backends — not a convention that could drift — and the consequence that a compound assignment does not see writes made by its own operand is stated explicitly in `docs/backend/cx_eval_order.md`.
+
+With this landing, the known-issues §28 "still a parse error" list is empty for the first time. Every write shape the runtime and IR support is now accepted by the grammar.
+
+## Roadmap updates
+
+The roadmap on submain already carries updates from the Model A/B work (Aug 23-24). For this daily-log branch, the following conservative edits are applied:
+
+- **Updated:** "Last updated" date to 2026-08-25.
+- **Removed:** "expression receivers for operator dispatch" from the 0.4 remaining lowering blockers list — landed on submain at `56983eb` (Aug 18), already present in submain's roadmap diff but not yet reflected in the daily-log branch copy.
+- No items checked off in "Shipped" — these commits are on submain, not tagged.
+- No new tasks added — the existing roadmap structure covers the remaining work.
+
+## What's next
+
+**Yesterday's predictions vs. today:**
+1. "Merge submain to main" — did not happen. Submain grew by two more commits (now 9 ahead).
+2. "Address the remaining write-side parse limitations" — this is exactly what happened. Both the body-position gap and the compound-assignment gap were closed.
+3. "`.copy` / `.copy.free` / `copy_into` parameter kinds" — did not happen.
+
+**Most likely next moves:**
+1. **Merge submain to main.** Now 9 commits ahead with five semantic/backend milestones (array returns, expression receivers, Model B, Model A, assignment-target unification), extensively tested. The merge would bring main from 414 to 453 tests.
+2. **`.copy` / `.copy.free` / `copy_into` parameter kinds.** With value semantics (Model B) and contiguous arrays (Model A) both landed and the assignment grammar unified, the parameter-kinds lowering blocker is the next natural target on the 0.4 list.
+3. **Remaining 0.4 lowering blockers.** Nested function definitions, `while-in`, function-body `const`, `t128` printing, `char`, non-identifier string interpolation — all still open.
+
+---
+
+**Matrix:** 414 PASS / 0 FAIL on main (unchanged from yesterday). Submain reports 453/453.
+**Submain divergence:** 9 commits ahead of main (was 7 yesterday).
+**Reverts:** None.
+**Evidence sources:** `git log --all --since="24 hours ago"` (3 commits: 2 work on submain, 1 daily-log), `git show e943103` and `git show eb54b36` (full diff inspection of parser, AST, semantic, exec, scope, eval_order doc, known_issues), `git diff origin/main...origin/submain` (96 files), `git status` (clean on main), `run_matrix.sh` (414/0), `find` scans on `src/` and `docment/` (no uncommitted changes newer than ROADMAP.md outside git-tracked files), yesterday's daily log from `origin/daily-log-2026-08-24`.

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-08-16
+Last updated: 2026-08-25
 
 This file is a concise synthesis of the project's roadmap state. Detailed
 0.1-era phase logs live at:
@@ -92,13 +92,13 @@ remaining blockers folded into 0.4.
   **design gate** in parallel — see below. The design gate touches no code, so
   it runs alongside 0.4's implementation work rather than queuing behind it.
 
-  **Remaining lowering blockers** — array returns from methods, expression
-  receivers for operator dispatch, `.copy` / `.copy.free` / `copy_into`
+  **Remaining lowering blockers** — `.copy` / `.copy.free` / `copy_into`
   parameter kinds, nested function definitions, `while-in`, function-body
   `const`, `t128` printing, `char`, and non-identifier string interpolation.
-  Array returns and expression receivers were briefly carried as a prospective
-  0.3.4; they belong here, and inventing a version slot to hold them would
-  recreate the phantom-slot problem the roadmap reconciliation cleaned up. If a
+  Array returns (fixed on submain Aug 16) and expression receivers (fixed on
+  submain Aug 18) were briefly carried as a prospective 0.3.4; they belong
+  here and are now closed. Inventing a version slot to hold them would have
+  recreated the phantom-slot problem the roadmap reconciliation cleaned up. If a
   0.3.4 is ever needed, it gets created when something actually justifies it.
 - **0.5** — **Multidimensional arrays landed, or actively completing.**
 - **1.0** — First stable release.


### PR DESCRIPTION
Automated daily log and roadmap update for 2026-08-25.

Two commits landed on submain: unified assignment-target grammar (e943103) and deletion of AssignTarget enum for compound assignment (eb54b36). Corpus 444→453, parity 404→413. Roadmap updated to reflect array returns and expression receivers as closed lowering blockers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLS88dzi52FQpzF9Q7mKy1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project roadmap with the latest status as of August 25, 2026.
  * Removed completed items from the remaining blockers list and clarified outstanding work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->