### PR TITLE
daily log 2026-08-31

### DIFF
--- a/daily_log/2026-08-31.md
+++ b/daily_log/2026-08-31.md
@@ -1,0 +1,62 @@
+# Cx Daily Log — 2026-08-31
+
+## Snapshot
+
+Rest day. No development commits by the project author in the last 24 hours, no uncommitted work, clean working tree. The matrix holds at 414/414 on main. Submain remains at 13 commits ahead with the `.copy` ABI work from yesterday still branch-local. Two automated commits landed — a daily log for Aug 30 (on its daily-log branch) and a site blog post for Aug 21 (on the site branch) — neither is compiler or language work.
+
+## Landed today
+
+Nothing to report. No code, language, or compiler commits by the project author in the last 24 hours.
+
+Two automated documentation commits exist in the 24-hour window:
+
+- `35eb8ba` on `daily-log-2026-08-30` (23:37 UTC, Aug 30) — daily log and roadmap working-note update for Aug 30. Authored by Claude. Not merged to main. — CONFIRMED
+- `9d848c7` on `site` (00:16 UTC, Aug 31) — blog post for the Aug 21 dev log. Authored by Claude. Not merged to main. — CONFIRMED
+
+Neither represents development work. Both are documentation artifacts from the daily-log and site-publishing pipelines.
+
+## In progress / uncommitted work
+
+Working tree on main is clean. No staged changes, no unstaged changes, no untracked files, no files modified on disk in the last 24 hours.
+
+**Submain state (unchanged from yesterday):** 13 commits ahead of main. The four `.copy` commits from yesterday remain branch-local:
+1. `5312b77` — roadmap re-freeze against the code
+2. `dd6be28` — back-merge main into submain
+3. `aa76b68` — `.copy` semantic settlement (Slice 1)
+4. `005df8c` — `.copy` ABI implementation (Slice 2)
+
+No new commits on submain today. The submain parity stood at 420 PASS / 39 SKIP / 0 PARITY_FAIL across 459 fixtures as of yesterday's close.
+
+**Unmerged daily-log branches:** daily-log-2026-08-27 through daily-log-2026-08-30 each carry one commit not on main. These are documentation-only and carry no merge risk, but the backlog continues to grow.
+
+## Decisions and direction
+
+Nothing to report. No design decisions, technical direction changes, or implementation choices were made today.
+
+## Roadmap updates
+
+No items checked off — no development work landed. No new tasks added — nothing in today's evidence justifies one.
+
+The ROADMAP.md on main (last updated 2026-08-16) was updated with a working note carrying forward the Aug 30 `.copy` work summary from the daily-log-2026-08-30 branch, which hasn't merged to main yet. The date was updated to 2026-08-31. No structural changes.
+
+## What's next
+
+**Yesterday's predictions vs. today:**
+1. "`copy_into` / Container lowering" — did not happen (rest day)
+2. "Nested function definitions" — did not happen
+3. "Merge submain → main" — did not happen; submain is still 13 commits ahead
+4. "Remaining 0.4 blockers" — no progress
+
+All four predictions remain valid as next moves. The most likely resumption points, in rough priority order:
+
+1. **`copy_into` / Container lowering.** The direct continuation of yesterday's `.copy` work. `copy_into` is the only remaining piece of blocker #3, blocked on `SemanticType::Container` → `IrType` mapping.
+2. **Merge submain → main.** Now 13 commits ahead, the oldest (array returns, expression receivers) dating to Aug 16–18. The back-merge from yesterday resolved containment; the forward merge is overdue.
+3. **Nested function definitions.** Blocks `t10`–`t13` and `t50_nested_func_no_leak`. JIT exit 127.
+4. **Daily-log PR cleanup.** Four daily-log branches (Aug 27–30) have unmerged commits. Documentation-only, no risk.
+
+---
+
+**Matrix (main):** 414 PASS / 0 FAIL (unchanged)
+**Submain divergence:** 13 commits ahead of main (unchanged)
+**Reverts:** None
+**Evidence sources:** `git log --all --since="24 hours ago"` (2 commits, both Claude-authored), `git log origin/main..origin/submain` (13 commits), `git status` (clean), `git diff` (empty), `find -mmin -1440` (no files modified on disk), `run_matrix.sh` (414/414), `daily_log/2026-08-30.md` (from daily-log-2026-08-30 branch)

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-08-16
+Last updated: 2026-08-31
 
 This file is a concise synthesis of the project's roadmap state. Detailed
 0.1-era phase logs live at:
@@ -198,6 +198,8 @@ on nested Handles. Needs its own scoping audit before scheduling.
 ---
 
 ## Working Notes
+
+**2026-08-30:** `.copy` lowering landed on `submain` in two slices. Slice 1 (`aa76b68`) settled the semantics: repeated `.copy` targets rejected (were nondeterministic), `copy_into` bundles enforced at analysis time, `.copy` on methods rejected, `.copy.free` deprecated. Slice 2 (`005df8c`) implemented the ABI: by-address passing for all types, `t49_copy_contract` converted (SKIP 40 → 39), six new fixtures (corpus 453 → 459), parity 420/39/0. `copy_into` still open — needs Container lowering. Back-merge `main` into `submain` (`dd6be28`) restored branch containment. Roadmap re-frozen against the code on `submain` (`5312b77`). The `submain` roadmap is now the authoritative version with a detailed `.copy`/`copy_into` sub-section and a re-verified blocker list.
 
 **2026-05-18:** PR #268 merged `train/backend-determinism` → submain (host_boundary expansion, IR lowering fixes, 23 new parity fixtures including CX-228 t159–t177). CX-233 implements while-in loop source-to-IR lowering on `stokowski/CX-233` (branch-local, not yet merged) — WhileLoop parity moves to 8/0. Submain 171 commits ahead of main.
 


### PR DESCRIPTION
Automated daily log and roadmap update for 2026-08-31.

Rest day — no development commits. Daily log records the quiet state, carries forward the Aug 30 `.copy` working note to the main-branch roadmap, and updates the roadmap date.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1fT21Cgd4fik7s3uZz6N9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap’s last-updated date.
  * Added working notes covering recent `.copy` lowering progress, remaining `copy_into` work, and roadmap synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->