### PR TITLE
daily log 2026-09-02

### DIFF
--- a/daily_log/2026-09-02.md
+++ b/daily_log/2026-09-02.md
@@ -1,0 +1,67 @@
+# Cx Daily Log — 2026-09-02
+
+## Snapshot
+
+Third consecutive rest day. No development commits from the project author, no uncommitted work, clean working tree on main. The matrix holds steady at 414/414. Submain remains 13 commits ahead with the `.copy` ABI work and multidimensional array groundwork from Aug 30 still branch-local. The daily-log PR backlog has grown to six open PRs (#392–#397, Aug 27 through Sep 1), none merged.
+
+## Landed today
+
+Nothing to report. No code, compiler, or language-design commits from the project author in the last 24 hours.
+
+Two automated documentation commits exist in the 24-hour window:
+
+- `157cb2f` on `daily-log-2026-09-01` (23:36 UTC, Sep 1) — daily log and roadmap date update for Sep 1. Authored by Claude. PR #397 opened, not merged. — CONFIRMED
+- `5570e6a` on `site` (00:14 UTC, Sep 2) — blog post `2026-08-20.mdx` for the site branch. Authored by Claude. Not merged to main. — CONFIRMED
+
+Neither represents development work.
+
+## In progress / uncommitted work
+
+Working tree on main is clean. No staged changes, no unstaged changes, no untracked files.
+
+**Submain state (unchanged since Aug 30):** 13 commits ahead of main. The substantive branch-local work includes:
+
+- Array returns via caller-allocated slot (`65736b5`)
+- Expression receivers for operator dispatch (`56983eb`)
+- Array and struct assignment copies (`f291116`)
+- Model B: aggregates are values, receiver is the declared exception (`4fe3fd2`)
+- Model A: contiguous multidimensional arrays (`332a46a`)
+- One assignment-target grammar (`e943103`)
+- Clippy baseline reconciliation, `.copy.free` deprecation candidate (`d60e508`)
+- `.copy` semantic settlement — Slice 1 (`aa76b68`)
+- `.copy` ABI implementation — Slice 2: `.copy` passes by address (`005df8c`)
+
+No new commits on submain since Aug 30. The `copy_into` parameter kind remains the blocked continuation of the `.copy` work — it needs `SemanticType::Container` to `IrType` mapping before it can lower.
+
+**Unmerged daily-log PRs:** Six open PRs (#392–#397, covering Aug 27 through Sep 1) are queued for merge. All are documentation-only with no merge risk. Additionally, external PR #347 ("Update version in the README" from foxzyt) remains open.
+
+## Decisions and direction
+
+Nothing to report. No design decisions or technical direction changes were made today. The project's direction remains as set by the Aug 30 `.copy` ABI work and the multidimensional array design groundwork on submain.
+
+## Roadmap updates
+
+No items checked off — no development work landed. No new tasks added — nothing in today's evidence justifies one. ROADMAP.md date updated to 2026-09-02 with a working note recording the continued pause.
+
+## What's next
+
+**Yesterday's predictions vs. today:** All four predicted next steps from yesterday carried forward unchanged for the third day running — none were acted on:
+
+1. `copy_into` / Container lowering — still the direct continuation of the Aug 30 `.copy` work
+2. Merge submain to main — still 13 commits ahead, forward merge overdue
+3. Nested function definitions — still blocking several fixtures
+4. Daily-log PR cleanup — backlog grew from five to six open PRs
+
+The most likely resumption points remain the same:
+
+1. **`copy_into` / Container lowering.** The blocked piece of `.copy` blocker #3. Needs `SemanticType::Container` to `IrType` mapping.
+2. **Merge submain to main.** 13 commits ahead, oldest dating to Aug 16–18. Back-merge already resolved containment; forward merge is the straightforward remaining step.
+3. **Nested function definitions.** JIT exit 127 on several fixtures (`t10`–`t13`, `t50_nested_func_no_leak`).
+4. **Daily-log PR cleanup.** Six open PRs (#392–#397). Merging them would clear the documentation backlog.
+
+---
+
+**Matrix (main):** 414 PASS / 0 FAIL out of 414 total (unchanged from yesterday)
+**Submain divergence:** 13 commits ahead of main (unchanged)
+**Reverts:** None detected in the last 24 hours
+**Evidence sources:** `git log --all --since="24 hours ago"` (2 commits, both Claude-authored), `git log origin/main..origin/submain` (13 commits, unchanged), `git status` (clean), `git diff` (empty), `find src/ -type f -mtime -1` (no recent modifications), `run_matrix.sh` (414/414), `daily_log/2026-09-01.md` (from daily-log-2026-09-01 branch), GitHub PR listing (6 open daily-log PRs + 1 external PR)

--- a/docment/ROADMAP.md
+++ b/docment/ROADMAP.md
@@ -1,6 +1,6 @@
 # Cx Project Roadmap — Living Summary
 
-Last updated: 2026-08-16
+Last updated: 2026-09-02
 
 This file is a concise synthesis of the project's roadmap state. Detailed
 0.1-era phase logs live at:
@@ -206,3 +206,5 @@ on nested Handles. Needs its own scoping audit before scheduling.
 **2026-05-05:** CX-18/19/20 merged to submain. CX-21–24 committed branch-local (Phase 11 error, Phase 12 start, Phase 13 start, host boundary). Submain 26+ commits ahead of main. Matrix 117/117 stable.
 
 **2026-05-04:** PR #57 merged submain → main after 37 days. CX-7 through CX-17 IR lowering sprint landed on submain. Main jumped from 78 to 117 tests.
+
+**2026-09-02:** Third consecutive rest day. Submain 13 commits ahead (unchanged since Aug 30). Matrix 414/414 stable. Six daily-log PRs (#392–#397) queued. `.copy` ABI (Slice 2) landed on submain Aug 30; `copy_into` remains the next lowering blocker.


### PR DESCRIPTION
Automated daily log and roadmap update for 2026-09-02.

- Daily log: `daily_log/2026-09-02.md`
- Roadmap date updated to 2026-09-02 with working note

Third consecutive rest day. Matrix 414/414 stable. Submain 13 commits ahead (unchanged since Aug 30). Six daily-log PRs (#392–#397) queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyRV9h3cYDQE5tYDfkbwPT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyRV9h3cYDQE5tYDfkbwPT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap’s last-modified date.
  * Added a working note covering current project status, test-matrix results, queued daily-log updates, ABI progress, and the next lowering blocker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->