### PR TITLE
fix(ci): stale-base check measures against the PR's real base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,15 +70,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Check out the PR head, not the default merge commit. The merge
+          # commit already contains the base, so measuring the base from it
+          # always yields 0 and the gate silently becomes a no-op.
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check how far behind submain
+      - name: Check how far behind the PR base
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin submain
-          BEHIND=$(git rev-list --count HEAD..origin/submain)
-          echo "Branch is $BEHIND commits behind submain"
+          git fetch origin "$BASE_REF"
+          BEHIND=$(git rev-list --count "HEAD..origin/$BASE_REF")
+          echo "Branch is $BEHIND commits behind $BASE_REF"
           if [ "$BEHIND" -gt 20 ]; then
-            echo "STALE BASE: This branch is $BEHIND commits behind submain."
-            echo "Rebase onto submain before merging."
+            echo "STALE BASE: This branch is $BEHIND commits behind $BASE_REF."
+            echo "Rebase onto $BASE_REF before merging."
             exit 1
           fi
 


### PR DESCRIPTION
## What was wrong

`Stale Base Check` fetched `origin/submain` and measured `HEAD..origin/submain` on every PR — including the 93 open PRs that target `main`.

The base-ref mismatch is the obvious half. The subtler half: `actions/checkout@v4` gives a `pull_request` run the **merge commit**, which already contains the base. So the count was never branch staleness at all — it was *how far `submain` led `main` at run time*. That is a property of the repo, not of the PR.

Measured from the merge commit on #386:

```
behind-submain = 9    behind-main = 0
```

That `9` is exactly submain's current lead over main. The gate was reporting a repo-wide artifact and attributing it to individual PRs.

## The fix

Two halves, both required:

1. Measure against `github.base_ref` — the PR's actual base.
2. Check out the PR **head** (`github.event.pull_request.head.sha`). Without this, the merge commit already contains the base, the count reads `0` for every mergeable PR, and the gate passes vacuously. Fixing only the ref would have replaced a wrong gate with a dead one.

## This makes the gate stricter

Measured correctly from each PR head against its real base, **84 of 93 open PRs are genuinely stale** (>20 behind `main`) — versus 29 flagged by the broken check. The oldest are 167 commits behind.

That number is not being accommodated. The threshold stays at 20. The historical daily-log backlog is being cleared as a **one-time migration** — landing the log content directly with roadmap hunks stripped — rather than by loosening the gate to let it through. An honest gate is worth more than a green backlog.

## Verification

- YAML parses; job/step structure confirmed via `yaml.safe_load`.
- Behavior on this PR is itself the live test: it should report a real, small number against `main` — not `0`, and not the submain-lead artifact.